### PR TITLE
Fix inference of return type of spectrogram/stft

### DIFF
--- a/doc/periodograms.rst
+++ b/doc/periodograms.rst
@@ -40,15 +40,11 @@
     with overlap of ``noverlap`` samples, and returns a Spectrogram object. See
     :func:`periodogram` for description of optional keyword arguments.
 
-.. function:: stft(s, n=div(length(s), 8), noverlap=div(n, 2); onesided=eltype(s)<:Real, nfft=nextfastfft(n), fs=1, window=nothing, psdonly=false)
-
+.. function:: stft(s, n=div(length(s), 8), noverlap=div(n, 2); onesided=eltype(s)<:Real, nfft=nextfastfft(n), fs=1, window=nothing)
     Computes the STFT of a signal ``s`` based on segments with ``n`` samples
     with overlap of ``noverlap`` samples, and returns a matrix containing the STFT
     coefficients. See :func:`periodogram` for description of optional
-    keyword arguments. The argument ``psdonly``, when set to `true`, 
-    makes this function return the power spectral density instead
-    of the complex STFT coefficients (used internally in the implementation
-    of `spectrogram`).
+    keyword arguments.
 
 
 .. function:: periodogram(s::AbstractMatrix; nfft=nextfastfft(size(s)), fs=1, radialsum=false, radialavg=false)


### PR DESCRIPTION
The instability of the output type doesn't make a huge performance difference unless there are a large number of segments, but caused the return type of `spectrogram` to be inferred as `Union(Spectrogram{Float64,Frequencies},Spectrogram{Complex{Float64},Frequencies}))` which could be bad for user code that wants to process it further.

I removed the `psdonly` argument from the docs since I don't think there's much reason to use it directly.
