### PR TITLE
Bump minimum required Julia version to 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-rc1
+julia 0.6
 Compat 0.63
 Polynomials 0.1.0
 Reexport


### PR DESCRIPTION
METADATA does not allow `julia 0.6-rc1` anymore.