### PR TITLE
Add @simd macro to amenable loops

### DIFF
--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -542,7 +542,7 @@ function fftfilt(b::AbstractVector{T}, x::AbstractArray{T},
             mul!(tmp1, p2, tmp2)
 
             # Copy to output
-            for j = 0:min(L - 1, nx - off)
+            @simd for j = 0:min(L - 1, nx - off)
                 @inbounds out[colstart+off+j] = tmp1[nb+j]*normfactor
             end
 

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -247,8 +247,8 @@ function dpsseig(A::Matrix{Float64}, nw::Real)
         fill!(tmp1, 0)
         copyto!(tmp1, 1, A, (i-1)*size(A, 1)+1, size(A, 1))
         mul!(tmp2, p1, tmp1)
-        for j = 1:length(tmp2)
-            @inbounds tmp2[j] = abs2(tmp2[j])
+        @inbounds @simd for j = 1:length(tmp2)
+            tmp2[j] = abs2(tmp2[j])
         end
         mul!(tmp1, p2, tmp2)
 


### PR DESCRIPTION
A number of loops that satisfy the constraints to use the @simd macro did not. I
have added them to the loops that I could find, and found that performance and
memory use for `mt_pgram` increased by a few percent. While I expect other
performance gains to be similarly modest, it's a 'free' boost.