### PR TITLE
Fix esprit tests so they don't randomly fail

### DIFF
--- a/test/filt.jl
+++ b/test/filt.jl
@@ -4,7 +4,6 @@ using DSP, Compat, Compat.Test, Compat.Random, FilterTestHelpers
 # filt with different filter forms
 #
 @testset "filt" begin
-    seed!(1776)
     x = randn(100)
 
     for n = 1:6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,8 @@ testfiles = [ "dsp.jl", "util.jl", "windows.jl", "filter_conversion.jl",
     "periodograms.jl", "resample.jl", "lpc.jl", "estimation.jl", "unwrap.jl",
     "remez_fir.jl" ]
 
+seed!(1776)
+
 for testfile in testfiles
     eval(:(@testset $testfile begin include($testfile) end))
 end

--- a/test/unwrap.jl
+++ b/test/unwrap.jl
@@ -39,7 +39,6 @@ using DSP, Compat, Compat.Test
     # test generically typed unwrapping
     types = (Float32, Float64, BigFloat)
     for T in types
-        seed!(1234)
         A_unwrapped = collect(Compat.range(0, stop=4convert(T, π), length=10))
         A_wrapped = A_unwrapped .% (2convert(T, π))
 
@@ -58,7 +57,6 @@ end
 @testset "Unwrap 2D" begin
     types = (Float32, Float64, BigFloat)
     for T in types
-        seed!(1234)
         v_unwrapped = collect(Compat.range(0, stop=4convert(T, π), length=7))
         A_unwrapped = v_unwrapped .+ v_unwrapped'
         A_wrapped = A_unwrapped .% (2convert(T, π))


### PR DESCRIPTION
After esprit was added to DSP.jl, testing the package randomly fails. This can
be fixed by seeding the random number generator prior to testing esprit.