### PR TITLE
Fix a bunch of deprecations on Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6-rc1
+Compat 0.32
 Polynomials 0.1.0
 Reexport
 SpecialFunctions

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -422,7 +422,7 @@ filt(h::AbstractArray, x::AbstractArray) =
 # fftfilt and filt
 #
 
-const FFT_LENGTHS = 2.^(1:28)
+const FFT_LENGTHS = 2 .^ (1:28)
 # FFT times computed on a Core i7-3930K @4.4GHz
 # The real time doesn't matter, just the relative difference
 const FFT_TIMES = [6.36383e-7, 6.3779e-7 , 6.52212e-7, 6.65282e-7, 7.12794e-7, 7.63172e-7,

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -26,7 +26,7 @@ function implements the mathematics published in [1].
 (DAFX 2003 article, Lagrange et al)
 http://www.sylvain-marchand.info/Publications/dafx03.pdf
 """
-function lpc{T <: Number}(x::AbstractVector{T}, p::Int, ::LPCBurg)
+function lpc(x::AbstractVector{T}, p::Int, ::LPCBurg) where T <: Number
     ef = x                      # forward error
     eb = x                      # backwards error
     a = [1; zeros(T, p)]        # prediction coefficients
@@ -62,7 +62,7 @@ function implements the mathematics described in [1].
 [1] - The Wiener (RMS) Error Criterion in Filter Design and Prediction
 (Studies in Applied Mathematics 1947 article, N. Levison)
 """
-function lpc{T <: Number}(x::AbstractVector{T}, p::Int, ::LPCLevinson)
+function lpc(x::AbstractVector{<:Number}, p::Int, ::LPCLevinson)
     R_xx = xcorr(x,x)[length(x):end]
     a = zeros(p,p)
     prediction_err = zeros(1,p)

--- a/test/FilterTestHelpers.jl
+++ b/test/FilterTestHelpers.jl
@@ -108,7 +108,7 @@ end
 
 # Show the poles and zeros in each biquad
 # This is not currently used for testing, but is useful for debugging
-function sosfilter_poles_zeros{T}(sos::SecondOrderSections{T})
+function sosfilter_poles_zeros(sos::SecondOrderSections)
     z = fill(complex(nan(T)), 2, length(sos.biquads))
     p = fill(complex(nan(T)), 2, length(sos.biquads))
     for (i, biquad) in enumerate(sos.biquads)

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -224,7 +224,7 @@ f = DSP.digitalfilter(DSP.Bandpass(0.1, 0.3), DSP.Butterworth(2))
 # fftfilt/filt
 #
 
-for xlen in 2.^(7:18).-1, blen in 2.^(1:6).-1
+for xlen in 2 .^ (7:18) .- 1, blen in 2 .^ (1:6) .- 1
     b = randn(blen)
     for x in (rand(xlen), rand(xlen, 2))
         filtres = filt(b, [1.0], x)


### PR DESCRIPTION
* `Range` -> `AbstractRange` (requires Compat 0.32 on Julia 0.6)
* use `where` syntax for parametric functions
* `2.^` -> `2 .^`
* `-` -> `.-` (where necessary)

The tests show some `Loop variable "x" overwrites a variable in an enclosing scope. In the future the variable will be local to the loop instead.` warnings, but they're all harmless, the last value of `x` isn't actually used for anything.