### PR TITLE
back to more complete function arg documentation of unwrap

### DIFF
--- a/doc/util.rst
+++ b/doc/util.rst
@@ -1,7 +1,8 @@
 :mod:`Util` - utility functions
 =================================
 
-.. function:: unwrap(m[, dim]; range=2pi)
+.. function:: unwrap{T <: FloatingPoint}(m::Array{T}, dim::Integer=ndims(m);
+                                         range::Number=2pi)
 
     Assumes m (along dimension dim) to be a sequences of values that have been
     wrapped to be inside the given range, and undoes the wrapping by
@@ -12,6 +13,7 @@
     successive frames of a short-time-fourier-transform, as each frame is
     wrapped to stay within (-pi, pi].
 
-.. function:: unwrap!(m[, dim]; range=2pi)
+.. function:: unwrap!{T <: FloatingPoint}(m::Array{T}, dim::Integer=ndims(m);
+                                          range::Number=2pi)
 
-    In-place version of unwrap(v, dim, range)
+    In-place version of unwrap(m, dim, range)


### PR DESCRIPTION
for consistency

I broke up the function def documentation onto 2 lines to keep them under 80 chars. I don't have the infrastructure set up to generate the docs so I can't check whether they render properly.
