### PR TITLE
Use new stateful filter API for filtfilt

### DIFF
--- a/test/filt.jl
+++ b/test/filt.jl
@@ -107,7 +107,7 @@ zi_python = [0.55996501, -0.72343165,  0.68312446, -0.2220676 ,  0.04030775]
 b = [ 0.00327922,  0.01639608,  0.03279216,  0.03279216,  0.01639608,  0.00327922]
 a = [ 1.1       , -2.47441617,  2.81100631, -1.70377224,  0.54443269, -0.07231567]
 
-@test_approx_eq_eps zi_python DSP.Filters.filt_stepstate(b, a) 1e-7
+@test_throws ArgumentError DSP.Filters.filt_stepstate(b, a)
 
 
 ##############
@@ -266,6 +266,6 @@ end
 
 b = randn(10)
 for x in (randn(100), randn(100, 2))
-    @test_approx_eq DSP.Filters.fir_filtfilt(b, x) DSP.Filters.iir_filtfilt(b, [1.0], x)
-    @test_approx_eq DSP.Filters.filtfilt(b, [2.0], x) DSP.Filters.iir_filtfilt(b, [2.0], x)
+    @test_approx_eq DSP.Filters.fir_filtfilt(b, x) DSP.Filters.filtfilt(PolynomialRatio(b, [1.0; zeros(9)]), x)
+    @test_approx_eq DSP.Filters.filtfilt(b, [2.0], x) DSP.Filters.filtfilt(PolynomialRatio(b, [2.0; zeros(9)]), x)
 end


### PR DESCRIPTION
This provides reduces the memory allocation and provides a small speed boost (on 0.4; on 0.3, where SubArrays are slow, it's probably substantially slower). We could conceivably use this to provide in-place filtfilt, although that is not yet implemented.

I removed support for non-1 initial values of a in filt_stepstate, since we don't need it if the filter is normalized before it is used.