### PR TITLE
Add function to calculate the mean frequency of a signal

### DIFF
--- a/doc/util.rst
+++ b/doc/util.rst
@@ -72,11 +72,11 @@
     Return the root mean square of signal ``s`` given the FFT transform
     ``f = fft(s)``. Equivalent to ``rms(ifft(f))``.
 
-.. function:: meanfreq(f, fs)
+.. function:: meanfreq(x, fs)
 
-    Calculate the mean power frequency of `f` with a sampling frequency of `fs`, defined as:
+    Calculate the mean power frequency of `x` with a sampling frequency of `fs`, defined as:
 
-    .. math:: \\textup{MPF} = \\frac{\\sum_{i=1}^{F} f_i X_i^2 }{\\sum_{i=0}^{F} X_i^2 } \\textup{Hz}
+    .. math:: MPF = \frac{\sum_{i=1}^{F} f_i X_i^2 }{\sum_{i=0}^{F} X_i^2 } Hz
 
     where `F` is the Nyquist frequency, and `X` is the power spectral density.
 

--- a/doc/util.rst
+++ b/doc/util.rst
@@ -72,9 +72,9 @@
     Return the root mean square of signal ``s`` given the FFT transform
     ``f = fft(s)``. Equivalent to ``rms(ifft(f))``.
 
-.. function:: meanfreq(f)
+.. function:: meanfreq(f, fs)
 
-    Calculate the mean power frequency of `x`, defined as:
+    Calculate the mean power frequency of `f` with a sampling frequency of `fs`, defined as:
 
     .. math:: \\textup{MPF} = \\frac{\\sum_{i=1}^{F} f_i X_i^2 }{\\sum_{i=0}^{F} X_i^2 } \\textup{Hz}
 

--- a/doc/util.rst
+++ b/doc/util.rst
@@ -72,3 +72,11 @@
     Return the root mean square of signal ``s`` given the FFT transform
     ``f = fft(s)``. Equivalent to ``rms(ifft(f))``.
 
+.. function:: meanfreq(f)
+
+    Calculate the mean power frequency of `x`, defined as:
+
+    .. math:: \\textup{MPF} = \\frac{\\sum_{i=1}^{F} f_i X_i^2 }{\\sum_{i=0}^{F} X_i^2 } \\textup{Hz}
+
+    where `F` is the Nyquist frequency, and `X` is the power spectral density.
+

--- a/src/util.jl
+++ b/src/util.jl
@@ -173,14 +173,14 @@ rms(s::AbstractArray{T}) where {T<:Number} = sqrt(sum(abs2, s)/length(s))
 # root mean square of fft of signal
 rmsfft(f::AbstractArray{T}) where {T<:Complex} = sqrt(sum(abs2, f))/length(f)
 
-function meanfreq{T}(f::AbstractVector{T},ΔT)
-    pxxX = abs2.(rfft(f))
+function meanfreq{T<:Real}(f::AbstractVector{T},fs=2*π)
+    pxx = abs2.(rfft(f))
 
     len = length(f)
-    npoints = fld(len,2);
-    freqrg = (1/ΔT)/len.*(0:(npoints))
+    npoints = fld(len,2)
+    freqrg = fs/len.*(0:(npoints))
 
-    mf = sum(pxxX.*freqrg)./sum(pxxX)
+    mf = sum(pxx.*freqrg)./sum(pxx)
     return mf
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -173,10 +173,10 @@ rms(s::AbstractArray{T}) where {T<:Number} = sqrt(sum(abs2, s)/length(s))
 # root mean square of fft of signal
 rmsfft(f::AbstractArray{T}) where {T<:Complex} = sqrt(sum(abs2, f))/length(f)
 
-function meanfreq{T<:Real}(f::AbstractVector{T},fs=2*π)
-    pxx = abs2.(rfft(f))
+function meanfreq(x::AbstractVector{<:Real}, fs=2*π)
+    pxx = abs2.(rfft(x))
 
-    len = length(f)
+    len = length(x)
     npoints = fld(len,2)
     freqrg = fs/len.*(0:(npoints))
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -22,6 +22,7 @@ export  unwrap!,
         db2amp,
         rms,
         rmsfft,
+        meanfreq,
         unsafe_dot,
         polyfit,
         shiftin!
@@ -172,7 +173,16 @@ rms(s::AbstractArray{T}) where {T<:Number} = sqrt(sum(abs2, s)/length(s))
 # root mean square of fft of signal
 rmsfft(f::AbstractArray{T}) where {T<:Complex} = sqrt(sum(abs2, f))/length(f)
 
+function meanfreq{T}(f::AbstractVector{T},ΔT)
+    pxxX = abs2.(rfft(f))
 
+    len = length(f)
+    npoints = fld(len,2);
+    freqrg = (1/ΔT)/len.*(0:(npoints))
+
+    mf = sum(pxxX.*freqrg)./sum(pxxX)
+    return mf
+end
 
 # Computes the dot product of a single column of a, specified by aColumnIdx, with the vector b.
 # The number of elements used in the dot product determined by the size(A)[1].

--- a/test/util.jl
+++ b/test/util.jl
@@ -95,6 +95,8 @@ for n = 1:7
     @test fftshift(fftfreq(n)) ≈ fftshift([fftfreq(n);])
 end
 
+@test isapprox(meanfreq(sin.(2*pi*10*(0:1e-3:10*pi)),1e-3),10.0,rtol=0.1)
+
 # nextfastfft
 @test nextfastfft(64) == 64
 @test nextfastfft(65) == 70

--- a/test/util.jl
+++ b/test/util.jl
@@ -95,7 +95,7 @@ for n = 1:7
     @test fftshift(fftfreq(n)) ≈ fftshift([fftfreq(n);])
 end
 
-@test isapprox(meanfreq(sin.(2*pi*10*(0:1e-3:10*pi)),1e-3),10.0,rtol=0.1)
+@test isapprox(meanfreq(sin.(2*pi*10*(0:1e-3:10*pi)),1e3),10.0,rtol=0.1)
 
 # nextfastfft
 @test nextfastfft(64) == 64

--- a/test/util.jl
+++ b/test/util.jl
@@ -95,7 +95,7 @@ for n = 1:7
     @test fftshift(fftfreq(n)) ≈ fftshift([fftfreq(n);])
 end
 
-@test isapprox(meanfreq(sin.(2*pi*10*(0:1e-3:10*pi)),1e3),10.0,rtol=0.1)
+@test meanfreq(sin.(2*π*10*(0:1e-3:10*π)),1e3) ≈ 10.0 rtol=1e-3
 
 # nextfastfft
 @test nextfastfft(64) == 64


### PR DESCRIPTION
The mean frequency of a signal is a useful analysis and is also present in MATLAB.

I'm open to suggestions to improve the code or re-work the pull request to make it more convenient to accept.