### PR TITLE
Fix FFTW related warning on Julia 0.6

### DIFF
--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -6,9 +6,11 @@ module DSP
 # This macro will be called in each submodule herein to do the appropriate imports
 macro importffts()
     quote
-        using AbstractFFTs, FFTW
-        importall AbstractFFTs, FFTW
+        using AbstractFFTs
+        importall AbstractFFTs
         if VERSION >= v"0.7.0-DEV.602"
+            using FFTW
+            importall FFTW
             import AbstractFFTs: fftshift, ifftshift
             import FFTW: plan_fft, plan_fft!, plan_rfft, plan_brfft, plan_irfft, plan_bfft, plan_bfft!,
                          fft, fft!, ifft, ifft!, irfft, bfft, bfft!

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,6 +1,5 @@
 module Util
 using ..DSP: @importffts
-import FFTW: fftwReal, fftwComplex, fftwNumber
 import Base: *
 @importffts
 
@@ -49,7 +48,7 @@ function unwrap(m::Array{T}, args...; kwargs...) where T<:AbstractFloat
     unwrap!(copy(m), args...; kwargs...)
 end
 
-function hilbert(x::StridedVector{T}) where T<:fftwReal
+function hilbert(x::StridedVector{T}) where T<:FFTW.fftwReal
 # Return the Hilbert transform of x (a real signal).
 # Code inspired by Scipy's implementation, which is under BSD license.
     N = length(x)
@@ -104,18 +103,18 @@ end
 ## FFT TYPES
 
 # Get the input element type of FFT for a given type
-fftintype(::Type{T}) where {T<:fftwNumber} = T
+fftintype(::Type{T}) where {T<:FFTW.fftwNumber} = T
 fftintype(::Type{T}) where {T<:Real} = Float64
 fftintype(::Type{T}) where {T<:Complex} = Complex128
 
 # Get the return element type of FFT for a given type
-fftouttype(::Type{T}) where {T<:fftwComplex} = T
-fftouttype(::Type{T}) where {T<:fftwReal} = Complex{T}
+fftouttype(::Type{T}) where {T<:FFTW.fftwComplex} = T
+fftouttype(::Type{T}) where {T<:FFTW.fftwReal} = Complex{T}
 fftouttype(::Type{T}) where {T<:Union{Real,Complex}} = Complex128
 
 # Get the real part of the return element type of FFT for a given type
-fftabs2type(::Type{Complex{T}}) where {T<:fftwReal} = T
-fftabs2type(::Type{T}) where {T<:fftwReal} = T
+fftabs2type(::Type{Complex{T}}) where {T<:FFTW.fftwReal} = T
+fftabs2type(::Type{T}) where {T<:FFTW.fftwReal} = T
 fftabs2type(::Type{T}) where {T<:Union{Real,Complex}} = Float64
 
 ## FREQUENCY VECTOR


### PR DESCRIPTION
Avoid `using FFTW` on Julia 0.6, as the FFTW package does not define a
module there, leading to a warning about failed precompilation. Closes #176.