### PR TITLE
Some clean-up of remez

### DIFF
--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -408,8 +408,7 @@ function remez(numtaps::Integer, bands::Vector, desired::Vector;
         nfcns = nfcns + 1
     end
     temp = (ngrid-1) / nfcns
-    dimsize = ceil(Int64, numtaps/2 + 2)
-    
+
     #
     # SET UP A NEW APPROXIMATION PROBLEM WHICH IS EQUIVALENT
     # TO THE ORIGINAL PROBLEM
@@ -437,10 +436,12 @@ function remez(numtaps::Integer, bands::Vector, desired::Vector;
             end
         end
     end
-        
-    iext = zeros(Int64, dimsize)   # indices of extremals
-    x = zeros(Float64, dimsize)
-    y = zeros(Float64, dimsize)
+
+    nz  = nfcns+1
+    nzz = nfcns+2
+    iext = zeros(Int64, nzz)   # indices of extremals
+    x = zeros(Float64, nzz)
+    y = zeros(Float64, nz)
 
     for j = 1 : nfcns
         iext[j] = Int64(floor((j-1)*temp)) + 1
@@ -450,8 +451,6 @@ function remez(numtaps::Integer, bands::Vector, desired::Vector;
     dev = 0.0     # deviation from the desired function, 
                   # that is, the amount of "ripple" on the extremal set
     devl = -1.0   # deviation on last iteration
-    nz  = nfcns+1
-    nzz = nfcns+2
     niter = 0
     ad = zeros(Float64, nz)
     
@@ -634,23 +633,23 @@ function remez(numtaps::Integer, bands::Vector, desired::Vector;
 
         @goto L100
       @label L370
-        
-        
+
+
         if jchnge <= 0  # we are done if none of the extremal indices changed
             break
         end
     end  # while
 
-    # 
+    #
     #    CALCULATION OF THE COEFFICIENTS OF THE BEST APPROXIMATION
     #    USING THE INVERSE DISCRETE FOURIER TRANSFORM
     #
 
-    a = zeros(Float64, dimsize)   # frequency response on evenly spaced grid
-    p = zeros(Float64, dimsize)
-    q = zeros(Float64, dimsize) 
-    alpha = zeros(Float64, dimsize)   # return vector
-    
+    a = zeros(Float64, nfcns)   # frequency response on evenly spaced grid
+    p = zeros(Float64, nfcns)
+    q = zeros(Float64, nfcns-2)
+    alpha = zeros(Float64, nzz)   # return vector
+
     nm1 = nfcns - 1   # nm1 => "nfcns minus 1"
     fsh = 1.0e-06
     x[nzz] = -2.0

--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -211,19 +211,21 @@ function build_grid(numtaps, bands, desired, weight, grid_density, filter_type::
     # CALCULATE THE DESIRED MAGNITUDE RESPONSE AND THE WEIGHT
     # FUNCTION ON THE GRID
     #
+    # and
+    #
+    # SET UP A NEW APPROXIMATION PROBLEM WHICH IS EQUIVALENT
+    # TO THE ORIGINAL PROBLEM
+    #
     for lband in 1:nbands
         flow = edges[1, lband]
         fup = edges[2, lband]
-        for f in (flow:delf:fup)[1:end-1]
-            grid[j] = f
-            des[j] = eff(f,fx,lband,filter_type)
-            wt[j] = wate(f,fx,wtx,lband,filter_type)
+        for f in [(flow:delf:fup)[1:end-1]; fup]
+            change = neg ? (nodd ? sinpi(2f) : sinpi(f)) : (nodd ? 1.0 : cospi(f))
+            grid[j] = cospi(2f)
+            des[j] = eff(f,fx,lband,filter_type) / change
+            wt[j] = wate(f,fx,wtx,lband,filter_type) * change
             j += 1
         end
-        grid[j] = fup
-        des[j] = eff(fup,fx,lband,filter_type)
-        wt[j] = wate(fup,fx,wtx,lband,filter_type)
-        j += 1
     end
     @assert ngrid == j - 1
 
@@ -407,35 +409,6 @@ function remez(numtaps::Integer, bands::Vector, desired::Vector;
         nfcns = nfcns + 1
     end
     temp = (ngrid-1) / nfcns
-
-    #
-    # SET UP A NEW APPROXIMATION PROBLEM WHICH IS EQUIVALENT
-    # TO THE ORIGINAL PROBLEM
-    #
-    if !neg
-        if !nodd
-            for j = 1 : ngrid
-                change = cospi(grid[j])
-                des[j] = des[j] / change
-                wt[j]  = wt[j] * change
-            end
-        end
-    else
-        if !nodd
-            for j = 1 : ngrid
-                change = sinpi(grid[j])
-                des[j] = des[j] / change
-                wt[j]  = wt[j]  * change
-            end
-        else
-            for j = 1 : ngrid
-                change = sinpi(2grid[j])
-                des[j] = des[j] / change
-                wt[j]  = wt[j]  * change
-            end
-        end
-    end
-    grid .= cospi.(2 .* grid)
 
     nz  = nfcns+1
     nzz = nfcns+2

--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -628,11 +628,9 @@ function remez(numtaps::Integer, bands::Vector, desired::Vector;
         iext[1] = k1
         @goto L100
       @label L350
-        kn = iext[nzz]
-        for j = 1 : nfcns
+        for j = 1:nz
             iext[j] = iext[j+1]
         end
-        iext[nz] = kn
 
         @goto L100
       @label L370

--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -199,7 +199,11 @@ function build_grid(numtaps, bands, desired, weight, grid_density, filter_type::
         flimhigh = (neg == nodd) ? 0.5 - delf : 0.5
         edges = map(f -> clamp(f, flimlow, flimhigh), edges)
     end
-    ngrid = sum(max(length(edges[1,lband]:delf:edges[2,lband]), 1) for lband in 1:nbands)
+    local ngrid
+    # work around JuliaLang/julia#15276
+    let delf=delf, edges=edges
+        ngrid = sum(max(length(edges[1,lband]:delf:edges[2,lband]), 1) for lband in 1:nbands)#::Int
+    end
 
     grid = zeros(Float64, ngrid)  # the array of frequencies, between 0 and 0.5
     des = zeros(Float64, ngrid)   # the desired function on the grid


### PR DESCRIPTION
Start of an attempt to make this more readable. I found it quite hard to keep track of what all those variables mean, so I've started eliminating some of them.

Also, there is one algorithmic change, basically doing `grid .= cospi.(2.*grid)`. Before, the cosine might have potentially been applied only to a subset of grid points, but OTOH potentially multiple times. Net performance impact seems small (but an improvement), but this allows to remove some `cospi` calls, making for slightly less code.

What does have a significant performance impact is fixing a type-instabilty in `build_grid`:
```julia
# master
julia> @btime remez(20, $[0, 0.475, 0.5, 1.0], $[1.0, 0.0]; Hz=2.0);
  283.074 μs (8114 allocations: 142.48 KiB)

julia> @btime remez(151, $[0, 0.475, 0.5, 1.0], $[1.0, 0.0]; Hz=2.0);
  4.846 ms (87515 allocations: 1.41 MiB)
```
```julia
# this PR
julia> @btime remez(20, $[0, 0.475, 0.5, 1.0], $[1.0, 0.0]; Hz=2.0);
  53.988 μs (88 allocations: 11.80 KiB)

julia> @btime remez(151, $[0, 0.475, 0.5, 1.0], $[1.0, 0.0]; Hz=2.0);
  2.803 ms (104 allocations: 60.39 KiB)
```
@sirtom67 have you done the benchmarks shown at JuliaCon with the version from master? That might explain (part of) the overhead for small filter sizes.