### PR TITLE
fixed rounding error in arraysplit

### DIFF
--- a/src/periodogram.jl
+++ b/src/periodogram.jl
@@ -19,7 +19,7 @@ function arraysplit(s, n::Integer, m::Integer)
     # total number of strides is the total length of the signal divided
     # by the unique number of elements per stride.  extra elements at the
     # end of of the signal are dropped.
-    k = int(length(s)/l - n/l + 1)
+    k = ifloor(length(s)/l - n/l + 1)
     [s[(a*l + 1):(a*l + n)] for a=0:(k-1)]
 end
 


### PR DESCRIPTION
this patch fixes the following error:

julia> arraysplit(randn(1,584752),4096,2048)
ERROR: BoundsError()
 in copy! at array.jl:54

julia> versioninfo()
Julia Version 0.3.0-prerelease+2078
Commit 00ca83c\* (2014-03-17 22:41 UTC)
Platform Info:
  System: Linux (x86_64-redhat-linux)
  CPU: Intel(R) Xeon(R) CPU           E5645  @ 2.40GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY)
  LAPACK: libopenblas
  LIBM: libopenlibm

julia> Pkg.status()
9 required packages:
- ClusterManagers               0.0.1
- DSP                           0.0.1+             master
- Debug                         0.0.0
- Devectorize                   0.2.1
- Distributions                 0.4.2
- MAT                           0.2.3
- PyPlot                        1.2.2
- Stats                         0.1.0
- WAV                           0.2.2
  11 additional packages:
- ArrayViews                    0.4.1
- BinDeps                       0.2.12
- Color                         0.2.8
- HDF5                          0.2.20
- NumericExtensions             0.5.6
- PDMats                        0.1.1
- Polynomial                    0.1.1
- PyCall                        0.4.2
- StatsBase                     0.3.9
- URIParser                     0.0.1
- Zlib                          0.1.5
