### PR TITLE
Resample delay and 'resample_filter' length fix

### DIFF
--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -506,12 +506,12 @@ function resample_filter(rate::AbstractFloat, Nϕ = 32, rel_bw = 1.0, attenuatio
     # Round the number of taps up to a multiple of Nϕ.
     # Otherwise the missing taps will be filled with 0.
     hLen = Nϕ * ceil(Int, hLen/Nϕ)
-	
-	# Ensure that the filter is an odd length
-	if (rem(hLen,2.0) == 0) 
-		hLen += 1
-	end
-	
+
+    # Ensure that the filter is an odd length
+    if (iseven(hLen)) 
+        hLen += 1
+    end
+
     # Design filter
     h = digitalfilter(Lowpass(cutoff), FIRWindow(kaiser(hLen, α)))
     scale!(h, Nϕ)
@@ -532,11 +532,11 @@ function resample_filter(rate::Rational, rel_bw = 1.0, attenuation = 60)
     # Otherwise the missing taps will be filled with 0.
     hLen = Nϕ * ceil(Int, hLen/Nϕ)
 
-	# Ensure that the filter is an odd length
-	if (rem(hLen,2.0) == 0) 
-		hLen += 1
-	end
-		
+    # Ensure that the filter is an odd length
+    if (iseven(hLen)) 
+        hLen += 1
+    end
+        
     # Design filter
     h = digitalfilter(Lowpass(cutoff), FIRWindow(kaiser(hLen, α)))
     scale!(h, Nϕ)

--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -507,7 +507,7 @@ function resample_filter(rate::AbstractFloat, Nϕ = 32, rel_bw = 1.0, attenuatio
     # Otherwise the missing taps will be filled with 0.
     hLen = Nϕ * ceil(Int, hLen/Nϕ)
 	
-	# ensure that the filter is an odd length
+	# Ensure that the filter is an odd length
 	if (rem(hLen,2.0) == 0) 
 		hLen += 1
 	end
@@ -519,8 +519,8 @@ end
 
 # Compute FIR coefficients necessary for rational rate resampling
 function resample_filter(rate::Rational, rel_bw = 1.0, attenuation = 60)
-    Nϕ          = num(rate) 															# interpolation
-    decimation  = den(rate)																# decimation
+    Nϕ          = num(rate)
+    decimation  = den(rate)
     f_nyq       = min(1/Nϕ, 1/decimation)
     cutoff      = f_nyq * rel_bw
     trans_width = cutoff * 0.2
@@ -532,7 +532,7 @@ function resample_filter(rate::Rational, rel_bw = 1.0, attenuation = 60)
     # Otherwise the missing taps will be filled with 0.
     hLen = Nϕ * ceil(Int, hLen/Nϕ)
 
-	# ensure that the filter is an odd length
+	# Ensure that the filter is an odd length
 	if (rem(hLen,2.0) == 0) 
 		hLen += 1
 	end

--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -506,7 +506,12 @@ function resample_filter(rate::AbstractFloat, Nϕ = 32, rel_bw = 1.0, attenuatio
     # Round the number of taps up to a multiple of Nϕ.
     # Otherwise the missing taps will be filled with 0.
     hLen = Nϕ * ceil(Int, hLen/Nϕ)
-
+	
+	# ensure that the filter is an odd length
+	if (rem(hLen,2.0) == 0) 
+		hLen += 1
+	end
+	
     # Design filter
     h = digitalfilter(Lowpass(cutoff), FIRWindow(kaiser(hLen, α)))
     scale!(h, Nϕ)
@@ -514,8 +519,8 @@ end
 
 # Compute FIR coefficients necessary for rational rate resampling
 function resample_filter(rate::Rational, rel_bw = 1.0, attenuation = 60)
-    Nϕ          = num(rate)
-    decimation  = den(rate)
+    Nϕ          = num(rate) 															# interpolation
+    decimation  = den(rate)																# decimation
     f_nyq       = min(1/Nϕ, 1/decimation)
     cutoff      = f_nyq * rel_bw
     trans_width = cutoff * 0.2
@@ -527,6 +532,11 @@ function resample_filter(rate::Rational, rel_bw = 1.0, attenuation = 60)
     # Otherwise the missing taps will be filled with 0.
     hLen = Nϕ * ceil(Int, hLen/Nϕ)
 
+	# ensure that the filter is an odd length
+	if (rem(hLen,2.0) == 0) 
+		hLen += 1
+	end
+		
     # Design filter
     h = digitalfilter(Lowpass(cutoff), FIRWindow(kaiser(hLen, α)))
     scale!(h, Nϕ)

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -24,7 +24,7 @@ type FIRInterpolator{T} <: FIRKernel{T}
     tapsPerϕ::Int
     inputDeficit::Int
     ϕIdx::Int
-	hLen::Int
+    hLen::Int
 end
 
 function FIRInterpolator(h::Vector, interpolation::Integer)
@@ -33,9 +33,9 @@ function FIRInterpolator(h::Vector, interpolation::Integer)
     interpolation = interpolation
     inputDeficit  = 1
     ϕIdx          = 1
-	hLen		  = length(h)
-	
-    FIRInterpolator(pfb, interpolation, Nϕ, tapsPerϕ, inputDeficit, ϕIdx, 	hLen)
+    hLen          = length(h)
+    
+    FIRInterpolator(pfb, interpolation, Nϕ, tapsPerϕ, inputDeficit, ϕIdx,   hLen)
 end
 
 
@@ -64,7 +64,7 @@ type FIRRational{T}  <: FIRKernel{T}
     tapsPerϕ::Int
     ϕIdx::Int
     inputDeficit::Int
-	hLen::Int
+    hLen::Int
 end
 
 function FIRRational(h::Vector, ratio::Rational)
@@ -73,7 +73,7 @@ function FIRRational(h::Vector, ratio::Rational)
     ϕIdxStepSize = mod(den(ratio), num(ratio))
     ϕIdx         = 1
     inputDeficit = 1
-	hLen 		 = length(h)
+    hLen         = length(h)
     FIRRational(pfb, ratio, Nϕ, ϕIdxStepSize, tapsPerϕ, ϕIdx, inputDeficit, hLen)
 end
 
@@ -101,7 +101,7 @@ type FIRArbitrary{T} <: FIRKernel{T}
     Δ::Float64
     inputDeficit::Int
     xIdx::Int
-	hLen::Int
+    hLen::Int
 end
 
 function FIRArbitrary(h::Vector, rate::Real, Nϕ::Integer)
@@ -115,7 +115,7 @@ function FIRArbitrary(h::Vector, rate::Real, Nϕ::Integer)
     Δ            = Nϕ/rate
     inputDeficit = 1
     xIdx         = 1
-	hLen		 = length(h)
+    hLen         = length(h)
     FIRArbitrary(rate, pfb, dpfb, Nϕ, tapsPerϕ, ϕAccumulator, ϕIdx, α, Δ, inputDeficit, xIdx, hLen)
 end
 
@@ -187,8 +187,8 @@ end
 function setphase!(kernel::@compat(Union{FIRInterpolator, FIRRational}), ϕ::Real)
     ϕ >= zero(ϕ) || throw(ArgumentError("ϕ must be >= 0"))
     (ϕ, xThrowaway) = modf(ϕ)
-	kernel.inputDeficit += round(Int, xThrowaway)
-	kernel.ϕIdx = round(ϕ*(kernel.Nϕ) + 1.0)
+    kernel.inputDeficit += round(Int, xThrowaway)
+    kernel.ϕIdx = round(ϕ*(kernel.Nϕ) + 1.0)
     nothing
 end
 
@@ -364,7 +364,7 @@ function timedelay(kernel::@compat(Union{FIRRational, FIRInterpolator, FIRArbitr
 end
 
 function timedelay(kernel::@compat(Union{FIRStandard, FIRDecimator}))
-    (kernel.hLen - 1)/2.0					
+    (kernel.hLen - 1)/2
 end
 
 
@@ -653,7 +653,7 @@ end
 
 function resample(x::AbstractVector, rate::Real, h::Vector)
     self = FIRFilter(h, rate)
-			
+
     # Get delay, in # of samples at the output rate, caused by filtering processes
     τ = timedelay(self)
 
@@ -661,7 +661,7 @@ function resample(x::AbstractVector, rate::Real, h::Vector)
     #   a) adjust the input samples to skip over before producing and output (integer part of τ)
     #   b) set the ϕ index of the PFB (fractional part of τ)
     setphase!(self, τ)
-	
+
     # Calculate the number of 0's required
     outLen      = ceil(Int, length(x)*rate)
     reqInlen    = inputlength(self, outLen)

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -24,7 +24,7 @@ type FIRInterpolator{T} <: FIRKernel{T}
     tapsPerϕ::Int
     inputDeficit::Int
     ϕIdx::Int
-	hLen::Int														# added this
+	hLen::Int
 end
 
 function FIRInterpolator(h::Vector, interpolation::Integer)
@@ -33,7 +33,7 @@ function FIRInterpolator(h::Vector, interpolation::Integer)
     interpolation = interpolation
     inputDeficit  = 1
     ϕIdx          = 1
-	hLen		  = length(h)									# added this
+	hLen		  = length(h)
 	
     FIRInterpolator(pfb, interpolation, Nϕ, tapsPerϕ, inputDeficit, ϕIdx, 	hLen)
 end
@@ -64,7 +64,7 @@ type FIRRational{T}  <: FIRKernel{T}
     tapsPerϕ::Int
     ϕIdx::Int
     inputDeficit::Int
-	hLen::Int														#### added this
+	hLen::Int
 end
 
 function FIRRational(h::Vector, ratio::Rational)
@@ -73,7 +73,7 @@ function FIRRational(h::Vector, ratio::Rational)
     ϕIdxStepSize = mod(den(ratio), num(ratio))
     ϕIdx         = 1
     inputDeficit = 1
-	hLen 		 = length(h)										#### added this
+	hLen 		 = length(h)
     FIRRational(pfb, ratio, Nϕ, ϕIdxStepSize, tapsPerϕ, ϕIdx, inputDeficit, hLen)
 end
 
@@ -101,6 +101,7 @@ type FIRArbitrary{T} <: FIRKernel{T}
     Δ::Float64
     inputDeficit::Int
     xIdx::Int
+	hLen::Int
 end
 
 function FIRArbitrary(h::Vector, rate::Real, Nϕ::Integer)
@@ -114,7 +115,8 @@ function FIRArbitrary(h::Vector, rate::Real, Nϕ::Integer)
     Δ            = Nϕ/rate
     inputDeficit = 1
     xIdx         = 1
-    FIRArbitrary(rate, pfb, dpfb, Nϕ, tapsPerϕ, ϕAccumulator, ϕIdx, α, Δ, inputDeficit, xIdx)
+	hLen		 = length(h)
+    FIRArbitrary(rate, pfb, dpfb, Nϕ, tapsPerϕ, ϕAccumulator, ϕIdx, α, Δ, inputDeficit, xIdx, hLen)
 end
 
 
@@ -186,7 +188,7 @@ function setphase!(kernel::@compat(Union{FIRInterpolator, FIRRational}), ϕ::Rea
     ϕ >= zero(ϕ) || throw(ArgumentError("ϕ must be >= 0"))
     (ϕ, xThrowaway) = modf(ϕ)
 	kernel.inputDeficit += round(Int, xThrowaway)
-	kernel.ϕIdx = round(ϕ*(kernel.Nϕ) + 1.0)						#removed the -1 and changed floor to round
+	kernel.ϕIdx = round(ϕ*(kernel.Nϕ) + 1.0)
     nothing
 end
 
@@ -239,7 +241,7 @@ function reset!(self::FIRFilter)
 end
 
 #
-# taps2 pfb
+# taps2pfb
 #
 # Converts a vector of coefficients to a matrix. Each column is a filter.
 # NOTE: also flips the matrix up/down so computing the dot product of a
@@ -354,11 +356,11 @@ end
 
 
 #
-# Calculates the delay in # samples, at the input sample rate, caused by the filter process
+# Calculates the delay caused by the FIR filter in # samples, at the input sample rate, caused by the filter process
 #
 
 function timedelay(kernel::@compat(Union{FIRRational, FIRInterpolator, FIRArbitrary}))
-    (kernel.hLen - 1)/(2.0*kernel.Nϕ)													# added this
+    (kernel.hLen - 1)/(2.0*kernel.Nϕ)
 end
 
 function timedelay(kernel::@compat(Union{FIRStandard, FIRDecimator}))
@@ -643,7 +645,7 @@ function Base.filt(h::Vector, x::AbstractVector, ratio::Rational)
     filt(self, x)
 end
 
-# Arbitrary resampling with polyphase interpolation and two neighbor lnear interpolation.
+# Arbitrary resampling with polyphase interpolation and two neighbor linear interpolation.
 function Base.filt(h::Vector, x::AbstractVector, rate::AbstractFloat, Nϕ::Integer=32)
     self = FIRFilter(h, rate, Nϕ)
     filt(self, x)


### PR DESCRIPTION
**Details:**
- Ensures that the FIR filter in 'resample_filter' is always odd, thus ensuring that when interpolating, the original samples are retained within the interpolated data.
- The time delay introduced by the FIR filter was not correctly compensated for, this is corrected here.
- The results now correlate better with MATLAB/Octave.