### PR TITLE
Ensure slicedim always returns an array on v0.5, replace sub -> view

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
 Polynomials
 Reexport
-Compat 0.7.15
+Compat 0.8.4

--- a/src/util.jl
+++ b/src/util.jl
@@ -38,7 +38,7 @@ function unwrap!{T <: AbstractFloat}(m::Array{T}, dim::Integer=ndims(m);
         return m
     end
     for i = 2:size(m, dim)
-        d = slicedim(m, dim, i) - slicedim(m, dim, i-1)
+        d = slicedim(m, dim, i:i) - slicedim(m, dim, i-1:i-1)
         slice_tuple = ntuple(n->(n==dim ? (i:i) : (1:size(m,n))), ndims(m))
         offset = floor((d.+thresh) / (range)) * range
 #        println("offset: ", offset)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,5 +1,6 @@
 module Util
 using Compat
+import Compat.view
 import Base.Operators: *
 
 export  unwrap!,
@@ -62,7 +63,7 @@ function hilbert{T<:FFTW.fftwReal}(x::StridedVector{T})
     X = zeros(Complex{T}, N)
     @julia_newer_than v"0.4.0-dev+6068" begin
         p = plan_rfft(x)
-        A_mul_B!(sub(X, 1:(N >> 1)+1), p, x)
+        A_mul_B!(view(X, 1:(N >> 1)+1), p, x)
     end begin
         p = FFTW.Plan(x, X, 1, FFTW.ESTIMATE, FFTW.NO_TIMELIMIT)
         FFTW.execute(T, p.plan)
@@ -82,7 +83,7 @@ function hilbert{T<:Real}(x::AbstractArray{T})
 
     @julia_newer_than v"0.4.0-dev+6068" begin
         p1 = plan_rfft(xc)
-        Xsub = sub(X, 1:(N >> 1)+1)
+        Xsub = view(X, 1:(N >> 1)+1)
         p2 = plan_bfft!(X)
     end begin
         p1 = FFTW.Plan(xc, X, 1, FFTW.ESTIMATE, FFTW.NO_TIMELIMIT)


### PR DESCRIPTION
On Julia v0.5-rc1+1, tests were failing due to `slicedim` returning a scalar instead of a vector of length 1 in cases of slicing at exactly one location. This is possibly due to the first breaking change mentioned here:
https://github.com/JuliaLang/julia/blob/release-0.5/NEWS.md#breaking-changes

Using the recommended syntax `i:i` fixed the problem and all tests passed. ~~Deprecation warnings are yet to be addressed, though.~~ UPDATE: deprecation warnings are now fixed, mainly by replacing `sub` -> `view` by using Compat v0.8.4. The warnings related to `symbol` -> `Symbol` are also already taken care of on the master of Polynomials.jl.