### PR TITLE
Workaround JuliaLang/julia#28077

### DIFF
--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -84,6 +84,12 @@ C CODE BANNER
  *********************************************************/
 
 =============================================#
+if v"0.7.0-DEV.5103" ≤ VERSION < v"0.7.0-beta2.22"
+    # work around JuliaLang/julia#28077 by inserting a no-op (`nothing`) after each label
+    macro label(sym)
+        :($(esc(Expr(:symboliclabel, sym))); nothing)
+    end
+end
 
 # RemezFilterType:
 #    Type I and II symmetric linear phase: neg==0   (filter_type==bandpass)


### PR DESCRIPTION
Place a no-op (`nothing`) immediately after labels which would otherwise be followed by a phi-node. Looks silly but prevents Julia 0.7-beta2 from crashing on the remez tests due to JuliaLang/julia#28077 (and should generally make `remez` work correctly on beta2).

CC @sirtom67 