### PR TITLE
RFC/WIP: Use functions in remez API

### DIFF
--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -3,7 +3,7 @@ using ..DSP: @importffts, mul!, rmul!
 using ..Unwrap
 using Polynomials, ..Util
 import Base: *
-using Compat: copyto!, undef
+using Compat: copyto!, Nothing, undef
 import Compat
 using Compat.LinearAlgebra: I
 using Compat.Statistics: middle

--- a/test/remez_fir.jl
+++ b/test/remez_fir.jl
@@ -1,5 +1,5 @@
 !(dirname(@__FILE__) in LOAD_PATH) && push!(LOAD_PATH, dirname(@__FILE__))
-using DSP, Compat, Compat.Test, FilterTestHelpers
+using DSP, Compat, Compat.Test, Compat.DelimitedFiles, FilterTestHelpers
 
 @testset "remez_argument_check1" begin
     # bands not monotonically increasing

--- a/test/remez_fir.jl
+++ b/test/remez_fir.jl
@@ -3,7 +3,8 @@ using DSP, Compat, Compat.Test, Compat.DelimitedFiles, FilterTestHelpers
 
 @testset "remez_argument_check1" begin
     # bands not monotonically increasing
-    @test_throws ArgumentError remez(151, [0, 0.25, 0.23, 0.5], [1.0, 0.0])
+    @test_throws ArgumentError remez(151, [0, 0.25, 0.25, 0.5], [1.0, 0.0])
+    @test_throws ArgumentError remez(151, [0.2, 0.1, 0.25, 0.5], [1.0, 0.0])
 end
 
 @testset "remez_argument_check2" begin
@@ -30,21 +31,25 @@ end
 # Length 151 LPF (Low Pass Filter).
 #
 @testset "remez_151_lpf" begin
-    h = remez(151, [0, 0.475, 0.5, 1.0], [1.0, 0.0]; Hz=2.0);
     h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_151_lpf.txt"),'\t')
+    h = remez(151, [0, 0.475, 0.5, 1.0], [1.0, 0.0]; Hz=2.0);
+    @test h ≈ h_scipy
+    h = remez(151, [(0, 0.475) => 1, (0.5, 1.0) => 0]; Hz=2.0);
     @test h ≈ h_scipy
 end
 
 #
 # Length 152 LPF. Non-default "weight" input.
-# 
+#
 #    from scipy.signal import remez
 #    lpf = remez(152, [0, 0.475, 0.5, 1.0], [1.0, 0.0], weight=[1,2], Hz=2.0)
 #    lpf.tofile('remez_152_lpf.txt', sep='\n')
 #
 @testset "remez_152_lpf" begin
-    h = remez(152, [0, 0.475, 0.5, 1.0], [1.0, 0.0]; weight=[1,2], Hz=2.0);
     h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_152_lpf.txt"),'\t')
+    h = remez(152, [0, 0.475, 0.5, 1.0], [1.0, 0.0]; weight=[1,2], Hz=2.0);
+    @test h ≈ h_scipy
+    h = remez(152, [(0, 0.475) => (1, 1), (0.5, 1.0) => (0, 2)]; Hz=2.0);
     @test h ≈ h_scipy
 end
 
@@ -56,8 +61,10 @@ end
 #    hpf.tofile('remez_51_hpf.txt', sep='\n')
 #
 @testset "remez_51_hpf" begin
-    h = remez(51, [0, 0.75, 0.8, 1.0], [0.0, 1.0]; Hz=2.0);
     h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_51_hpf.txt"),'\t')
+    h = remez(51, [0, 0.75, 0.8, 1.0], [0.0, 1.0]; Hz=2.0);
+    @test h ≈ h_scipy
+    h = remez(51, [(0, 0.75) => 0, (0.8, 1.0) => 1]; Hz=2.0);
     @test h ≈ h_scipy
 end
 
@@ -69,27 +76,32 @@ end
 #    bpf.tofile('remez_180_bpf.txt', sep='\n')
 #
 @testset "remez_180_bpf" begin
+h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_180_bpf.txt"),'\t')
     h = remez(180, [0, 0.375, 0.4, 0.5, 0.525, 1.0], [0.0, 1.0, 0.0]; Hz=2.0, maxiter=30);
-    h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_180_bpf.txt"),'\t')
+    @test h ≈ h_scipy
+    h = remez(180, [(0, 0.375) => 0, (0.4, 0.5) => 1, (0.525, 1.0) => 0]; Hz=2.0, maxiter=30);
     @test h ≈ h_scipy
 end
 
 @testset "remez_warn_no_converge_after_maxiter_iterations" begin
     @static if VERSION ≥ v"0.7.0-DEV.2988"
         @test_logs (:warn, r"filter is not converged") remez(180, [0, 0.375, 0.4, 0.5, 0.525, 1.0], [0.0, 1.0, 0.0]; Hz=2.0)
+        @test_logs (:warn, r"filter is not converged") remez(180, [(0, 0.375) => 0, (0.4, 0.5) => 1, (0.525, 1.0) => 0]; Hz=2.0)
     else
         warn_check(msg) = contains(msg, "filter is not converged")
         @test_warn warn_check remez(180, [0, 0.375, 0.4, 0.5, 0.525, 1.0], [0.0, 1.0, 0.0]; Hz=2.0)
+        @test_warn warn_check remez(180, [(0, 0.375) => 0, (0.4, 0.5) => 1, (0.525, 1.0) => 0]; Hz=2.0)
     end
 end
 
 @testset "remez_error_no_converge_transition_band_too_wide" begin
     @test_throws ErrorException remez(151, [0, 0.1, 0.4, 0.5], [1.0, 0.0])
+    @test_throws ErrorException remez(151, [(0, 0.1) => 1, (0.4, 0.5) => 0])
 end
 
 #
 #  Odd-symmetric filters - hilbert and differentiators type.
-#  Even length - much better approximation since it is not constrained to 0 at 
+#  Even length - much better approximation since it is not constrained to 0 at
 #  the nyquist frequency
 #
 # Length 20 hilbert
@@ -99,8 +111,10 @@ end
 #    h.tofile('remez_20_hilbert.txt', sep='\n')
 #
 @testset "remez_20_hilbert" begin
-    h = remez(20, [0.1, 0.95],[1]; filter_type=filter_type_hilbert, Hz=2.0);
     h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_20_hilbert.txt"),'\t')
+    h = remez(20, [0.1, 0.95], [1]; filter_type=filter_type_hilbert, Hz=2.0);
+    @test h ≈ h_scipy
+    h = remez(20, [(0.1, 0.95) => 1]; neg=true, Hz=2.0);
     @test h ≈ h_scipy
 end
 
@@ -112,8 +126,10 @@ end
 #    h.tofile('remez_21_hilbert.txt', sep='\n')
 #
 @testset "remez_21_hilbert" begin
-    h = remez(21, [0.1, 0.95],[1]; filter_type=filter_type_hilbert, Hz=2.0);
     h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_21_hilbert.txt"),'\t')
+    h = remez(21, [0.1, 0.95], [1]; filter_type=filter_type_hilbert, Hz=2.0);
+    @test h ≈ h_scipy
+    h = remez(21, [(0.1, 0.95) => 1]; neg=true, Hz=2.0);
     @test h ≈ h_scipy
 end
 
@@ -125,8 +141,10 @@ end
 #    h.tofile('remez_200_differentiator.txt', sep='\n')
 #
 @testset "remez_200_differentiator" begin
-    h = remez(200, [0.01, 0.99],[1]; filter_type=filter_type_differentiator, Hz=2.0);
     h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_200_differentiator.txt"),'\t')
+    h = remez(200, [0.01, 0.99], [1]; filter_type=filter_type_differentiator, Hz=2.0);
+    @test h ≈ h_scipy
+    h = remez(200, [(0.01, 0.99) => (f -> f/2, f -> 1/f)]; neg=true, Hz=2.0);
     @test h ≈ h_scipy
 end
 
@@ -138,7 +156,9 @@ end
 #    h.tofile('remez_201_differentiator.txt', sep='\n')
 #
 @testset "remez_201_differentiator" begin
-    h = remez(201, [0.05, 0.95],[1]; filter_type=filter_type_differentiator, Hz=2.0);
     h_scipy = readdlm(joinpath(dirname(@__FILE__), "data", "remez_201_differentiator.txt"),'\t')
+    h = remez(201, [0.05, 0.95], [1]; filter_type=filter_type_differentiator, Hz=2.0);
+    @test h ≈ h_scipy
+    h = remez(201, [(0.05, 0.95) => (f -> f/2, f -> 1/f)]; neg=true, Hz=2.0);
     @test h ≈ h_scipy
 end


### PR DESCRIPTION
Ref. https://github.com/JuliaDSP/DSP.jl/pull/210#issuecomment-406966472

I actually needed this functionality just the other day. WIP as I'm not quite sure about the API, yet. (Hence, also no tests or docs, yet.) Presently, this allows `desired` and `weight` to contain functions from frequency to desired gain or weight, respectively. I wonder whether we should instead allow an API that looked somewhat like this:
```julia
remez(152, [0..0.475 => 1,
            0.5..1.0 => (desired=0.0, weight=2.0)],
      Hz=2.0)
```
instead of
```julia
remez(152, [0, 0.475, 0.5, 1.0], [1.0, 0.0]; weight=[1,2], Hz=2.0)
```
where the RHS of `=>` could be a single number for desired gain (with weight defaulting to 1) or a (named) tuple, or a function/(named) tuple of functions (or a function returning a tuple?). Opinions?