### PR TITLE
Speed up FIR filtering

### DIFF
--- a/doc/filters.rst
+++ b/doc/filters.rst
@@ -99,7 +99,9 @@ Filter application
     to zeros). If ``f`` is a ``PolynomialRatio``, ``Biquad``, or
     ``SecondOrderSections``, filtering is implemented directly. If
     ``f`` is a ``ZeroPoleGain`` object, it is first converted to a
-    ``SecondOrderSections`` object.
+    ``SecondOrderSections`` object.  If ``f`` is a Vector, it is
+    interpreted as an FIR filter, and a naïve or FFT-based algorithm is
+    selected based on the data and filter length.
 
 .. function:: filt!(out, f, x[, si])
 
@@ -123,12 +125,6 @@ Filter application
 
     Apply FIR filter ``b`` along the first dimension of array ``x``
     using an FFT-based overlap-save algorithm.
-
-.. function:: firfilt(b, x)
-
-    Apply FIR filter ``b`` along the first dimension of array ``x``,
-    choosing the optimal algorithm based on the lengths of ``b`` and
-    ``x``.
 
 
 Filter design

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -13,8 +13,7 @@ export FilterCoefficients,
 include("filt.jl")
 export  DF2TFilter,
         filtfilt,
-        fftfilt,
-        firfilt
+        fftfilt
 
 include("design.jl")
 export  FilterType,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -3,3 +3,5 @@ const TFFilter = PolynomialRatio
 const BiquadFilter = Biquad
 const SOSFilter = SecondOrderSections
 export ZPKFilter, TFFilter, BiquadFilter, SOSFilter
+
+@deprecate firfilt(h, x) filt(h, x)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,4 +1,5 @@
 module Util
+using Compat
 
 export  unwrap!,
         unwrap,
@@ -174,7 +175,7 @@ rmsfft{T<:Complex}(f::AbstractArray{T}) = sqrt(sumabs2(f))/length(f)
 # Computes the dot product of a single column of a, specified by aColumnIdx, with the vector b.
 # The number of elements used in the dot product determined by the size(A)[1].
 # Note: bIdx is the last element of b used in the dot product.
-function unsafe_dot(a::Matrix, aColIdx::Integer, b::Vector, bLastIdx::Integer)
+@inline function _unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector, bLastIdx::Integer)
     aLen     = size(a, 1)
     bBaseIdx = bLastIdx - aLen
     dotprod  = a[1, aColIdx] * b[ bBaseIdx + 1]
@@ -185,7 +186,18 @@ function unsafe_dot(a::Matrix, aColIdx::Integer, b::Vector, bLastIdx::Integer)
     return dotprod
 end
 
-function unsafe_dot{T}(a::Matrix, aColIdx::Integer, b::Vector{T}, c::Vector{T}, cLastIdx::Integer)
+unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector, bLastIdx::Integer) =
+    _unsafe_dot(a, aColIdx, b, bLastIdx)
+
+@inline function unsafe_dot{T<:Base.LinAlg.BlasReal}(a::Matrix{T}, aColIdx::Integer, b::Vector{T}, bLastIdx::Integer)
+    if size(a, 1) > 16
+        BLAS.dot(size(a, 1), pointer(a, size(a, 1)*(aColIdx-1) + 1), 1, pointer(b, bLastIdx - size(a, 1) + 1), 1)
+    else
+        _unsafe_dot(a, aColIdx, b, bLastIdx)
+    end
+end
+
+function unsafe_dot{T}(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer)
     aLen = size(a, 1)
     bLen = length(b)
     bLen == aLen-1  || error( "length(b) must equal to length(a)[1] - 1" )
@@ -202,10 +214,10 @@ function unsafe_dot{T}(a::Matrix, aColIdx::Integer, b::Vector{T}, c::Vector{T}, 
     return dotprod
 end
 
-function unsafe_dot(a::Vector, b::Vector, bLastIdx::Integer)
+@inline function _unsafe_dot(a::AbstractVector, b::AbstractArray, bLastIdx::Integer)
     aLen     = length(a)
     bBaseIdx = bLastIdx - aLen
-    dotprod  = a[1] * b[bBaseIdx + 1]
+    @inbounds dotprod  = a[1] * b[bBaseIdx + 1]
     @simd for i in 2:aLen
         @inbounds dotprod += a[i] * b[bBaseIdx + i]
     end
@@ -213,7 +225,17 @@ function unsafe_dot(a::Vector, b::Vector, bLastIdx::Integer)
     return dotprod
 end
 
-function unsafe_dot{T}(a::Vector, b::Vector{T}, c::Vector{T}, cLastIdx::Integer)
+unsafe_dot(a::AbstractVector, b::AbstractArray, bLastIdx::Integer) = _unsafe_dot(a, b, bLastIdx)
+
+@inline function unsafe_dot{T<:Base.LinAlg.BlasReal}(a::Vector{T}, b::Array{T}, bLastIdx::Integer)
+    if length(a) > 16
+        BLAS.dot(length(a), pointer(a), 1, pointer(b, bLastIdx - length(a) + 1), 1)
+    else
+        _unsafe_dot(a, b, bLastIdx)
+    end
+end
+
+function unsafe_dot{T}(a::AbstractVector, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer)
     aLen    = length(a)
     dotprod = zero(a[1]*b[1])
     @simd for i in 1:aLen-cLastIdx

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -248,7 +248,7 @@ x2_output = readdlm(joinpath(dirname(@__FILE__), "data", "filtfilt_output_2d_sos
 @test_approx_eq x2_output filtfilt(sosfilter, x)
 
 #
-# fftfilt/firfilt
+# fftfilt/filt
 #
 
 for xlen in 2.^(7:18).-1, blen in 2.^(1:6).-1
@@ -256,7 +256,7 @@ for xlen in 2.^(7:18).-1, blen in 2.^(1:6).-1
     for x in (rand(xlen), rand(xlen, 2))
         filtres = filt(b, [1.0], x)
         fftres = fftfilt(b, x)
-        firres = firfilt(b, x)
+        firres = filt(b, x)
         @test_approx_eq filtres fftres
         @test_approx_eq filtres firres
     end


### PR DESCRIPTION
- Implement fast path for stateless filtering
- Use `BLAS.dot()` to compute sufficiently large dot products (this also benefits stateful/multirate filters)
- Make `filt(h, x)` use `fftfilt` when it should be faster than naive convolution, replacing `firfilt`

Here's a performance comparison with `DSP.filt()` from the original multirate commit (top) and `Base.filt()` (bottom). It's slower than `Base.filt()` only for very small filter lengths (is this worth optimizing further?), and much faster for filters with 16+ taps.

![perf](https://cloud.githubusercontent.com/assets/470884/7487997/e21d0f9a-f390-11e4-8d35-7b76129c1fd9.png)

