### PR TITLE
Compat fixes for v0.5 and v0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-Polynomials
+Polynomials v0.1.0 v0.1.2+
 Reexport
 SpecialFunctions
 Compat 0.17.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.5
 Polynomials
 Reexport
-Compat 0.8.4
+SpecialFunctions
+Compat 0.17.0

--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -1,6 +1,6 @@
 # Filter types and conversions
 
-abstract FilterCoefficients
+@compat abstract type FilterCoefficients end
 
 realtype(x::DataType) = x
 realtype{T}(::Type{Complex{T}}) = T
@@ -38,8 +38,8 @@ immutable PolynomialRatio{T<:Number} <: FilterCoefficients
     b::Poly{T}
     a::Poly{T}
 
-    PolynomialRatio(b::Poly, a::Poly) =
-        new(convert(Poly{T}, b/a[end]), convert(Poly{T}, a/a[end]))
+    (::Type{PolynomialRatio{Ti}}){Ti<:Number}(b::Poly, a::Poly) =
+        new{Ti}(convert(Poly{Ti}, b/a[end]), convert(Poly{Ti}, a/a[end]))
 end
 PolynomialRatio{T<:Number}(b::Poly{T}, a::Poly{T}) = PolynomialRatio{T}(b, a)
 

--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -2,7 +2,7 @@
 
 using ..Windows
 
-abstract FilterType
+@compat abstract type FilterType end
 
 #
 # Butterworth prototype
@@ -216,23 +216,17 @@ end
 
 immutable Lowpass{T} <: FilterType
     w::T
-
-    Lowpass(w) = new(convert(T, w))
 end
 Lowpass(w::Real; fs::Real=2) = Lowpass{typeof(w/1)}(normalize_freq(w, fs))
 
 immutable Highpass{T} <: FilterType
     w::T
-
-    Highpass(w) = new(convert(T, w))
 end
 Highpass(w::Real; fs::Real=2) = Highpass{typeof(w/1)}(normalize_freq(w, fs))
 
 immutable Bandpass{T} <: FilterType
     w1::T
     w2::T
-
-    Bandpass(w1, w2) = new(convert(T, w1), convert(T, w2))
 end
 function Bandpass(w1::Real, w2::Real; fs::Real=2)
     w1 < w2 || error("w1 must be less than w2")
@@ -242,8 +236,6 @@ end
 immutable Bandstop{T} <: FilterType
     w1::T
     w2::T
-
-    Bandstop(w1, w2) = new(convert(T, w1), convert(T, w2))
 end
 function Bandstop(w1::Real, w2::Real; fs::Real=2)
     w1 < w2 || error("w1 must be less than w2")
@@ -508,7 +500,7 @@ function resample_filter(rate::AbstractFloat, Nϕ = 32, rel_bw = 1.0, attenuatio
     hLen = Nϕ * ceil(Int, hLen/Nϕ)
 
     # Ensure that the filter is an odd length
-    if (iseven(hLen)) 
+    if (iseven(hLen))
         hLen += 1
     end
 
@@ -533,10 +525,10 @@ function resample_filter(rate::Rational, rel_bw = 1.0, attenuation = 60)
     hLen = Nϕ * ceil(Int, hLen/Nϕ)
 
     # Ensure that the filter is an odd length
-    if (iseven(hLen)) 
+    if (iseven(hLen))
         hLen += 1
     end
-        
+
     # Design filter
     h = digitalfilter(Lowpass(cutoff), FIRWindow(kaiser(hLen, α)))
     scale!(h, Nϕ)

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -105,19 +105,19 @@ immutable DF2TFilter{T<:FilterCoefficients,S<:Array}
     coef::T
     state::S
 
-    function DF2TFilter(coef::PolynomialRatio, state::Vector)
+    function (::Type{DF2TFilter{Ti,Si}}){Ti,Si}(coef::PolynomialRatio, state::Vector)
         length(state) == length(coef.a)-1 == length(coef.b)-1 ||
             throw(ArgumentError("length of state vector must match filter order"))
-        new(coef, state)
+        new{Ti,Si}(coef, state)
     end
-    function DF2TFilter(coef::SecondOrderSections, state::Matrix)
+    function (::Type{DF2TFilter{Ti,Si}}){Ti,Si}(coef::SecondOrderSections, state::Matrix)
         (size(state, 1) == 2 && size(state, 2) == length(coef.biquads)) ||
             throw(ArgumentError("state must be 2 x nbiquads"))
-        new(coef, state)
+        new{Ti,Si}(coef, state)
     end
-    function DF2TFilter(coef::Biquad, state::Vector)
+    function (::Type{DF2TFilter{Ti,Si}}){Ti,Si}(coef::Biquad, state::Vector)
         length(state) == 2 || throw(ArgumentError("length of state must be 2"))
-        new(coef, state)
+        new{Ti,Si}(coef, state)
     end
 end
 

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -1,7 +1,7 @@
-typealias PFB{T} Matrix{T}          # polyphase filter bank
+@compat const PFB{T} = Matrix{T}          # polyphase filter bank
 
-abstract Filter
-abstract FIRKernel{T}
+@compat abstract type Filter end
+@compat abstract type FIRKernel{T} end
 
 # Single rate FIR kernel
 type FIRStandard{T} <: FIRKernel{T}
@@ -34,7 +34,7 @@ function FIRInterpolator(h::Vector, interpolation::Integer)
     inputDeficit  = 1
     ϕIdx          = 1
     hLen          = length(h)
-    
+
     FIRInterpolator(pfb, interpolation, Nϕ, tapsPerϕ, inputDeficit, ϕIdx,   hLen)
 end
 

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -1,5 +1,6 @@
 module Windows
 using Compat, ..Util
+import SpecialFunctions: besseli
 export  rect,
         hanning,
         hamming,


### PR DESCRIPTION
With this changes, it should be no warnings compiling DSP.jl on v0.5 and v0.6 (master). Some notes:

- I had to set upper bound version for Polynomials to pass all tests. With recent Polynomials (> v0.1.2) I had test failures in filter conversions. I would appreciate some experts can take a look at this in a separate issue/PR.
- Since new syntax for inner constructors (e.g. `A{T1,T2}(a, b) where {T1,T2}`) cannot be parsed with v0.5, I had to use deprecated call overloading syntax `(::Type{A{T1,T2}}{T1,T2}(a,b)` instead (ref: https://github.com/JuliaLang/Compat.jl/issues/332). This should be updated once we can drop v0.5.