### PR TITLE
add n-dimensional unwrap

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-rc1
+julia 0.6
 Compat 0.63
 Polynomials 0.1.0
 Reexport

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -46,13 +46,14 @@ if VERSION >= v"0.7.0-DEV.602"
 end
 
 include("util.jl")
+include("unwrap.jl")
 include("windows.jl")
 include("periodograms.jl")
 include("Filters/Filters.jl")
 include("lpc.jl")
 
 using Reexport
-@reexport using .Util, .Windows, .Periodograms, .Filters, .LPC
+@reexport using .Util, .Windows, .Periodograms, .Filters, .LPC, .Unwrap
 
 include("deprecated.jl")
 end

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -1,5 +1,6 @@
 module Filters
 using ..DSP: @importffts, mul!, rmul!
+using ..Unwrap
 using Polynomials, ..Util
 import Base: *
 using Compat: copyto!, undef

--- a/src/Filters/response.jl
+++ b/src/Filters/response.jl
@@ -54,7 +54,7 @@ or frequencies `w` in radians/sample.
 """
 function phasez(filter::FilterCoefficients, w = Compat.range(0, stop=π, length=250))
     h = freqz(filter, w)
-    unwrap(-atan2.(imag(h), real(h)))
+    unwrap(-atan2.(imag(h), real(h)); dims=ndims(h))
 end
 
 

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -68,16 +68,16 @@ measurement of a scene, such as when retrieving the phase information of
 of an image, as each pixel is wrapped to stay within (-pi, pi].
 
 # Arguments
-- `m::AbstractArray{T, N}`: Array to unwrap
+- `m::AbstractArray{T, N}`: Array to unwrap.
 - `dims=nothing`: Dimensions along which to unwrap. If `dims` is an integer, then
-    `unwrap` is called that dimension. If `dims=1:ndims(m)`, then `m` is unwrapped
+    `unwrap` is called on that dimension. If `dims=1:ndims(m)`, then `m` is unwrapped
     across all dimensions.
-- `range=2pi`: Range of wrapped array
+- `range=2pi`: Range of wrapped array.
 - `circular_dims=(false, ...)`:  When an element of this tuple is `true`, the
     unwrapping process will consider the edges along the corresponding axis
-    of the array to be connected
+    of the array to be connected.
 - `rng=GLOBAL_RNG`: Unwrapping of arrays with dimension > 1 uses a random
-    initialization. A user can be pass their own RNG through this argument.
+    initialization. A user can pass their own RNG through this argument.
 """
 function unwrap(m::AbstractArray{T,N}; dims=nothing, kwargs...) where {T, N}
     if dims === nothing && N != 1

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -10,12 +10,12 @@ export unwrap, unwrap!
 
 In-place version of [`unwrap`](@ref).
 """
-function unwrap!(m::AbstractArray{T,N}; dims=nothing, range=2T(pi), kwargs...) where {T, N}
+function unwrap!(m::AbstractArray{T,N}; dims=nothing, kwargs...) where {T, N}
     if dims === nothing && N != 1
         Base.depwarn("`unwrap!(m::AbstractArray)` is deprecated, use `unwrap!(m, dims=ndims(m))` instead", :unwrap!)
         dims = N
     end
-    unwrap!(m, m; dims=dims, range=range, kwargs...)
+    unwrap!(m, m; dims=dims, kwargs...)
 end
 
 """
@@ -23,7 +23,7 @@ end
 
 Unwrap `m` storing the result in `y`, see [`unwrap`](@ref).
 """
-function unwrap!(y::AbstractArray{T,N}, m::AbstractArray{T,N}; dims=nothing, range::Number=2T(pi), kwargs...) where {T, N}
+function unwrap!(y::AbstractArray{T,N}, m::AbstractArray{T,N}; dims=nothing, range=2T(pi), kwargs...) where {T, N}
     if dims === nothing
         if N != 1
             throw(ArgumentError("`unwrap!`: required keyword parameter dims missing"))
@@ -40,7 +40,7 @@ function unwrap!(y::AbstractArray{T,N}, m::AbstractArray{T,N}; dims=nothing, ran
     return y
 end
 
-unwrap_kernel(range=2π) = (x, y) -> y - round((y - x) / range) * range
+unwrap_kernel(range) = (x, y) -> y - round((y - x) / range) * range
 
 """
     unwrap(m; dims=nothing, range=2pi)
@@ -64,6 +64,9 @@ of an image, as each pixel is wrapped to stay within (-pi, pi].
 
 # Arguments
 - `m::AbstractArray{T, N}`: Array to unwrap
+- `dims=nothing`: Dimensions along which to unwrap. If `dims` is an integer, then
+    `unwrap` is called that dimension. If `dims=1:ndims(m)`, then `m` is unwrapped
+    across all dimensions.
 - `range=2pi`: Range of wrapped array
 - `circular_dims=(false, ...)`:  When an element of this tuple is `true`, the
     unwrapping process will consider the edges along the corresponding axis

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -11,7 +11,7 @@ import Compat.Random: GLOBAL_RNG
 export unwrap, unwrap!
 
 """
-    unwrap!(m; dims=nothing, range=2pi)
+    unwrap!(m; kwargs...)
 
 In-place version of [`unwrap`](@ref).
 """
@@ -24,7 +24,7 @@ function unwrap!(m::AbstractArray{T,N}; dims=nothing, kwargs...) where {T, N}
 end
 
 """
-    unwrap!(y, m; dims=nothing, range=2pi)
+    unwrap!(y, m; kwargs...)
 
 Unwrap `m` storing the result in `y`, see [`unwrap`](@ref).
 """
@@ -48,7 +48,7 @@ end
 unwrap_kernel(range) = (x, y) -> y - round((y - x) / range) * range
 
 """
-    unwrap(m; dims=nothing, range=2pi)
+    unwrap(m; kwargs...)
 
 
 Assumes `m` to be a sequence of values that has been wrapped to be inside the

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -293,11 +293,11 @@ function calculate_reliability(pixel_image::AbstractArray{T, N}, circular_dims, 
             end
             border_begin          = fill(2, N)
             border_begin[idx_dim] = size_img[idx_dim]
-            border_begin          = CartesianIndex{N}(border_begin...)
+            border_begin_cart     = CartesianIndex{N}(border_begin...)
             border_end            = collect(size_img)-1
             border_end[idx_dim]   = size_img[idx_dim]
-            border_end = CartesianIndex{N}(border_end...)
-            for i in CartesianRange(border_begin, border_end)
+            border_end_cart       = CartesianIndex{N}(border_end...)
+            for i in CartesianRange(border_begin_cart, border_end_cart)
                 @inbounds pixel_image[i].reliability = calculate_pixel_reliability(pixel_image, i, pixel_shifts_border, range)
             end
             # second border
@@ -312,27 +312,27 @@ function calculate_reliability(pixel_image::AbstractArray{T, N}, circular_dims, 
             end
             border_begin          = fill(2, N)
             border_begin[idx_dim] = 1
-            border_begin          = CartesianIndex{N}(border_begin...)
+            border_begin_cart     = CartesianIndex{N}(border_begin...)
             border_end            = collect(size_img)-1
             border_end[idx_dim]   = 1
-            border_end = CartesianIndex{N}(border_end...)
-            for i in CartesianRange(border_begin, border_end)
+            border_end_cart       = CartesianIndex{N}(border_end...)
+            for i in CartesianRange(border_begin_cart, border_end_cart)
                 @inbounds pixel_image[i].reliability = calculate_pixel_reliability(pixel_image, i, pixel_shifts_border, range)
             end
         end
     end
 end
 
-function calculate_pixel_reliability(pixel_image::AbstractArray{T, N}, pixel_index, pixel_shifts, range) where {T, N}
-    sum_val = zero(fieldtype(T, :val))
+function calculate_pixel_reliability(pixel_image::AbstractArray{Pixel{T}, N}, pixel_index, pixel_shifts, range) where {T, N}
+    sum_val = zero(T)
     for pixel_shift in pixel_shifts
-        @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shift].val - pixel_image[pixel_index].val), range)^2
+        @inbounds sum_val += wrap_val(pixel_image[pixel_index+pixel_shift].val - pixel_image[pixel_index].val, range)^2
     end
     return sum_val
 end
 
 # specialized pixel reliability calculations for different N
-function calculate_pixel_reliability(pixel_image::AbstractArray{T, 2}, pixel_index, pixel_shifts, range) where T
+function calculate_pixel_reliability(pixel_image::AbstractArray{Pixel{T}, 2}, pixel_index, pixel_shifts, range) where T
     @inbounds D1 = wrap_val(pixel_image[pixel_index+pixel_shifts[2]].val - pixel_image[pixel_index].val, range)
     @inbounds D2 = wrap_val(pixel_image[pixel_index+pixel_shifts[4]].val - pixel_image[pixel_index].val, range)
     @inbounds H  = wrap_val(pixel_image[pixel_index+pixel_shifts[6]].val - pixel_image[pixel_index].val, range)
@@ -340,8 +340,8 @@ function calculate_pixel_reliability(pixel_image::AbstractArray{T, 2}, pixel_ind
     return H*H + V*V + D1*D1 + D2*D2
 end
 
-function calculate_pixel_reliability(pixel_image::AbstractArray{T, 3}, pixel_index, pixel_shifts, range) where T
-    sum_val = zero(fieldtype(T, :val))
+function calculate_pixel_reliability(pixel_image::AbstractArray{Pixel{T}, 3}, pixel_index, pixel_shifts, range) where T
+    sum_val = zero(T)
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[1]].val - pixel_image[pixel_index].val, range))^2
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[2]].val - pixel_image[pixel_index].val, range))^2
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[3]].val - pixel_image[pixel_index].val, range))^2

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -355,7 +355,9 @@ function calculate_pixel_reliability(pixel_image::AbstractArray{T, 3}, pixel_ind
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[11]].val - pixel_image[pixel_index].val, range))^2
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[12]].val - pixel_image[pixel_index].val, range))^2
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[13]].val - pixel_image[pixel_index].val, range))^2
+    # pixel_shifts[14] is null shift
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[15]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[16]].val - pixel_image[pixel_index].val, range))^2
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[17]].val - pixel_image[pixel_index].val, range))^2
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[18]].val - pixel_image[pixel_index].val, range))^2
     @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[19]].val - pixel_image[pixel_index].val, range))^2
@@ -370,6 +372,4 @@ function calculate_pixel_reliability(pixel_image::AbstractArray{T, 3}, pixel_ind
     return sum_val
 end
 
-A = rand(10)
-unwrap(A; range=10)
 end

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -1,0 +1,349 @@
+module Unwrap
+
+export unwrap, unwrap!
+
+"""
+    unwrap!(m; range=2pi, wrap_around=tuple(fill(false, N)...), seed=-1)
+
+In-place version of unwrap(m; range, wrap_around, seed)
+"""
+unwrap!
+
+"""
+    unwrap(m::AbstractArray{T, N}; range=2pi, wrap_around=tuple(fill(false, N)...), seed=-1)
+
+Assumes `m` to be an array of values of arbitrary dimension that
+have been wrapped to be inside the given range (centered around
+zero), and undoes the wrapping by identifying discontinuities. To operate on a
+subset of dimensions of an array, simply pass in the corresponding `view`.
+
+A common usage is for a phase measurement over time, such as when
+comparing successive frames of a short-time-fourier-transform, as
+each frame is wrapped to stay within (-pi, pi].
+
+# Arguments
+- `A::AbstractArray{T, N}`: Array to unwrap
+- `range::Number`: Range of wrapped array
+- `wrap_around::NTuple{N, Bool}`:  When an element of this tuple is `true`, the
+    unwrapping process will consider the edges along the corresponding axis
+    of the image to be connected
+- `seed::Int`: Unwrapping of arrays with dimension > 1 uses a random initialization. This
+    sets the seed of the RNG.
+"""
+unwrap
+
+function unwrap(m::AbstractArray{T, N}, args...; kwargs...) where {T<:AbstractFloat, N}
+    unwrap!(copy(m), args...; kwargs...)
+end
+
+function unwrap!(A::AbstractVector{T};
+                 range::Number=2*convert(T, pi),
+                 wrap_around::NTuple{1, Bool}=(false,),
+                 seed::Int=-1) where T
+    @inbounds previous_element = A[1]
+    difference = zero(previous_element)
+    periods = 0
+    @inbounds for i in 2:length(A)
+        difference = A[i] - previous_element
+        periods += ifelse(difference >  range/2, -1, 0)
+        periods += ifelse(difference < -range/2,  1, 0)
+        previous_element = A[i]
+        A[i] = previous_element + one(previous_element) * periods * range
+    end
+    return A
+end
+
+#= Algorithm based off of
+ M. A. Herráez, D. R. Burton, M. J. Lalor, and M. A. Gdeisat,
+ "Fast two-dimensional phase-unwrapping algorithm based on sorting by reliability following a noncontinuous path"
+ `Applied Optics, Vol. 41, Issue 35, pp. 7437-7444 (2002) <http://dx.doi.org/10.1364/AO.41.007437>`
+ and
+ H. Abdul-Rahman, M. Gdeisat, D. Burton, M. Lalor,
+ "Fast three-dimensional phase-unwrapping algorithm based on sorting by reliability following a non-continuous path",
+ `Proc. SPIE 5856, Optical Measurement Systems for Industrial Inspection IV, 32 (2005) <http://dx.doi.ogr/doi:10.1117/12.611415>`
+ Code inspired by Scipy's implementation, which is under BSD license.
+=#
+
+mutable struct Pixel{T}
+    periods::Int
+    val::T
+    reliability::Float64
+    groupsize::Int
+    head::Pixel{T}
+    last::Pixel{T}
+    next::Union{Void, Pixel{T}}
+    function Pixel{T}(periods, val, rel, gs) where T
+        pixel = new(periods, val, rel, gs)
+        pixel.head = pixel
+        pixel.last = pixel
+        pixel.next = nothing
+        return pixel
+    end
+end
+Pixel(v) = Pixel{typeof(v)}(0, v, rand(), 1)
+@inline Base.length(p::Pixel) = p.head.groupsize
+
+struct Edge{N}
+    reliability::Float64
+    periods::Int
+    pixel_1::CartesianIndex{N}
+    pixel_2::CartesianIndex{N}
+end
+function Edge{N}(pixel_image::AbstractArray, ind1::CartesianIndex{N}, ind2::CartesianIndex{N}, range) where N
+    @inbounds rel = pixel_image[ind1].reliability + pixel_image[ind2].reliability
+    @inbounds periods = find_period(pixel_image[ind1].val, pixel_image[ind2].val, range)
+    return Edge{N}(rel, periods, ind1, ind2)
+end
+@inline Base.isless(e1::Edge, e2::Edge) = isless(e1.reliability, e2.reliability)
+
+function unwrap!(wrapped_image::AbstractArray{T, N};
+                 range::Number=2*convert(T, pi),
+                 wrap_around::NTuple{N, Bool}=tuple(fill(false, N)...),
+                 seed::Int=-1) where {T, N}
+
+    if seed != -1
+        srand(seed)
+    end
+
+    range_T = convert(T, range)
+
+    pixel_image = init_pixels(wrapped_image)
+    calculate_reliability(pixel_image, wrap_around, range_T)
+    edges = Edge{N}[]
+    num_edges = _predict_num_edges(size(wrapped_image), wrap_around)
+    sizehint!(edges, num_edges)
+    for idx_dim=1:N
+        populate_edges!(edges, pixel_image, idx_dim, wrap_around[idx_dim], range_T)
+    end
+
+    sort!(edges, alg=MergeSort)
+    gather_pixels!(pixel_image, edges)
+    unwrap_image!(wrapped_image, pixel_image, range_T)
+
+    return wrapped_image
+end
+
+function _predict_num_edges(size_img, wrap_around)
+    num_edges = 0
+    for (size_dim, wrap_dim) in zip(size_img, wrap_around)
+        num_edges += prod(size_img) * (size_dim-1) ÷ size_dim + wrap_dim * prod(size_img) ÷ size_dim
+    end
+    return num_edges
+end
+
+# function to broadcast
+function init_pixels(wrapped_image::AbstractArray{T, N}) where {T, N}
+    pixel_image = similar(wrapped_image, Pixel{T})
+    @Threads.threads for i in eachindex(wrapped_image)
+        @inbounds pixel_image[i] = Pixel(wrapped_image[i])
+    end
+    return pixel_image
+end
+
+function gather_pixels!(pixel_image, edges)
+    for edge in edges
+        @inbounds p1 = pixel_image[edge.pixel_1]
+        @inbounds p2 = pixel_image[edge.pixel_2]
+        merge_groups!(edge, p1, p2)
+    end
+end
+
+function unwrap_image!(image, pixel_image, range)
+    @Threads.threads for i in eachindex(image)
+        @inbounds image[i] = range * pixel_image[i].periods + pixel_image[i].val
+    end
+end
+
+function wrap_val(val, range)
+    wrapped_val  = val
+    wrapped_val += ifelse(val >  range/2, -range, zero(val))
+    wrapped_val += ifelse(val < -range/2,  range, zero(val))
+    return wrapped_val
+end
+
+function find_period(val_left, val_right, range)
+    difference = val_left - val_right
+    period  = 0
+    period += ifelse(difference >  range/2, -1, 0)
+    period += ifelse(difference < -range/2,  1, 0)
+    return period
+end
+
+function merge_groups!(edge, pixel_1, pixel_2)
+    if is_differentgroup(pixel_1, pixel_2)
+        # pixel 2 is alone in group
+        if is_pixelalone(pixel_2)
+            merge_pixels!(pixel_1, pixel_2, -edge.periods)
+        elseif is_pixelalone(pixel_1)
+            merge_pixels!(pixel_2, pixel_1, edge.periods)
+        else
+            if is_bigger(pixel_1, pixel_2)
+                merge_into_group!(pixel_1, pixel_2, -edge.periods)
+            else
+                merge_into_group!(pixel_2, pixel_1, edge.periods)
+            end
+        end
+    end
+end
+
+@inline function is_differentgroup(p1::Pixel, p2::Pixel)
+    return p1.head !== p2.head
+end
+@inline function is_pixelalone(pixel::Pixel)
+    return pixel.head === pixel.last
+end
+@inline function is_bigger(p1::Pixel, p2::Pixel)
+    return length(p1) ≥ length(p2)
+end
+
+function merge_pixels!(pixel_base::Pixel, pixel_target::Pixel, periods)
+    pixel_base.head.groupsize += pixel_target.head.groupsize
+    pixel_base.head.last.next = pixel_target.head
+    pixel_base.head.last = pixel_target.head.last
+    pixel_target.head = pixel_base.head
+    pixel_target.periods = pixel_base.periods + periods
+end
+
+function merge_into_group!(pixel_base::Pixel, pixel_target::Pixel, periods)
+    add_periods = pixel_base.periods + periods - pixel_target.periods
+    pixel = pixel_target.head
+    while pixel ≠ nothing
+        # merge all pixels in pixel_target's group to pixel_base's group
+        if pixel !== pixel_target
+            pixel.periods += add_periods
+            pixel.head = pixel_base.head
+        end
+        pixel = pixel.next
+    end
+    # assign pixel_target to pixel_base's group last
+    merge_pixels!(pixel_base, pixel_target, periods)
+end
+
+function populate_edges!(edges, pixel_image::Array{T, N}, dim, connected, range) where {T, N}
+    size_img       = collect(size(pixel_image))
+    size_img[dim] -= 1
+    idx_step       = fill(0, N)
+    idx_step[dim] += 1
+    idx_step_cart  = CartesianIndex{N}(idx_step...)
+    idx_size       = CartesianIndex{N}(size_img...)
+    for i in CartesianRange(idx_size)
+        push!(edges, Edge{N}(pixel_image, i, i+idx_step_cart, range))
+    end
+    if connected
+        idx_step        = fill(0, N)
+        idx_step[dim]   = -size_img[dim]
+        idx_step_cart   = CartesianIndex{N}(idx_step...)
+        edge_begin      = fill(1, N)
+        edge_begin[dim] = size(pixel_image)[dim]
+        edge_begin_cart = CartesianIndex{N}(edge_begin...)
+        for i in CartesianRange(edge_begin_cart, CartesianIndex(size(pixel_image)))
+            push!(edges, Edge{N}(pixel_image, i, i+idx_step_cart, range))
+        end
+    end
+end
+
+function calculate_reliability(pixel_image::AbstractArray{T, N}, wrap_around, range) where {T, N}
+    # get the shifted pixel indices in CartesinanIndex form
+    # This gets all the nearest neighbors (CartesionIndex{N}() = one(CartesianIndex{N}))
+    pixel_shifts = collect(CartesianRange(-CartesianIndex{N}(),
+                                           CartesianIndex{N}()))
+    size_img = size(pixel_image)
+    # inner loop
+    for i in CartesianRange((CartesianIndex{N}()+1), (CartesianIndex{N}(size_img)-1))
+        @inbounds pixel_image[i].reliability = calculate_pixel_reliability(pixel_image, i, pixel_shifts, range)
+    end
+
+    for (idx_dim, connected) in enumerate(wrap_around)
+        if connected
+            # first border
+            pixel_shifts_border = copy(pixel_shifts)
+            for (idx_ps, ps) in enumerate(pixel_shifts_border)
+                # if the pixel shift goes out of bounds, we make the shift wrap
+                if ps[idx_dim] == 1
+                    new_ps          = fill(0, N)
+                    new_ps[idx_dim] = -size_img[idx_dim]+1
+                    pixel_shifts_border[idx_ps] = CartesianIndex{N}(new_ps...)
+                end
+            end
+            border_begin          = fill(2, N)
+            border_begin[idx_dim] = size_img[idx_dim]
+            border_begin          = CartesianIndex{N}(border_begin...)
+            border_end            = collect(size_img)-1
+            border_end[idx_dim]   = size_img[idx_dim]
+            border_end = CartesianIndex{N}(border_end...)
+            for i in CartesianRange(border_begin, border_end)
+                @inbounds pixel_image[i].reliability = calculate_pixel_reliability(pixel_image, i, pixel_shifts_border, range)
+            end
+            # second border
+            pixel_shifts_border = copy!(pixel_shifts_border, pixel_shifts)
+            for (idx_ps, ps) in enumerate(pixel_shifts_border)
+                # if the pixel shift goes out of bounds, we make the shift wrap, this time to the other side
+                if ps[idx_dim] == -1
+                    new_ps          = fill(0, N)
+                    new_ps[idx_dim] = size_img[idx_dim]-1
+                    pixel_shifts_border[idx_ps] = CartesianIndex{N}(new_ps...)
+                end
+            end
+            border_begin          = fill(2, N)
+            border_begin[idx_dim] = 1
+            border_begin          = CartesianIndex{N}(border_begin...)
+            border_end            = collect(size_img)-1
+            border_end[idx_dim]   = 1
+            border_end = CartesianIndex{N}(border_end...)
+            for i in CartesianRange(border_begin, border_end)
+                @inbounds pixel_image[i].reliability = calculate_pixel_reliability(pixel_image, i, pixel_shifts_border, range)
+            end
+        end
+    end
+end
+
+function calculate_pixel_reliability(pixel_image::AbstractArray{T, N}, pixel_index, pixel_shifts, range) where {T, N}
+    sum_val = zero(fieldtype(T, :val))
+    for pixel_shift in pixel_shifts
+        @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shift].val - pixel_image[pixel_index].val), range)^2
+    end
+    return sum_val
+end
+
+# specialized pixel reliability calculations for different N
+function calculate_pixel_reliability(pixel_image::AbstractArray{T, 2}, pixel_index, pixel_shifts, range) where T
+    @inbounds D1 = wrap_val(pixel_image[pixel_index+pixel_shifts[2]].val - pixel_image[pixel_index].val, range)
+    @inbounds D2 = wrap_val(pixel_image[pixel_index+pixel_shifts[4]].val - pixel_image[pixel_index].val, range)
+    @inbounds H  = wrap_val(pixel_image[pixel_index+pixel_shifts[6]].val - pixel_image[pixel_index].val, range)
+    @inbounds V  = wrap_val(pixel_image[pixel_index+pixel_shifts[8]].val - pixel_image[pixel_index].val, range)
+    return H*H + V*V + D1*D1 + D2*D2
+end
+
+function calculate_pixel_reliability(pixel_image::AbstractArray{T, 3}, pixel_index, pixel_shifts, range) where T
+    sum_val = zero(fieldtype(T, :val))
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[1]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[2]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[3]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[4]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[5]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[6]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[7]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[8]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[9]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[10]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[11]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[12]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[13]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[15]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[17]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[18]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[19]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[20]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[21]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[22]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[23]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[24]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[25]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[26]].val - pixel_image[pixel_index].val, range))^2
+    @inbounds sum_val += (wrap_val(pixel_image[pixel_index+pixel_shifts[27]].val - pixel_image[pixel_index].val, range))^2
+    return sum_val
+end
+
+A = rand(10)
+unwrap(A; range=10)
+end

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -42,7 +42,9 @@ end
 function unwrap!(m::Array{T}, dim::Integer; range::Number=2pi) where T<:AbstractFloat
     Base.depwarn(string("`unwrap!(m::Array{T}, dim::Integer; range::Number=2pi) ",
         " where T<:AbstractFloat` is deprecated, ",
-        "use `unwrap!(m; range)` instead if your data has more than one dimension."),
+        "use `unwrap!(m; range)` instead if your data has more than one dimension. ",
+        "If your data is one-dimensional but embedded in a larger-dimensional array, ",
+        "pass instead a view of each individual vector you would like to unwrap."),
          :unwrap!)
     thresh = range / 2
     if size(m, dim) < 2

--- a/src/util.jl
+++ b/src/util.jl
@@ -5,9 +5,7 @@ using Compat: copyto!, ComplexF64, selectdim, undef
 import Compat.LinearAlgebra.BLAS
 @importffts
 
-export  unwrap!,
-        unwrap,
-        hilbert,
+export  hilbert,
         Frequencies,
         fftintype,
         fftouttype,
@@ -28,46 +26,6 @@ export  unwrap!,
         polyfit,
         shiftin!
 
-"""
-    unwrap!(m, dim=ndims(m); range=2pi)
-
-In-place version of unwrap(m, dim, range)
-"""
-function unwrap!(m::Array{T}, dim::Integer=ndims(m); range::Number=2pi) where T<:AbstractFloat
-    thresh = range / 2
-    if size(m, dim) < 2
-        return m
-    end
-    for i = 2:size(m, dim)
-        d = selectdim(m, dim, i:i) - selectdim(m, dim, i-1:i-1)
-        slice_tuple = ntuple(n->(n==dim ? (i:i) : (1:size(m,n))), ndims(m))
-        offset = floor.((d.+thresh) / (range)) * range
-#        println("offset: ", offset)
-#        println("typeof(offset): ", typeof(offset))
-#        println("typeof(m[slice_tuple...]): ", typeof(m[slice_tuple...]))
-#        println("slice_tuple: ", slice_tuple)
-#        println("m[slice_tuple...]: ", m[slice_tuple...])
-        m[slice_tuple...] = m[slice_tuple...] - offset
-    end
-    return m
-end
-
-"""
-    unwrap(m, dim=ndims(m); range=2pi)
-
-Assumes m (along dimension dim) to be a sequences of values that
-have been wrapped to be inside the given range (centered around
-zero), and undoes the wrapping by identifying discontinuities. If
-dim is not given, the last dimension is used.
-
-A common usage is for a phase measurement over time, such as when
-comparing successive frames of a short-time-fourier-transform, as
-each frame is wrapped to stay within (-pi, pi].
-
-"""
-function unwrap(m::Array{T}, args...; kwargs...) where T<:AbstractFloat
-    unwrap!(copy(m), args...; kwargs...)
-end
 
 function hilbert(x::StridedVector{T}) where T<:FFTW.fftwReal
 # Return the Hilbert transform of x (a real signal).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Compat, DSP, AbstractFFTs, FFTW, Compat.Test
 
 testfiles = [ "dsp.jl", "util.jl", "windows.jl", "filter_conversion.jl",
     "filter_design.jl", "filter_response.jl", "filt.jl", "filt_stream.jl",
-    "periodograms.jl", "resample.jl", "lpc.jl"]
+    "periodograms.jl", "resample.jl", "lpc.jl", "unwrap.jl"]
 
 for testfile in testfiles
     eval(@__MODULE__, :(@testset $testfile begin include($testfile) end))

--- a/test/unwrap.jl
+++ b/test/unwrap.jl
@@ -79,21 +79,21 @@ end
         d = first(A_unwrapped_range) - first(test_unwrapped_range)
         @test (test_unwrapped_range + d) ≈ A_unwrapped_range
 
-        # Test wrap_around
+        # Test circular_dims
         # after unwrapping, pixels at borders should be equal to corresponding pixels
         # on other side
-        wrap_around = (true, true)
+        circular_dims = (true, true)
         wa_vec = linspace(0, 4convert(T, π), 10)
         wa_uw = wa_vec .+ zeros(10)'
         # make periodic
         wa_uw[end, :] = wa_uw[1, :]
         wa_w = wa_uw .% (2π)
-        wa_test = unwrap(wa_w, dims=1:2, wrap_around=wrap_around, seed=0)
+        wa_test = unwrap(wa_w, dims=1:2, circular_dims=circular_dims, rng=MersenneTwister(0))
         # with wrap-around, the borders should be equal, but for this problem the
         # image may not be recovered exactly
         @test wa_test[:, 1] ≈ wa_test[:, end]
         @test wa_test[end, :] ≈ wa_test[1, :]
-        # In this case, calling unwrap w/o wrap_around does not recover the borders
+        # In this case, calling unwrap w/o circular_dims does not recover the borders
         wa_test_nowa = unwrap(wa_w, dims=1:2)
         @test !(wa_test_nowa[end, :] ≈ wa_test_nowa[1, :])
 
@@ -123,17 +123,17 @@ end
         offset = first(f_uw) - first(uw_test)
         @test (uw_test+offset) ≈ f_uw #oop, 2wrap
         # test in-place version
-        unwrap!(f_wr, dims=1:3, wrap_around=(true, true, false))
+        unwrap!(f_wr, dims=1:3, circular_dims=(true, true, false))
         offset = first(f_uw) - first(f_wr)
         @test (f_wr+offset) ≈ f_uw #ip, 2wrap
 
         f_uw = f_wraparound3.(grid, grid', reshape(grid, 1, 1, :))
         f_wr = f_uw .% (2convert(T, π))
-        uw_test = unwrap(f_wr, dims=1:3, wrap_around=(true, true, true))
+        uw_test = unwrap(f_wr, dims=1:3, circular_dims=(true, true, true))
         offset = first(f_uw) - first(uw_test)
         @test (uw_test+offset) ≈ f_uw #oop, 3wrap
         # test in-place version
-        unwrap!(f_wr, dims=1:3, wrap_around=(true, true, true))
+        unwrap!(f_wr, dims=1:3, circular_dims=(true, true, true))
         offset = first(f_uw) - first(f_wr)
         @test (f_wr+offset) ≈ f_uw #oop, 3wrap
     end

--- a/test/unwrap.jl
+++ b/test/unwrap.jl
@@ -40,14 +40,14 @@ using DSP, Compat, Compat.Test
     types = (Float32, Float64, BigFloat)
     for T in types
         srand(1234)
-        A_unwrapped = collect(linspace(0, 4convert(T, π), 10))
+        A_unwrapped = collect(Compat.range(0, stop=4convert(T, π), length=10))
         A_wrapped = A_unwrapped .% (2convert(T, π))
 
         @test unwrap(A_wrapped) ≈ A_unwrapped
         unwrap!(A_wrapped)
         @test A_wrapped ≈ A_unwrapped
 
-        A_unwrapped_range = collect(linspace(0, 4, 10))
+        A_unwrapped_range = collect(Compat.range(0, stop=4, length=10))
         test_range = convert(T, 2)
         A_wrapped_range = A_unwrapped_range .% test_range
         @test unwrap(A_wrapped_range; range=test_range) ≈ A_unwrapped_range
@@ -59,31 +59,31 @@ end
     types = (Float32, Float64, BigFloat)
     for T in types
         srand(1234)
-        v_unwrapped = collect(linspace(0, 4convert(T, π), 7))
+        v_unwrapped = collect(Compat.range(0, stop=4convert(T, π), length=7))
         A_unwrapped = v_unwrapped .+ v_unwrapped'
         A_wrapped = A_unwrapped .% (2convert(T, π))
 
         test_unwrapped = unwrap(A_wrapped, dims=1:2)
         d = first(A_unwrapped) - first(test_unwrapped)
-        @test (test_unwrapped + d) ≈ A_unwrapped
+        @test (test_unwrapped .+ d) ≈ A_unwrapped
         unwrap!(A_wrapped, dims=1:2)
         d = first(A_unwrapped) - first(A_wrapped)
-        @test (A_wrapped + d) ≈ A_unwrapped
+        @test (A_wrapped .+ d) ≈ A_unwrapped
 
-        v_unwrapped_range = collect(linspace(0, 4, 7))
+        v_unwrapped_range = collect(Compat.range(0, stop=4, length=7))
         A_unwrapped_range = v_unwrapped_range .+ v_unwrapped_range'
         test_range = convert(T, 2)
         A_wrapped_range = A_unwrapped_range .% test_range
 
         test_unwrapped_range = unwrap(A_wrapped_range, dims=1:2; range=test_range)
         d = first(A_unwrapped_range) - first(test_unwrapped_range)
-        @test (test_unwrapped_range + d) ≈ A_unwrapped_range
+        @test (test_unwrapped_range .+ d) ≈ A_unwrapped_range
 
         # Test circular_dims
         # after unwrapping, pixels at borders should be equal to corresponding pixels
         # on other side
         circular_dims = (true, true)
-        wa_vec = linspace(0, 4convert(T, π), 10)
+        wa_vec = Compat.range(0, stop=4convert(T, π), length=10)
         wa_uw = wa_vec .+ zeros(10)'
         # make periodic
         wa_uw[end, :] = wa_uw[1, :]
@@ -106,35 +106,35 @@ end
     f_wraparound2(x, y, z) = 5*sin(x) + 2*cos(y) + z
     f_wraparound3(x, y, z) = 5*sin(x) + 2*cos(y) - 4*cos(z)
     for T in types
-        grid = linspace(zero(T), 2convert(T, π), 11)
+        grid = Compat.range(zero(T), stop=2convert(T, π), length=11)
         f_uw = f.(grid, grid', reshape(grid, 1, 1, :))
         f_wr = f_uw .% (2convert(T, π))
         uw_test = unwrap(f_wr, dims=1:3)
         offset = first(f_uw) - first(uw_test)
-        @test (uw_test+offset) ≈ f_uw rtol=eps(T) #oop, nowrap
+        @test (uw_test.+offset) ≈ f_uw rtol=eps(T) #oop, nowrap
         # test in-place version
         unwrap!(f_wr, dims=1:3)
         offset = first(f_uw) - first(f_wr)
-        @test (f_wr+offset) ≈ f_uw rtol=eps(T) #ip, nowrap
+        @test (f_wr.+offset) ≈ f_uw rtol=eps(T) #ip, nowrap
 
         f_uw = f_wraparound2.(grid, grid', reshape(grid, 1, 1, :))
         f_wr = f_uw .% (2convert(T, π))
         uw_test = unwrap(f_wr, dims=1:3)
         offset = first(f_uw) - first(uw_test)
-        @test (uw_test+offset) ≈ f_uw #oop, 2wrap
+        @test (uw_test.+offset) ≈ f_uw #oop, 2wrap
         # test in-place version
         unwrap!(f_wr, dims=1:3, circular_dims=(true, true, false))
         offset = first(f_uw) - first(f_wr)
-        @test (f_wr+offset) ≈ f_uw #ip, 2wrap
+        @test (f_wr.+offset) ≈ f_uw #ip, 2wrap
 
         f_uw = f_wraparound3.(grid, grid', reshape(grid, 1, 1, :))
         f_wr = f_uw .% (2convert(T, π))
         uw_test = unwrap(f_wr, dims=1:3, circular_dims=(true, true, true))
         offset = first(f_uw) - first(uw_test)
-        @test (uw_test+offset) ≈ f_uw #oop, 3wrap
+        @test (uw_test.+offset) ≈ f_uw #oop, 3wrap
         # test in-place version
         unwrap!(f_wr, dims=1:3, circular_dims=(true, true, true))
         offset = first(f_uw) - first(f_wr)
-        @test (f_wr+offset) ≈ f_uw #oop, 3wrap
+        @test (f_wr.+offset) ≈ f_uw #oop, 3wrap
     end
 end

--- a/test/unwrap.jl
+++ b/test/unwrap.jl
@@ -1,0 +1,120 @@
+using DSP, Compat, Compat.Test
+
+@testset "Unwrap 1D" begin
+    @test unwrap([0.1, 0.2, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
+    @test unwrap([0.1, 0.2 + 2pi, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
+    @test unwrap([0.1, 0.2 - 2pi, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
+    @test unwrap([0.1, 0.2 - 2pi, 0.3 - 2pi, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
+    @test unwrap([0.1 + 2pi, 0.2, 0.3, 0.4]) ≈ [0.1 + 2pi, 0.2 + 2pi, 0.3 + 2pi, 0.4 + 2pi]
+
+    test_v = [0.1, 0.2, 0.3 + 2pi, 0.4]
+    res_v = unwrap(test_v)
+    @test test_v ≈ [0.1, 0.2, 0.3 + 2pi, 0.4]
+    unwrap!(test_v)
+    @test test_v ≈ [0.1, 0.2, 0.3, 0.4]
+
+    # test unwrapping with other ranges
+    unwrapped = [1.0:100;]
+    wrapped = Float64[i % 10 for i in unwrapped]
+    @test unwrap(wrapped, range=10) ≈ unwrapped
+
+    types = (Float32, Float64, BigFloat)
+    for T in types
+        srand(1234)
+        A_unwrapped = collect(linspace(0, 4convert(T, π), 10))
+        A_wrapped = A_unwrapped .% (2convert(T, π))
+
+        @test unwrap(A_wrapped) ≈ A_unwrapped
+        unwrap!(A_wrapped)
+        @test A_wrapped ≈ A_unwrapped
+
+        A_unwrapped_range = collect(linspace(0, 4, 10))
+        test_range = convert(T, 2)
+        A_wrapped_range = A_unwrapped_range .% test_range
+        @test unwrap(A_wrapped_range; range=test_range) ≈ A_unwrapped_range
+    end
+end
+
+@testset "Unwrap 2D" begin
+    types = (Float32, Float64, BigFloat)
+    for T in types
+        srand(1234)
+        v_unwrapped = collect(linspace(0, 4convert(T, π), 7))
+        A_unwrapped = v_unwrapped .+ v_unwrapped'
+        A_wrapped = A_unwrapped .% (2convert(T, π))
+
+        test_unwrapped = unwrap(A_wrapped)
+        d = first(A_unwrapped) - first(test_unwrapped)
+        @test (test_unwrapped + d) ≈ A_unwrapped
+        unwrap!(A_wrapped)
+        d = first(A_unwrapped) - first(A_wrapped)
+        @test (A_wrapped + d) ≈ A_unwrapped
+
+        v_unwrapped_range = collect(linspace(0, 4, 7))
+        A_unwrapped_range = v_unwrapped_range .+ v_unwrapped_range'
+        test_range = convert(T, 2)
+        A_wrapped_range = A_unwrapped_range .% test_range
+
+        test_unwrapped_range = unwrap(A_wrapped_range; range=test_range)
+        d = first(A_unwrapped_range) - first(test_unwrapped_range)
+        @test (test_unwrapped_range + d) ≈ A_unwrapped_range
+
+        # Test wrap_around
+        # after unwrapping, pixels at borders should be equal to corresponding pixels
+        # on other side
+        wrap_around = (true, true)
+        wa_vec = linspace(0, 4convert(T, π), 10)
+        wa_uw = wa_vec .+ zeros(10)'
+        # make periodic
+        wa_uw[end, :] = wa_uw[1, :]
+        wa_w = wa_uw .% (2π)
+        wa_test = unwrap(wa_w, wrap_around=wrap_around, seed=0)
+        # with wrap-around, the borders should be equal, but for this problem the
+        # image may not be recovered exactly
+        @test wa_test[:, 1] ≈ wa_test[:, end]
+        @test wa_test[end, :] ≈ wa_test[1, :]
+        # In this case, calling unwrap w/o wrap_around does not recover the borders
+        wa_test_nowa = unwrap(wa_w)
+        @test !(wa_test_nowa[end, :] ≈ wa_test_nowa[1, :])
+
+    end
+end
+
+@testset "Unwrap 3D" begin
+    types = (Float32, Float64, BigFloat)
+    f(x, y, z) = 0.1x^2 - 2y + 2z
+    f_wraparound2(x, y, z) = 5*sin(x) + 2*cos(y) + z
+    f_wraparound3(x, y, z) = 5*sin(x) + 2*cos(y) - 4*cos(z)
+    for T in types
+        grid = linspace(zero(T), convert(T, 2π), 11)
+        f_uw = f.(grid, grid', reshape(grid, 1, 1, :))
+        f_wr = f_uw .% (2π)
+        uw_test = unwrap(f_wr)
+        offset = first(f_uw) - first(uw_test)
+        @test isapprox(uw_test + offset, f_uw, atol=1e-8)
+        # test in-place version
+        unwrap!(f_wr)
+        offset = first(f_uw) - first(f_wr)
+        @test isapprox(f_wr + offset, f_uw, atol=1e-8)
+
+        f_uw = f_wraparound2.(grid, grid', reshape(grid, 1, 1, :))
+        f_wr = f_uw .% (2π)
+        uw_test = unwrap(f_wr, wrap_around=(true, true, false))
+        offset = first(f_uw) - first(uw_test)
+        @test isapprox(uw_test + offset, f_uw, atol=1e-8)
+        # test in-place version
+        unwrap!(f_wr, wrap_around=(true, true, false))
+        offset = first(f_uw) - first(f_wr)
+        @test isapprox(f_wr + offset, f_uw, atol=1e-8)
+
+        f_uw = f_wraparound3.(grid, grid', reshape(grid, 1, 1, :))
+        f_wr = f_uw .% (2π)
+        uw_test = unwrap(f_wr, wrap_around=(true, true, true))
+        offset = first(f_uw) - first(uw_test)
+        @test isapprox(uw_test + offset, f_uw, atol=1e-8)
+        # test in-place version
+        unwrap!(f_wr, wrap_around=(true, true, true))
+        offset = first(f_uw) - first(f_wr)
+        @test isapprox(f_wr + offset, f_uw, atol=1e-8)
+    end
+end

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,33 +1,5 @@
 using DSP, Compat, Compat.Test
 
-@testset "unwrap" begin
-    @test unwrap([0.1, 0.2, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
-    @test unwrap([0.1, 0.2 + 2pi, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
-    @test unwrap([0.1, 0.2 - 2pi, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
-    @test unwrap([0.1, 0.2 - 2pi, 0.3 - 2pi, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
-    @test unwrap([0.1 + 2pi, 0.2, 0.3, 0.4]) ≈ [0.1 + 2pi, 0.2 + 2pi, 0.3 + 2pi, 0.4 + 2pi]
-    @test unwrap([0.1, 0.2 + 6pi, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]
-
-    test_v = [0.1, 0.2, 0.3 + 2pi, 0.4]
-    res_v = unwrap(test_v)
-    @test test_v ≈ [0.1, 0.2, 0.3 + 2pi, 0.4]
-    unwrap!(test_v)
-    @test test_v ≈ [0.1, 0.2, 0.3, 0.4]
-
-    # test multi-dimensional unwrapping
-    wrapped = [0.1, 0.2 + 2pi, 0.3, 0.4]
-    unwrapped = [0.1, 0.2, 0.3, 0.4]
-    wrapped = hcat(wrapped, wrapped)
-    unwrapped = hcat(unwrapped, unwrapped)
-    @test unwrap(wrapped) ≈ wrapped
-    @test unwrap(wrapped, 1) ≈ unwrapped
-
-    # test unwrapping with other ranges
-    unwrapped = [1.0:100;]
-    wrapped = Float64[i % 10 for i in unwrapped]
-    @test unwrap(wrapped, range=10) ≈ unwrapped
-end
-
 @testset "hilbert" begin
     # Testing hilbert transform
     t = (0:1/256:2-1/256)


### PR DESCRIPTION
Ref #196 

I've added the n-dimensional `unwrap` from `Unwrap.jl` [here](https://github.com/platawiec/Unwrap.jl). The doc-string for `unwrap` goes over how to use it. The new functionality allows the user to take arbitrary arrays that are "wrapped" (or modulo some arbitrary number) and recover the original array. This is primarily useful when looking at the recovered phases for 2D/3D scenes. Also included is the ability to specify which dimensions are periodic.

There are two other changes to the old `unwrap`:
* There is no longer a `dim` keyword, a user who wants to recover that functionality will have to pass the appropriate `view`s.
* The old `unwrap` would perform the modulo function on the input array. In other words, an array like `[0.0, 6pi, 0.0]` evaluated to `[0.0, 0.0, 0.0]`. If the user is worried that the array they are passing into `unwrap` has values which lie outside the range, then they should do `.%` before calling `unwrap`. Typically, the array passed in is already module some number, because that is why `unwrap` is being called in the first place.

I have not tested against v0.7. Let me know if there are any other tweaks to do.