### PR TITLE
Support for designing filters using second-order sections

### DIFF
--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -20,6 +20,6 @@ export
        # FFTFilt
        fftfilt, firfilt,
        # FilterDesign
-       Butterworth, Lowpass, Highpass, Bandpass, Bandstop,
-       analogfilter, digitalfilter
+       ZPKFilter, TFFilter, BiquadFilter, SOSFilter, Butterworth, Lowpass,
+       Highpass, Bandpass, Bandstop, analogfilter, digitalfilter
 end

--- a/src/filter_design.jl
+++ b/src/filter_design.jl
@@ -41,7 +41,8 @@
 module FilterDesign
 using Polynomial
 
-export Butterworth, Lowpass, Highpass, Bandpass, Bandstop, analogfilter, digitalfilter
+export ZPKFilter, TFFilter, BiquadFilter, SOSFilter, Butterworth, Lowpass, Highpass, Bandpass,
+       Bandstop, analogfilter, digitalfilter
 import Base: convert, filt
 
 #

--- a/test/filter_design.jl
+++ b/test/filter_design.jl
@@ -1,6 +1,6 @@
 using DSP, Base.Test, Polynomial
 import Base.Sort.Lexicographic
-import DSP.FilterDesign: coeffs, TFFilter, ZPKFilter, BiquadFilter, SOSFilter
+import DSP.FilterDesign: coeffs
 
 function lt(a, b)
     if abs(real(a) - real(b)) > 1e-10


### PR DESCRIPTION
This PR adds new `BiquadFilter` and `SOSFilter` types, the ability to design filters using second-order sections as `digitalfilter(responsetype, convert(SOSFilter, prototype))`, and an efficient `filt` routine for filtering using `SOSFilter`s. Tests pass but I'd welcome review. In particular, `convert{Z,P}(::Type{SOSFilter}, f::ZPKFilter{Z,P})` deserves attention because I'm not sure a bug in it would necessarily show up in the tests.
