### PR TITLE
Specialized freqz/freqs methods

### DIFF
--- a/src/Filters/response.jl
+++ b/src/Filters/response.jl
@@ -10,13 +10,26 @@ function freqz(filter::FilterCoefficients, w::Number)
     polyval(filter.b, ejw) ./ polyval(filter.a, ejw)
 end
 
+function freqz(filter::ZeroPoleGain, w::Number)
+    ejw = exp(im * w)
+    filter.k * prod([ejw - z for z in filter.z]) / prod([ejw - p for p in filter.p])
+end
+
+function freqz(filter::Biquad, w::Number)
+    ejw = exp(-im * w)
+    ejw2 = ejw*ejw
+    (filter.b0 + filter.b1*ejw + filter.b2*ejw2) / (1 + filter.a1*ejw  + filter.a2*ejw2)
+end
+
+function freqz(filter::SecondOrderSections, w::Number)
+    filter.g * prod([freqz(b, w) for b in filter.biquads])
+end
+
 function freqz(filter::FilterCoefficients, w = linspace(0, π, 250))
-    filter = convert(PolynomialRatio, filter)
     [freqz(filter, i) for i = w]
 end
 
 function freqz(filter::FilterCoefficients, hz::Union{Number, AbstractVector}, fs::Number)
-    filter = convert(PolynomialRatio, filter)
     freqz(filter, hz_to_radians_per_second(hz, fs))
 end
 

--- a/src/Filters/response.jl
+++ b/src/Filters/response.jl
@@ -73,13 +73,26 @@ function freqs(filter::FilterCoefficients, w::Number)
     polyval(filter.b, s) ./ polyval(filter.a, s)
 end
 
+function freqs(filter::ZeroPoleGain, w::Number)
+    s = im * w
+    filter.k * prod([s - z for z in filter.z]) / prod([s - p for p in filter.p])
+end
+
+function freqs(filter::Biquad, w::Number)
+    s = im * w
+    s2 = s*s
+    (filter.b0*s2 + filter.b1*s + filter.b2) / (s2 + filter.a1*s  + filter.a2)
+end
+
+function freqs(filter::SecondOrderSections, w::Number)
+    filter.g * prod([freqs(b, w) for b in filter.biquads])
+end
+
 function freqs(filter::FilterCoefficients, w::AbstractVector)
-    filter = convert(PolynomialRatio, filter)
     [freqs(filter, i) for i = w]
 end
 
 function freqs(filter::FilterCoefficients, hz::Union{Number, AbstractVector}, fs::Number)
-    filter = convert(PolynomialRatio, filter)
     freqs(filter, hz_to_radians_per_second(hz, fs))
 end
 

--- a/test/filter_response.jl
+++ b/test/filter_response.jl
@@ -39,6 +39,27 @@ h_abs = convert(Array{Float64}, abs.(h))
 #=xlabel("Normalised Frequency (x pi rad/s)")=#
 #=file(figure, "MATLAB-freqz.png", width=1200, height=800)=#
 
+#######################################
+#
+# freqz with conversion to PolynomialRatio may lead to undesirable roundoff errors
+# check by using the same poles and zeros such that they should cancel
+#
+#######################################
+
+rs = [1-10.0^-n for n in 1:15]
+@test freqz(ZeroPoleGain(rs, reverse(rs), 42.0), linspace(0, 2π, 50)) ≈ fill(42., 50)
+
+biq = Biquad(42.0, 84.0*real(.999999*exp(im)), 42.0*.999999^2, 2.0*real(.999999*exp(im)), .999999^2)
+@test freqz(biq, linspace(0, 2π, 50)) ≈ fill(42.0, 50)
+
+pr = [1-10.0^-n for n in 1:10]
+zr = reverse(pr)
+bs = [Biquad(42.0, 84.0*real(r[1]*exp(im)), 42.0*r[1]^2, 2.0*real(r[2]*exp(im)), r[2]^2) for r in zip(zr, pr)]
+sos = SecondOrderSections(bs, 42.0^-9)
+@test freqz(sos, linspace(0, 2π, 50)) ≈ fill(42.0, 50)
+
+@test freqz(ZeroPoleGain(Complex128[], Complex128[], 42.0), linspace(0, 2π, 50)) == fill(42.0, 50)
+@test freqz(SecondOrderSections(Biquad{Float64}[], 42.0), linspace(0, 2π, 50)) == fill(42.0, 50)
 
 #######################################
 #
@@ -68,6 +89,8 @@ stepz_matlab = matlab_resp[:,3]
 
 h_matlab = matlab_resp[:,4]
 @test abs.(freqz(df, w)) ≈ h_matlab
+@test abs.(freqz(SecondOrderSections(df), w)) ≈ h_matlab
+@test abs.(freqz(ZeroPoleGain(df), w)) ≈ h_matlab
 
 phi_matlab = matlab_resp[:,5]
 @test phasez(df, w) ≈ phi_matlab

--- a/test/filter_response.jl
+++ b/test/filter_response.jl
@@ -161,6 +161,9 @@ matlab_phasedeg = freqs_eg1_w_mag_phasedeg[:,3]
 @test mag ≈ matlab_mag
 @test phasedeg ≈ matlab_phasedeg
 
+@test h ≈ freqs(ZeroPoleGain(PolynomialRatio(b, a)), w)
+@test h ≈ freqs(SecondOrderSections(PolynomialRatio(b, a)), w)
+
 #=using Winston=#
 #=figure = loglog(w, mag)=#
 #=ylabel("Magnitude")=#


### PR DESCRIPTION
Just bumped into #143 when I was trying to numerically verify some custom filter design methods and thought I might give fixing it a try. While at it, I did the same for `freqs`, although I didn't construct test cases that previously would suffer badly from the rounding.

I've left
```julia
function freq[sz](filter::FilterCoefficients, w::Number)
    filter = convert(PolynomialRatio, filter)
    # ...
end
```
in place as a fallback for potential additional `FilterCoefficients` subtypes.