### PR TITLE
Add a new line before starting a code block in stft doc

### DIFF
--- a/doc/periodograms.rst
+++ b/doc/periodograms.rst
@@ -41,6 +41,7 @@
     :func:`periodogram` for description of optional keyword arguments.
 
 .. function:: stft(s, n=div(length(s), 8), noverlap=div(n, 2); onesided=eltype(s)<:Real, nfft=nextfastfft(n), fs=1, window=nothing)
+
     Computes the STFT of a signal ``s`` based on segments with ``n`` samples
     with overlap of ``noverlap`` samples, and returns a matrix containing the STFT
     coefficients. See :func:`periodogram` for description of optional


### PR DESCRIPTION
This fixes the broken format in `stft` docs. 

http://dspjl.readthedocs.org/en/latest/periodograms.html#stft
