### PR TITLE
Fix deprecations on Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6-rc1
-Compat 0.32
+Compat 0.38
 Polynomials 0.1.0
 Reexport
 SpecialFunctions

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -7,16 +7,8 @@ module DSP
 macro importffts()
     quote
         using AbstractFFTs
-        importall AbstractFFTs
         if VERSION >= v"0.7.0-DEV.602"
             using FFTW
-            importall FFTW
-            import AbstractFFTs: fftshift, ifftshift
-            import FFTW: plan_fft, plan_fft!, plan_rfft, plan_brfft, plan_irfft, plan_bfft, plan_bfft!,
-                         fft, fft!, ifft, ifft!, irfft, bfft, bfft!
-        else
-            import Base: plan_fft, plan_fft!, plan_rfft, plan_brfft, plan_irfft, plan_bfft, plan_bfft!,
-                         fft, fft!, ifft, ifft!, irfft, bfft, bfft!, fftshift, ifftshift
         end
     end
 end

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -2,6 +2,7 @@ module Filters
 import ..DSP: @importffts
 using Polynomials, ..Util
 import Base: *
+using Compat: uninitialized
 @importffts
 if VERSION >= v"0.7.0-DEV.602"
     import ..DSP: filt, filt!

--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -343,7 +343,7 @@ function Base.convert(::Type{SecondOrderSections}, f::ZeroPoleGain{Z,P}) where {
 
     # Allocate memory for biquads
     T = promote_type(realtype(Z), realtype(P))
-    biquads = Array{Biquad{T}}((n >> 1)+(n & 1))
+    biquads = Vector{Biquad{T}}(uninitialized, (n >> 1)+(n & 1))
 
     # Build second-order sections in reverse
     # First do complete pairs

--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -121,7 +121,7 @@ Chebyshev2(n::Integer, ripple::Real) = Chebyshev2(Float64, n, ripple)
 # Compute Landen sequence for evaluation of elliptic functions
 function landen(k::Real)
     niter = 7
-    kn = Array{typeof(k)}(niter)
+    kn = Vector{typeof(k)}(uninitialized, niter)
     # Eq. (50)
     for i = 1:niter
         kn[i] = k = abs2(k/(1+sqrt(1-abs2(k))))
@@ -191,8 +191,8 @@ function Elliptic(T::Type, n::Integer, rp::Real, rs::Real)
     # Eq. (65)
     v0 = -im/n*asne(im/εp, k1)
 
-    z = Array{Complex{T}}(2*div(n, 2))
-    p = Array{Complex{T}}(n)
+    z = Vector{Complex{T}}(uninitialized, 2*div(n, 2))
+    p = Vector{Complex{T}}(uninitialized, n)
     gain = one(T)
     for i = 1:div(n, 2)
         # Eq. (43)
@@ -365,8 +365,8 @@ function transform_prototype(ftype::Bandstop, proto::ZeroPoleGain)
     nz = length(z)
     np = length(p)
     npairs = nz+np-min(nz, np)
-    newz = Array{Base.promote_eltype(z, p)}(2*npairs)
-    newp = Array{Base.promote_eltype(z, p)}(2*npairs)
+    newz = Vector{Base.promote_eltype(z, p)}(uninitialized, 2*npairs)
+    newp = Vector{Base.promote_eltype(z, p)}(uninitialized, 2*npairs)
 
     num = one(eltype(z))
     for i = 1:nz
@@ -419,7 +419,7 @@ function bilinear(f::ZeroPoleGain{Z,P,K}, fs::Real) where {Z,P,K}
     z = fill(convert(ztype, -1), max(length(f.p), length(f.z)))
 
     ptype = typeof(0 + zero(P)/fs)
-    p = Array{typeof(zero(P)/fs)}(length(f.p))
+    p = Vector{typeof(zero(P)/fs)}(uninitialized, length(f.p))
 
     num = one(one(fs) - one(Z))
     for i = 1:length(f.z)

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -75,7 +75,7 @@ function filt!(out::AbstractArray, f::SecondOrderSections, x::AbstractArray,
 end
 
 filt(f::SecondOrderSections{T,G}, x::AbstractArray{S}, si=_zerosi(f, x)) where {T,G,S<:Number} =
-    filt!(Array{promote_type(T, G, S)}(size(x)), f, x, si)
+    filt!(Array{promote_type(T, G, S)}(uninitialized, size(x)), f, x, si)
 
 ## Biquad
 _zerosi(f::Biquad{T}, x::AbstractArray{S}) where {T,S} =
@@ -111,7 +111,7 @@ function filt!(out::AbstractArray, f::Biquad, x::AbstractArray,
 end
 
 filt(f::Biquad{T}, x::AbstractArray{S}, si=_zerosi(f, x)) where {T,S<:Number} =
-    filt!(Array{promote_type(T, S)}(size(x)), f, x, si)
+    filt!(Array{promote_type(T, S)}(uninitialized, size(x)), f, x, si)
 
 ## For arbitrary filters, convert to SecondOrderSections
 filt(f::FilterCoefficients, x) = filt(convert(SecondOrderSections, f), x)
@@ -200,7 +200,7 @@ end
 
 # Variant that allocates the output
 filt(f::DF2TFilter{T,S}, x::AbstractVector) where {T,S<:Array} =
-    filt!(Array{eltype(S)}(length(x)), f, x)
+    filt!(Vector{eltype(S)}(uninitialized, length(x)), f, x)
 
 # Fall back to SecondOrderSections
 DF2TFilter(coef::FilterCoefficients) = DF2TFilter(convert(SecondOrderSections, coef))
@@ -238,7 +238,7 @@ function iir_filtfilt(b::AbstractVector, a::AbstractVector, x::AbstractArray)
     zitmp = copy(zi)
     pad_length = 3 * (max(length(a), length(b)) - 1)
     t = Base.promote_eltype(b, a, x)
-    extrapolated = Array{t}(size(x, 1)+pad_length*2)
+    extrapolated = Vector{t}(uninitialized, size(x, 1)+pad_length*2)
     out = similar(x, t)
 
     istart = 1
@@ -313,7 +313,7 @@ function filtfilt(f::SecondOrderSections{T,G}, x::AbstractArray{S}) where {T,G,S
     zitmp = similar(zi)
     pad_length = 6 * length(f.biquads)
     t = Base.promote_type(T, G, S)
-    extrapolated = Array{t}(size(x, 1)+pad_length*2)
+    extrapolated = Vector{t}(uninitialized, size(x, 1)+pad_length*2)
     out = similar(x, t)
 
     istart = 1
@@ -365,7 +365,7 @@ function filt_stepstate(b::Union{AbstractVector{T}, T}, a::Union{AbstractVector{
 
 function filt_stepstate(f::SecondOrderSections{T}) where T
     biquads = f.biquads
-    si = Array{T}(2, length(biquads))
+    si = Matrix{T}(uninitialized, 2, length(biquads))
     y = one(T)
     for i = 1:length(biquads)
         biquad = biquads[i]
@@ -455,7 +455,7 @@ function filt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
 end
 
 filt(h::AbstractArray, x::AbstractArray) =
-    filt!(Array{eltype(x)}(size(x)), h, x)
+    filt!(Array{eltype(x)}(uninitialized, size(x)), h, x)
 
 #
 # fftfilt and filt
@@ -511,9 +511,9 @@ function fftfilt(b::AbstractVector{T}, x::AbstractArray{T},
     normfactor = 1/nfft
 
     L = min(nx, nfft - (nb - 1))
-    tmp1 = Array{T}(nfft)
-    tmp2 = Array{Complex{T}}(nfft >> 1 + 1)
-    out = Array{T}(size(x))
+    tmp1 = Vector{T}(uninitialized, nfft)
+    tmp2 = Vector{Complex{T}}(uninitialized, nfft >> 1 + 1)
+    out = Array{T}(uninitialized, size(x))
 
     p1 = plan_rfft(tmp1)
     p2 = plan_brfft(tmp2, nfft)
@@ -564,7 +564,7 @@ function filt(b::AbstractVector{T}, x::AbstractArray{T}) where T<:Number
         # 65536 is apprximate cutoff where FFT-based algorithm may be
         # more effective (due to overhead for allocation, plan
         # creation, etc.)
-        filt!(Array{eltype(x)}(size(x)), b, x)
+        filt!(Array{eltype(x)}(uninitialized, size(x)), b, x)
     else
         # Estimate number of multiplication operations for fftfilt()
         # and filt()
@@ -573,6 +573,6 @@ function filt(b::AbstractVector{T}, x::AbstractArray{T}) where T<:Number
         nchunk = ceil(Int, nx/L)*div(length(x), nx)
         fftops = (2*nchunk + 1) * nfft * log2(nfft)/2 + nchunk * nfft + 500000
 
-        filtops > fftops ? fftfilt(b, x, nfft) : filt!(Array{eltype(x)}(size(x)), b, x)
+        filtops > fftops ? fftfilt(b, x, nfft) : filt!(Array{eltype(x)}(uninitialized, size(x)), b, x)
     end
 end

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -356,7 +356,7 @@ function filt_stepstate(b::Union{AbstractVector{T}, T}, a::Union{AbstractVector{
     as<sz && (a = copy!(zeros(eltype(a), sz), a))
 
     # construct the companion matrix A and vector B:
-    A = [-a[2:end] [eye(T, sz-2); zeros(T, 1, sz-2)]]
+    A = [-a[2:end] [I; zeros(T, 1, sz-2)]]
     B = b[2:end] - a[2:end] * b[1]
     # Solve si = A*si + B
     # (I - A)*si = B

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -277,7 +277,7 @@ function taps2pfb(h::Vector{T}, Nϕ::Integer) where T
     hLen     = length(h)
     tapsPerϕ = ceil(Int, hLen/Nϕ)
     pfbSize  = tapsPerϕ * Nϕ
-    pfb      = Array{T}(tapsPerϕ, Nϕ)
+    pfb      = Matrix{T}(uninitialized, tapsPerϕ, Nϕ)
     hIdx     = 1
 
     for rowIdx in tapsPerϕ:-1:1, colIdx in 1:Nϕ
@@ -417,7 +417,7 @@ end
 
 function filt(self::FIRFilter{FIRStandard{Th}}, x::AbstractVector{Tx}) where {Th,Tx}
     bufLen         = outputlength(self, length(x))
-    buffer         = Array{promote_type(Th,Tx)}(bufLen)
+    buffer         = Vector{promote_type(Th,Tx)}(uninitialized, bufLen)
     samplesWritten = filt!(buffer, self, x)
 
     samplesWritten == bufLen || resize!(buffer, samplesWritten)
@@ -468,7 +468,7 @@ end
 
 function filt(self::FIRFilter{FIRInterpolator{Th}}, x::AbstractVector{Tx}) where {Th,Tx}
     bufLen         = outputlength(self, length(x))
-    buffer         = Array{promote_type(Th,Tx)}(bufLen)
+    buffer         = Vector{promote_type(Th,Tx)}(uninitialized, bufLen)
     samplesWritten = filt!(buffer, self, x)
 
     samplesWritten == bufLen || resize!(buffer, samplesWritten)
@@ -524,7 +524,7 @@ end
 
 function filt(self::FIRFilter{FIRRational{Th}}, x::AbstractVector{Tx}) where {Th,Tx}
     bufLen         = outputlength(self, length(x))
-    buffer         = Array{promote_type(Th,Tx)}(bufLen)
+    buffer         = Vector{promote_type(Th,Tx)}(uninitialized, bufLen)
     samplesWritten = filt!(buffer, self, x)
 
     samplesWritten == bufLen || resize!(buffer, samplesWritten)
@@ -572,7 +572,7 @@ end
 
 function filt(self::FIRFilter{FIRDecimator{Th}}, x::AbstractVector{Tx}) where {Th,Tx}
     bufLen         = outputlength(self, length(x))
-    buffer         = Array{promote_type(Th,Tx)}(bufLen)
+    buffer         = Vector{promote_type(Th,Tx)}(uninitialized, bufLen)
     samplesWritten = filt!(buffer, self, x)
 
     samplesWritten == bufLen || resize!(buffer, samplesWritten)
@@ -643,7 +643,7 @@ end
 
 function filt(self::FIRFilter{FIRArbitrary{Th}}, x::AbstractVector{Tx}) where {Th,Tx}
     bufLen         = outputlength(self, length(x))
-    buffer         = Array{promote_type(Th,Tx)}(bufLen)
+    buffer         = Vector{promote_type(Th,Tx)}(uninitialized, bufLen)
     samplesWritten = filt!(buffer, self, x)
 
     samplesWritten == bufLen || resize!(buffer, samplesWritten)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -12,7 +12,7 @@ state vector `si` (defaults to zeros).
 """
 function filt(b::Union{AbstractVector, Number}, a::Union{AbstractVector, Number},
               x::AbstractArray{T}, si::AbstractArray{S} = _zerosi(b,a,T)) where {T,S}
-    filt!(Array{promote_type(eltype(b), eltype(a), T, S)}(size(x)), b, a, x, si)
+    filt!(Array{promote_type(eltype(b), eltype(a), T, S)}(uninitialized, size(x)), b, a, x, si)
 end
 
 # in-place filtering: returns results in the out argument, which may shadow x

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -216,15 +216,15 @@ See also: [`fftfreq`](@ref), [`rfftfreq`](@ref)
 """
 freq(p::TFR) = p.freq
 freq(p::Periodogram2) = (p.freq1, p.freq2)
-fftshift(p::Periodogram{T,F}) where {T,F<:Frequencies} =
+AbstractFFTs.fftshift(p::Periodogram{T,F}) where {T,F<:Frequencies} =
     Periodogram(p.freq.nreal == p.freq.n ? p.power : fftshift(p.power), fftshift(p.freq))
-fftshift(p::Periodogram{T,F}) where {T,F<:AbstractRange} = p
+AbstractFFTs.fftshift(p::Periodogram{T,F}) where {T,F<:AbstractRange} = p
 # 2-d
-fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:Frequencies,F2<:Frequencies} =
+AbstractFFTs.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:Frequencies,F2<:Frequencies} =
     Periodogram2(p.freq1.nreal == p.freq1.n ? fftshift(p.power,2) : fftshift(p.power), fftshift(p.freq1), fftshift(p.freq2))
-fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:AbstractRange,F2<:Frequencies} =
+AbstractFFTs.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:AbstractRange,F2<:Frequencies} =
     Periodogram2(fftshift(p.power,2), p.freq1, fftshift(p.freq2))
-fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:AbstractRange,F2<:AbstractRange} = p
+AbstractFFTs.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:AbstractRange,F2<:AbstractRange} = p
 
 # Compute the periodogram of a signal S, defined as 1/N*X[s(n)]^2, where X is the
 # DTFT of the signal S.
@@ -440,9 +440,9 @@ struct Spectrogram{T,F<:Union{Frequencies,AbstractRange}} <: TFR{T}
     freq::F
     time::FloatRange{Float64}
 end
-fftshift(p::Spectrogram{T,F}) where {T,F<:Frequencies} =
+AbstractFFTs.fftshift(p::Spectrogram{T,F}) where {T,F<:Frequencies} =
     Spectrogram(p.freq.nreal == p.freq.n ? p.power : fftshift(p.power, 1), fftshift(p.freq), p.time)
-fftshift(p::Spectrogram{T,F}) where {T,F<:AbstractRange} = p
+AbstractFFTs.fftshift(p::Spectrogram{T,F}) where {T,F<:AbstractRange} = p
 
 """
     time(p)

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -5,7 +5,7 @@
 module Periodograms
 using ..DSP: @importffts
 using ..Util, ..Windows
-using Compat: AbstractRange
+using Compat: AbstractRange, uninitialized
 export arraysplit, nextfastfft, periodogram, welch_pgram, mt_pgram,
        spectrogram, power, freq, stft
 @importffts
@@ -371,7 +371,7 @@ function welch_pgram(s::AbstractVector{T}, n::Int=length(s)>>3, noverlap::Int=n>
     out = zeros(fftabs2type(T), onesided ? (nfft >> 1)+1 : nfft)
     r = fs*norm2*length(sig_split)
 
-    tmp = Array{fftouttype(T)}(T<:Real ? (nfft >> 1)+1 : nfft)
+    tmp = Vector{fftouttype(T)}(uninitialized, T<:Real ? (nfft >> 1)+1 : nfft)
     plan = forward_plan(sig_split.buf, tmp)
     for sig in sig_split
         A_mul_B!(tmp, plan, sig)
@@ -415,7 +415,7 @@ function mt_pgram(s::AbstractVector{T}; onesided::Bool=eltype(s)<:Real,
 
     out = zeros(fftabs2type(T), onesided ? (nfft >> 1)+1 : nfft)
     input = zeros(fftintype(T), nfft)
-    tmp = Array{fftouttype(T)}(T<:Real ? (nfft >> 1)+1 : nfft)
+    tmp = Vector{fftouttype(T)}(uninitialized, T<:Real ? (nfft >> 1)+1 : nfft)
 
     plan = forward_plan(input, tmp)
     for j = 1:size(window, 2)
@@ -491,7 +491,7 @@ function stft(s::AbstractVector{T}, n::Int=length(s)>>3, noverlap::Int=n>>1,
     sig_split = arraysplit(s, n, noverlap, nfft, win)
     nout = onesided ? (nfft >> 1)+1 : nfft
     out = zeros(stfttype(T, psdonly), nout, length(sig_split))
-    tmp = Array{fftouttype(T)}(T<:Real ? (nfft >> 1)+1 : nfft)
+    tmp = Vector{fftouttype(T)}(uninitialized, T<:Real ? (nfft >> 1)+1 : nfft)
     r = fs*norm2
 
     plan = forward_plan(sig_split.buf, tmp)

--- a/src/util.jl
+++ b/src/util.jl
@@ -182,7 +182,7 @@ containing the frequency bin centers at every sample point. `fs`
 is the sample rate of the input signal.
 """
 rfftfreq(n::Int, fs::Real=1) = Frequencies((n >> 1)+1, (n >> 1)+1, fs/n)
-fftshift(x::Frequencies) = (x.nreal-x.n:x.nreal-1)*x.multiplier
+AbstractFFTs.fftshift(x::Frequencies) = (x.nreal-x.n:x.nreal-1)*x.multiplier
 
 # Get next fast FFT size for a given signal length
 const FAST_FFT_SIZES = [2, 3, 5, 7]

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,6 +1,7 @@
 module Util
 using ..DSP: @importffts
 import Base: *
+using Compat: uninitialized
 @importffts
 
 export  unwrap!,
@@ -90,8 +91,8 @@ along the first dimension of x.
 """
 function hilbert(x::AbstractArray{T}) where T<:Real
     N = size(x, 1)
-    xc = Array{fftintype(T)}(N)
-    X = Array{fftouttype(T)}(N)
+    xc = Vector{fftintype(T)}(uninitialized, N)
+    X = Vector{fftouttype(T)}(uninitialized, N)
     out = similar(x, fftouttype(T))
 
     p1 = plan_rfft(xc)

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -2,6 +2,7 @@ module Windows
 using ..DSP: @importffts
 using ..Util
 import SpecialFunctions: besseli
+using Compat: uninitialized
 @importffts
 
 export  rect,
@@ -221,17 +222,17 @@ function dpsseig(A::Matrix{Float64}, nw::Real)
     w = nw/size(A, 1)
 
     # Compute coefficients
-    seq = Array{Float64}(size(A, 1))
+    seq = Vector{Float64}(uninitialized, size(A, 1))
     seq[1] = 1.0
     for i = 1:size(A, 1)-1
         seq[i+1] = 2 * sinc(2w*i)
     end
 
-    q = Array{Float64}(size(A, 2))
+    q = Vector{Float64}(uninitialized, size(A, 2))
     nfft = nextfastfft(2*size(A, 1)-1)
 
-    tmp1 = Array{Float64}(nfft)
-    tmp2 = Array{Complex{Float64}}(nfft >> 1 + 1)
+    tmp1 = Vector{Float64}(uninitialized, nfft)
+    tmp2 = Vector{Complex{Float64}}(uninitialized, nfft >> 1 + 1)
     p1 = plan_rfft(tmp1)
     p2 = plan_brfft(tmp2, nfft)
 

--- a/test/FilterTestHelpers.jl
+++ b/test/FilterTestHelpers.jl
@@ -1,5 +1,5 @@
 module FilterTestHelpers
-using DSP, Base.Test
+using DSP, Compat, Compat.Test
 
 export tffilter_eq, zpkfilter_eq, tffilter_accuracy, zpkfilter_accuracy,
        matrix_to_sosfilter, sosfilter_to_matrix

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -1,6 +1,6 @@
 # This file was formerly a part of Julia. License is MIT: https://julialang.org/license
 
-using Base.Test, DSP
+using Compat, Compat.Test, DSP
 import DSP: filt, filt!, deconv, conv, conv2, xcorr
 
 # Filter

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -1,5 +1,5 @@
 !(dirname(@__FILE__) in LOAD_PATH) && push!(LOAD_PATH, dirname(@__FILE__))
-using DSP, Base.Test, FilterTestHelpers
+using DSP, Compat, Compat.Test, FilterTestHelpers
 
 #
 # filt with different filter forms

--- a/test/filt_stream.jl
+++ b/test/filt_stream.jl
@@ -1,4 +1,4 @@
-using DSP, Base.Test
+using DSP, Compat, Compat.Test
 
 # Naive rational resampler
 function naivefilt(h::Vector, x::Vector, resamplerate::Rational=1//1)

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -1,5 +1,5 @@
 !(dirname(@__FILE__) in LOAD_PATH) && push!(LOAD_PATH, dirname(@__FILE__))
-using DSP, Base.Test, FilterTestHelpers, Polynomials
+using DSP, Compat, Compat.Test, FilterTestHelpers, Polynomials
 
 # Test conversion to SOS against MATLAB
 # Test poles/zeros generated with:

--- a/test/filter_design.jl
+++ b/test/filter_design.jl
@@ -1,5 +1,5 @@
 !(dirname(@__FILE__) in LOAD_PATH) && push!(LOAD_PATH, dirname(@__FILE__))
-using DSP, Base.Test, FilterTestHelpers
+using DSP, Compat, Compat.Test, FilterTestHelpers
 
 #
 # Butterworth filter prototype

--- a/test/filter_response.jl
+++ b/test/filter_response.jl
@@ -1,4 +1,4 @@
-using DSP, Base.Test
+using DSP, Compat, Compat.Test
 
 
 #######################################

--- a/test/periodograms.jl
+++ b/test/periodograms.jl
@@ -214,13 +214,7 @@ n2 = 46  # assuming n1>n2
 nf = (22,7) # the non-zero location
 F = (fftfreq(n1,1),fftfreq(n2,1))
 a = [F[1][nf[1]],F[2][nf[2]]]
-FB = Array{Bool}(n1,n2)
-for j = 1:n2
-    for i = 1:n1
-        FB[i,j] = [F[1][i], F[2][j]]==a || [F[1][i], F[2][j]]==-a
-    end
-end
-
+FB = Bool[[F[1][i], F[2][j]]==a || [F[1][i], F[2][j]]==-a for i = 1:n1, j = 1:n2]
 ind = find(FB)
 x = zeros(n1,n2)*0im;
 x[ind] = [1+2im,1-2im]

--- a/test/periodograms.jl
+++ b/test/periodograms.jl
@@ -14,7 +14,7 @@
 #  close(fid)
 #end
 
-using DSP, Base.Test
+using DSP, Compat, Compat.Test
 
 x0 = vec(readdlm(joinpath(dirname(@__FILE__), "data", "spectrogram_x.txt"),'\t'))
 f0 = vec(readdlm(joinpath(dirname(@__FILE__), "data", "spectrogram_f.txt"),'\t'))

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -1,5 +1,5 @@
 using DSP
-using Base.Test
+using Compat, Compat.Test
 
 # AM Modulator
 # sig(t) = [(1 + sin(2π*0.005*t)) * sin(2π*.05*t) for t in t]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using DSP, AbstractFFTs, FFTW, Base.Test
+using Compat, DSP, AbstractFFTs, FFTW, Compat.Test
 
 include("dsp.jl")
 include("util.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using DSP, AbstractFFTs, FFTW, Base.Test
-importall AbstractFFTs, FFTW
 
 include("dsp.jl")
 include("util.jl")

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,4 +1,4 @@
-using DSP, Base.Test
+using DSP, Compat, Compat.Test
 
 @test unwrap([0.1, 0.2, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
 @test unwrap([0.1, 0.2 + 2pi, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]

--- a/test/windows.jl
+++ b/test/windows.jl
@@ -1,4 +1,4 @@
-using DSP, Base.Test
+using DSP, Compat, Compat.Test
 
 # Test dpss against dpss computed with MATLAB
 d1 = dpss(128, 4)


### PR DESCRIPTION
This should fix all current deprecations except for a bunch of implicit assignments to global variables during the tests. These are probably best handled by introducing testsets to completely avoid globals, but that's for another PR...