### PR TITLE
Added convolution and correlation methods to the docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(
         "windows.md",
         "filters.md",
         "util.md",
+        "convolutions.md"
         "index.md",
     ],
 )

--- a/docs/src/contents.md
+++ b/docs/src/contents.md
@@ -10,6 +10,7 @@ Pages = ["periodograms.md",
     "windows.md",
     "filters.md",
     "util.md",
+    "convolutions.md"
     "index.md",
 ]
 ```

--- a/docs/src/convolutions.md
+++ b/docs/src/convolutions.md
@@ -1,0 +1,8 @@
+# `Convolutions` - similarity methods
+
+```@docs
+conv
+conv2
+deconv
+xcorr
+```


### PR DESCRIPTION
Currently, when searching google for a method to perform a convolution method in Julia, the results all return information that is only relevant to Julia 0.6 and below. This commit adds a page to the DSP.jl docs for the convolution and correlation functions so that they can become indexed.