### PR TITLE
Fix a few deprecations on Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-Compat 0.63
+Compat 0.69
 Polynomials 0.1.0
 Reexport
 SpecialFunctions

--- a/src/Filters/response.jl
+++ b/src/Filters/response.jl
@@ -54,7 +54,7 @@ or frequencies `w` in radians/sample.
 """
 function phasez(filter::FilterCoefficients, w = Compat.range(0, stop=π, length=250))
     h = freqz(filter, w)
-    unwrap(-atan2.(imag(h), real(h)); dims=ndims(h))
+    unwrap(-atan.(imag(h), real(h)); dims=ndims(h))
 end
 
 

--- a/src/estimation.jl
+++ b/src/estimation.jl
@@ -1,6 +1,10 @@
 module Estimation
 
-using Compat.LinearAlgebra: eig, svd
+if VERSION < v"0.7.0-DEV.5211"
+    using Compat.LinearAlgebra: eig, svd
+else
+    using LinearAlgebra: eigen, svd
+end
 
 export esprit
 
@@ -33,7 +37,11 @@ function esprit(x::AbstractArray, M::Integer, p::Integer, Fs::Real=1.0)
     N = length(x)
     X = x[ (1:M) .+ (0:N-M)' ]
     U,s,V = svd(X)
-    D,_ = eig( U[1:end-1,1:p] \ U[2:end,1:p] )
+    @static if VERSION < v"0.7.0-DEV.5211"
+        D,_ = eig( U[1:end-1,1:p] \ U[2:end,1:p] )
+    else
+        D,_ = eigen( U[1:end-1,1:p] \ U[2:end,1:p] )
+    end
     angle.(D)*Fs/2π
 end
 

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -4,7 +4,11 @@ using ..Util
 import SpecialFunctions: besseli
 import Compat
 using Compat: copyto!, undef
-using Compat.LinearAlgebra: Diagonal, SymTridiagonal, eigfact!
+if VERSION < v"0.7.0-DEV.5211"
+    using Compat.LinearAlgebra: Diagonal, SymTridiagonal, eigfact!
+else
+    using LinearAlgebra: Diagonal, SymTridiagonal, eigen!
+end
 @importffts
 
 export  rect,
@@ -193,8 +197,10 @@ function dpss(n::Int, nw::Real, ntapers::Int=ceil(Int, 2*nw)-1)
     # Get tapers
     @static if VERSION < v"0.7.0-DEV.3159"
         eigvec = eigfact!(mat, n-ntapers+1:n)[:vectors]
-    else
+    elseif VERSION < v"0.7.0-DEV.5211"
         eigvec = eigfact!(mat, n-ntapers+1:n).vectors
+    else
+        eigvec = eigen!(mat, n-ntapers+1:n).vectors
     end
     v = Compat.reverse(eigvec::Matrix{Float64}, dims=2)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,5 +5,5 @@ testfiles = [ "dsp.jl", "util.jl", "windows.jl", "filter_conversion.jl",
     "periodograms.jl", "resample.jl", "lpc.jl", "estimation.jl", "unwrap.jl"]
 
 for testfile in testfiles
-    eval(@__MODULE__, :(@testset $testfile begin include($testfile) end))
+    eval(:(@testset $testfile begin include($testfile) end))
 end


### PR DESCRIPTION
Remaining deprecation warnings at the moment are all due to the moval of `mean` and `middle` to `Statistics`. I'll fix those once https://github.com/JuliaLang/Compat.jl/pull/583 has landed. Whether as part of this PR or in another one is a matter of how fast we get the Compat. I'd like to tag a version with the new `unwrap` soon, but wanted to fix those deprecations where it was easy. So if the Statistics thing takes its time, I'll tag before, despite the remaining deprecations.