### PR TITLE
Consistent window return types

### DIFF
--- a/src/windows.jl
+++ b/src/windows.jl
@@ -9,7 +9,7 @@ export rect, hanning, hamming, tukey, cosine, lanczos,
 
 # Rectangular window function of length N.
 function rect(n::Integer)
-    ones(n,1)
+    ones(n)
 end
 
 # Hanning window of length N.
@@ -85,15 +85,15 @@ end
 # bartlett-hann window of length n
 function bartlett_hann(n::Integer)
     a0, a1, a2 = 0.62, 0.48, 0.38
-    _arg = (k,l) -> 2*pi*l*k/(n-1)
-    [a0 - a1*abs(k/(n-1) - 0.5) - a2*cos(_arg(k,1)) for k=0:(n-1)]
+    t=2*pi/(n-1)
+    [a0 - a1*abs(k/(n-1) - 0.5) - a2*cos(t*k) for k=0:(n-1)]
 end
 
 # "exact" blackman window, alpha=0.16
 function blackman(n::Integer)
     a0, a1, a2 = 7938/18608, 9240/18608, 1430/18608
-    _arg = (k,l) -> 2*pi*l*k/(n-1)
-    [a0 - a1*cos(_arg(k,1)) + a2*cos(_arg(k,2)) for k=0:(n-1)]
+    t=2*pi/(n-1)
+    [a0 - a1*cos(t*k) + a2*cos(t*k*2) for k=0:(n-1)]
 end
 
 # kaiser window parameterized by alpha

--- a/test/windows.jl
+++ b/test/windows.jl
@@ -4,3 +4,16 @@ using DSP, Base.Test
 d1 = dpss(128, 4)
 d2 = readdlm(joinpath(dirname(@__FILE__), "data", "dpss128,4.txt"), '\t')
 @test_approx_eq d1 d2
+
+
+# make sure return types are correct
+n=12
+ft=typeof(1.0)
+for W in(:rect, :hanning, :hamming, :cosine, :lanczos, :triang, :bartlett, :bartlett_hann, :blackman)
+    @eval @test Array{ft,1}==typeof($W(n)) && length($W(n))==n
+end
+#for W in(:gaussian, :kaiser, :dpss)
+@test Array{ft,1}==typeof(gaussian(n,0.4)) && length(gaussian(n,0.4))==n
+@test Array{ft,1}==typeof(kaiser(n,0.4)) && length(kaiser(n,0.4))==n
+@test Array{ft,2}==typeof(dpss(n,1.5)) && size(dpss(n,1.5),1)==n  # size(,2) depends on the parameters
+


### PR DESCRIPTION
all return 1d arrays except dpss, blackman and bartlett_hann faster, added window tests
