### PR TITLE
Initial istft implementation.

### DIFF
--- a/doc/util.rst
+++ b/doc/util.rst
@@ -22,6 +22,15 @@
     \hat{x}`, where :math:`\hat{x}` is the Hilbert transform of x,
     along the first dimension of x.
 
+.. function:: istft(S, wlen, overlap; nfft=nextfastfft(wlen), window=nothing)
+
+    Computes the inverse short-time Fourier transform (STFT) of S (a complex
+    matrix, as computed by `stft`). `wlen` and `overlap` are respectively the
+    window length and overlap used for computing the STFT. `nfft` is the used
+    FFT size (defaults to `nextfastfft(wlen)`) and `window` can be either a
+    function or a vector with the window elements (defaults to a rectangular
+    window).
+
 .. function:: fftfreq(n, fs=1)
 
     Return discrete fourier transform sample frequencies. The returned


### PR DESCRIPTION
I wrote an `istft` function to bring a real signal from its per-frame STFT representation to a time-domain signal by using overlap-add. This version is unoptimized as I am having some trouble to create an `FFTW.Plan` for a backward RFFT. I can add my non-working code to this branch in case you want to take a look. 

I understand the PR is in a crude shape right now but I need some help moving forward, and I figured it would be better to submit a PR than try to solve this via e-mail.

Any suggestions for improvement or tips on how I can use the `FFTW.Plan` interface to do what I want here?
