### PR TITLE
Faster FIR filtfilt

### DIFF
--- a/test/filt.jl
+++ b/test/filt.jl
@@ -247,3 +247,11 @@ for xlen in 2.^(7:18).-1, blen in 2.^(1:6).-1
         @test_approx_eq filtres firres
     end
 end
+
+# fir_filtfilt
+
+b = randn(10)
+for x in (randn(100), randn(100, 2))
+    @test_approx_eq DSP.Filters.fir_filtfilt(b, x) DSP.Filters.iir_filtfilt(b, [1.0], x)
+    @test_approx_eq DSP.Filters.filtfilt(b, [2.0], x) DSP.Filters.iir_filtfilt(b, [2.0], x)
+end


### PR DESCRIPTION
For FIR filters, it is better to use `firfilt` than `filt` since it ensures an appropriately fast algorithm is used. Additionally, the filter can simply be convolved with itself so that it is not necessary to process the data in the forwards and backwards direction. There is no need to compute the initial state because it has no effect on the result after the signal is padded.

This algorithm could still be made more efficient with an in-place variant of `firfilt` that can save the FFT of the filter.
