### PR TITLE
loosens shiftin! arg types to accept AbstractVectors

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -267,7 +267,7 @@ end
 #  4
 #  5
 #  6
-function shiftin!{T}(a::Vector{T}, b::Vector{T})
+function shiftin!{T}(a::AbstractVector{T}, b::AbstractVector{T})
     aLen = length(a)
     bLen = length(b)
 


### PR DESCRIPTION
This fixes an issue I had trying to do:

```julia
using DSP

ratio = 3//4;
f = FIRFilter(resample_filter(ratio), ratio)
outbuf = Array(Float32, 10)
buf = rand(Float32, 10)

filt!(outbuf, f, view(buf, 1:5))
```

on master I get the error:
```
ERROR: MethodError: no method matching shiftin!(::Array{Float32,1}, ::SubArray{Float32,1,Array{Float32,1},Tuple{UnitRange{Int64}},true})
Closest candidates are:
  shiftin!{T}(::Array{T,1}, ::Array{T,1}) at /Users/srussell/.julia/v0.5/DSP/src/util.jl:271
 in filt!(::Array{Float32,1}, ::DSP.Filters.FIRFilter{DSP.Filters.FIRRational{Float64}}, ::SubArray{Float32,1,Array{Float32,1},Tuple{UnitRange{Int64}},true}) at /Users/srussell/.julia/v0.5/DSP/src/Filters/stream_filt.jl:494
```

I tried to figure out a good place to put this as an additional test case but nothing jumped out at me. If you think it needs a test case and have an opinion on where it should go let me know.