### PR TITLE
Prevent bounds error when filtering large arrays

### DIFF
--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -3,7 +3,7 @@ using ..DSP: @importffts, mul!, rmul!
 using ..Unwrap
 using Polynomials, ..Util
 import Base: *
-using Compat: copyto!, undef
+using Compat: copyto!, undef, argmin
 import Compat
 using Compat.LinearAlgebra: I
 using Compat.Statistics: middle

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -525,15 +525,23 @@ end
 
 Like `fftfilt` but writes result into out array.
 """
-function fftfilt!(out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray{T},
-                  nfft::Integer=optimalfftfiltlength(length(b), length(x))) where T<:Real
+function fftfilt!(
+    out::AbstractArray{<:Real},
+    b::AbstractVector{<:Real},
+    x::AbstractArray{<:Real},
+    nfft::Integer=optimalfftfiltlength(length(b), length(x))
+)
     size(out) == size(x) || throw(ArgumentError("out and x must be the same size"))
     _fftfilt!(out, b, x, nfft)
 end
 
 # Like fftfilt! but does not check if out and x are the same size
-function _fftfilt!(out::AbstractArray{T}, b::AbstractVector{T}, x::AbstractArray{T},
-                 nfft::Integer) where T<:Real
+function _fftfilt!(
+    out::AbstractArray{<:Real},
+    b::AbstractVector{<:Real},
+    x::AbstractArray{T},
+    nfft::Integer
+) where T<:Real
     nb = length(b)
     nx = size(x, 1)
     normfactor = 1/nfft


### PR DESCRIPTION
As described in #213, FIR filtering will fail if the input vector is larger than
`2^28`, which is the last saved benchmark used by `optimalfftfiltlength` to
heuristically choose a chunk size `L` for the overlap-save algorithm used in `fftfilt`.

Instead of relying on saved benchmarks to pick `L`, it is possible to calculate
the per-sample complexity of the overlap-save algorithm, as a function of `nfft`
and by extension `L` [0] (the result is the same for overlap-save as the overlap-add calculation shown here). I have replaced looking up benchmarks with calls to a
new function, `os_fft_complexity`, which calculates the per-sample complexity for
a given `nfft` that is a power of 2 and the filter size `nb`. I then choose the
minimum complexity for a range of `nfft`s, and use that as the best `nfft`.

[0] e.g. https://www.allaboutcircuits.com/technical-articles/overlap-add-method-linear-filtering-based-on-the-discrete-fourier-transform/