### PR TITLE
Create mutating versions of fftfilt and filt

### DIFF
--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -46,6 +46,9 @@ filt
 filt!
 filtfilt
 fftfilt
+fftfilt!
+tdfilt
+tdfilt!
 resample
 ```
 ## Filter design

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -24,6 +24,8 @@ export FilterCoefficients,
 include("filt.jl")
 export  DF2TFilter,
         filtfilt,
+        tdfilt,
+        tdfilt!,
         fftfilt,
         fftfilt!
 

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -24,7 +24,8 @@ export FilterCoefficients,
 include("filt.jl")
 export  DF2TFilter,
         filtfilt,
-        fftfilt
+        fftfilt,
+        fftfilt!
 
 include("design.jl")
 export  FilterType,

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -426,7 +426,7 @@ let chain = :(throw(ArgumentError("invalid tuple size")))
     end
 end
 
-function filt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
+function tsfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
     if length(h) == 1
         return mul!(out, h[1], x)
     elseif length(h) <= 15
@@ -573,19 +573,17 @@ end
 # convolution in the time domain using filt or in the frequency domain
 # using fftfilt
 function filt(b::AbstractVector{T}, x::AbstractArray{T}) where T<:Number
-    _filt_choose_alg!(Array{T}(undef, size(x)), b, x)
+    filt_choose_alg!(Array{T}(undef, size(x)), b, x)
 end
 
 # Like filt but mutates output array
-function filt_choose_alg!(
-    out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray{T}) where T<:Number
+function filt!(out::AbstractArray, b::AbstractVector, x::AbstractArray)
     size(out) == size(x) || throw(ArgumentError("out must be the same size as x"))
-    _filt_choose_alg!(out, b, x)
+    filt_choose_alg!(out, b, x)
 end
 
 # like filt_choose_alg! but does not check if out and x are the same size
-function _filt_choose_alg!(
-    out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray{T}) where T<:Number
+function filt_choose_alg!(out::AbstractArray, b::AbstractVector, x::AbstractArray)
     nb = length(b)
     nx = size(x, 1)
 
@@ -594,7 +592,7 @@ function _filt_choose_alg!(
         # 65536 is apprximate cutoff where FFT-based algorithm may be
         # more effective (due to overhead for allocation, plan
         # creation, etc.)
-        filt!(out, b, x)
+        tsfilt!(out, b, x)
     else
         # Estimate number of multiplication operations for fftfilt()
         # and filt()
@@ -603,6 +601,6 @@ function _filt_choose_alg!(
         nchunk = ceil(Int, nx/L)*div(length(x), nx)
         fftops = (2*nchunk + 1) * nfft * log2(nfft)/2 + nchunk * nfft + 500000
 
-        filtops > fftops ? _fftfilt!(out, b, x, nfft) : filt!(out, b, x)
+        filtops > fftops ? _fftfilt!(out, b, x, nfft) : tsfilt!(out, b, x)
     end
 end

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -531,7 +531,6 @@ function _fftfilt!(out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray
     L = min(nx, nfft - (nb - 1))
     tmp1 = Vector{T}(undef, nfft)
     tmp2 = Vector{Complex{T}}(undef, nfft >> 1 + 1)
-    out = Array{T}(undef, size(x))
 
     p1 = plan_rfft(tmp1)
     p2 = plan_brfft(tmp2, nfft)
@@ -539,7 +538,7 @@ function _fftfilt!(out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray
     # FFT of filter
     filterft = similar(tmp2)
     copyto!(tmp1, b)
-    tmp1[nb+1:end] .= zero(T)
+    tmp1[nb+1:end] = zero(T)
     mul!(filterft, p1, tmp1)
 
     # FFT of chunks
@@ -550,8 +549,8 @@ function _fftfilt!(out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray
             xstart = off - nb + npadbefore + 1
             n = min(nfft - npadbefore, nx - xstart + 1)
 
-            tmp1[1:npadbefore] .= zero(T)
-            tmp1[npadbefore+n+1:end] .= zero(T)
+            tmp1[1:npadbefore] = zero(T)
+            tmp1[npadbefore+n+1:end] = zero(T)
 
             copyto!(tmp1, npadbefore+1, x, colstart+xstart, n)
             mul!(tmp2, p1, tmp1)

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -426,7 +426,7 @@ let chain = :(throw(ArgumentError("invalid tuple size")))
     end
 end
 
-function tsfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
+function tdfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
     if length(h) == 1
         return mul!(out, h[1], x)
     elseif length(h) <= 15
@@ -592,7 +592,7 @@ function filt_choose_alg!(out::AbstractArray, b::AbstractVector, x::AbstractArra
         # 65536 is apprximate cutoff where FFT-based algorithm may be
         # more effective (due to overhead for allocation, plan
         # creation, etc.)
-        tsfilt!(out, b, x)
+        tdfilt!(out, b, x)
     else
         # Estimate number of multiplication operations for fftfilt()
         # and filt()
@@ -601,6 +601,6 @@ function filt_choose_alg!(out::AbstractArray, b::AbstractVector, x::AbstractArra
         nchunk = ceil(Int, nx/L)*div(length(x), nx)
         fftops = (2*nchunk + 1) * nfft * log2(nfft)/2 + nchunk * nfft + 500000
 
-        filtops > fftops ? _fftfilt!(out, b, x, nfft) : tsfilt!(out, b, x)
+        filtops > fftops ? _fftfilt!(out, b, x, nfft) : tdfilt!(out, b, x)
     end
 end

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -624,6 +624,6 @@ function filt_choose_alg!(out::AbstractArray, b::AbstractVector, x::AbstractArra
         nchunk = ceil(Int, nx/L)*div(length(x), nx)
         fftops = (2*nchunk + 1) * nfft * log2(nfft)/2 + nchunk * nfft + 500000
 
-        filtops > fftops ? _fftfilt!(out, b, x, nfft) : tdfilt!(out, b, x)
+        filtops > fftops ? _fftfilt!(out, b, x, nfft) : _tdfilt!(out, b, x)
     end
 end

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -450,7 +450,6 @@ end
 
 # Does not check that 'out' and 'x' are the same length
 function _tdfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
-    size(x) != size(out) && error("out size must match x")
     if length(h) == 1
         return mul!(out, h[1], x)
     elseif length(h) <= 15

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -426,7 +426,7 @@ let chain = :(throw(ArgumentError("invalid tuple size")))
     end
 end
 
-function filt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
+function tsfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
     if length(h) == 1
         return mul!(out, h[1], x)
     elseif length(h) <= 15
@@ -574,19 +574,17 @@ end
 # convolution in the time domain using filt or in the frequency domain
 # using fftfilt
 function filt(b::AbstractVector{T}, x::AbstractArray{T}) where T<:Number
-    _filt_choose_alg!(Array{T}(undef, size(x)), b, x)
+    filt_choose_alg!(Array{T}(undef, size(x)), b, x)
 end
 
 # Like filt but mutates output array
-function filt_choose_alg!(
-    out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray{T}) where T<:Number
+function filt!(out::AbstractArray, b::AbstractVector, x::AbstractArray)
     size(out) == size(x) || throw(ArgumentError("out must be the same size as x"))
-    _filt_choose_alg!(out, b, x)
+    filt_choose_alg!(out, b, x)
 end
 
 # like filt_choose_alg! but does not check if out and x are the same size
-function _filt_choose_alg!(
-    out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray{T}) where T<:Number
+function filt_choose_alg!(out::AbstractArray, b::AbstractVector, x::AbstractArray)
     nb = length(b)
     nx = size(x, 1)
 
@@ -595,7 +593,7 @@ function _filt_choose_alg!(
         # 65536 is apprximate cutoff where FFT-based algorithm may be
         # more effective (due to overhead for allocation, plan
         # creation, etc.)
-        filt!(out, b, x)
+        tsfilt!(out, b, x)
     else
         # Estimate number of multiplication operations for fftfilt()
         # and filt()
@@ -604,6 +602,6 @@ function _filt_choose_alg!(
         nchunk = ceil(Int, nx/L)*div(length(x), nx)
         fftops = (2*nchunk + 1) * nfft * log2(nfft)/2 + nchunk * nfft + 500000
 
-        filtops > fftops ? _fftfilt!(out, b, x, nfft) : filt!(out, b, x)
+        filtops > fftops ? _fftfilt!(out, b, x, nfft) : tsfilt!(out, b, x)
     end
 end

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -12,7 +12,8 @@ _zerosi(f::PolynomialRatio{T}, x::AbstractArray{S}) where {T,S} =
     filt!(out, f, x[, si])
 
 Same as [`filt()`](@ref) but writes the result into the `out`
-argument, which may alias the input `x` to modify it in-place.
+argument. Output array `out` may not be an alias of `x`, i.e. filtering may
+not be done in place.
 """
 filt!(out, f::PolynomialRatio{T}, x::AbstractArray{S}, si=_zerosi(f, x)) where {T,S} =
     filt!(out, coefb(f), coefa(f), x, si)
@@ -426,6 +427,15 @@ let chain = :(throw(ArgumentError("invalid tuple size")))
     end
 end
 
+
+"""
+    tdfilt!(out, h, x)
+
+Apply filter or filter coefficients `h` along the first dimension
+of array `x` using a naïve time-domain algorithm, and writes the result into
+array `out`. Output array `out` may not be an alias of `x`, i.e. filtering may
+not be done in place.
+"""
 function tdfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
     if length(h) == 1
         return mul!(out, h[1], x)

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -226,11 +226,14 @@ end
 @testset "fftfilt $xlen/$blen" for xlen in 2 .^ (7:18) .- 1, blen in 2 .^ (1:6) .- 1
     b = randn(blen)
     for x in (rand(xlen), rand(xlen, 2))
+        out = similar(x)
         filtres = filt(b, [1.0], x)
         fftres = fftfilt(b, x)
+        fft_inplace_res = fftfilt!(out, b, x)
         firres = filt(b, x)
         @test filtres ≈ fftres
         @test filtres ≈ firres
+        @test filtres ≈ fft_inplace_res
     end
 end
 

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -229,13 +229,11 @@ end
         out = similar(x)
         filtres = filt(b, [1.0], x)
         fftres = fftfilt(b, x)
-        firres = filt(b, x)
         fft_inplace_res = fftfilt!(out, b, x)
-        fft_self_res = fftfilt!(x, b, x) # Check that out can be an alias of x
+        firres = filt(b, x)
         @test filtres ≈ fftres
         @test filtres ≈ firres
         @test filtres ≈ fft_inplace_res
-        @test filtres ≈ fft_self_res
     end
 end
 

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -230,12 +230,10 @@ end
         filtres = filt(b, [1.0], x)
         fftres = fftfilt(b, x)
         firres = filt(b, x)
-        fft_inplace_res = fftfilt!(out, b, x)
-        fft_self_res = fftfilt!(x, b, x) # Check that out can be an alias of x
+        fft_mutate_res = fftfilt!(out, b, x)
         @test filtres ≈ fftres
         @test filtres ≈ firres
-        @test filtres ≈ fft_inplace_res
-        @test filtres ≈ fft_self_res
+        @test filtres ≈ fft_mutate_res
     end
 end
 

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -229,11 +229,13 @@ end
         out = similar(x)
         filtres = filt(b, [1.0], x)
         fftres = fftfilt(b, x)
-        fft_inplace_res = fftfilt!(out, b, x)
         firres = filt(b, x)
+        fft_inplace_res = fftfilt!(out, b, x)
+        fft_self_res = fftfilt!(x, b, x) # Check that out can be an alias of x
         @test filtres ≈ fftres
         @test filtres ≈ firres
         @test filtres ≈ fft_inplace_res
+        @test filtres ≈ fft_self_res
     end
 end
 

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -230,10 +230,17 @@ end
         filtres = filt(b, [1.0], x)
         fftres = fftfilt(b, x)
         firres = filt(b, x)
-        fft_mutate_res = fftfilt!(out, b, x)
+        td_res = tdfilt(b, x)
+
         @test filtres ≈ fftres
         @test filtres ≈ firres
-        @test filtres ≈ fft_mutate_res
+        @test filtres ≈ td_res
+
+        fftfilt!(out, b, x)
+        @test filtres ≈ out # test output of fftfilt!
+
+        tdfilt!(out, b, x)
+        @test filtres ≈ out # test output of tdfilt!
     end
 end
 


### PR DESCRIPTION
I have split `fftfilt` into two functions, the original `fftfilt` which
initializes the output array, `ffiltfilt!` which checks the size of the output
array is consistent with the input array, and `_fftfilt!` which performs the
filtering by mutating the output array without checking its inputs.

Similarly, I have separated the FIR method of `filt` into the original function
which initializes the output array, `filt_choose_alg!` which checks if the
output array and input array are the same size, and `_filt_choose_alg!` which
will choose to use fftfilt or time-domain filtering based on the same heuristics.