### PR TITLE
Replace DSP by digital signal processing in docs/Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ DSP.jl
 [![Coverage Status](https://coveralls.io/repos/JuliaDSP/DSP.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaDSP/DSP.jl?branch=master)
 [![Package Evaluator](http://pkg.julialang.org/badges/DSP_0.6.svg)](http://pkg.julialang.org/?pkg=DSP)
 
-DSP.jl provides a number of common DSP routines in Julia. These include:
+DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia. These include:
 
 - [Periodogram estimation](https://juliadsp.github.io/DSP.jl/stable/periodograms)
 - [Filter design and filtering](https://juliadsp.github.io/DSP.jl/stable/filters)

--- a/docs/src/contents.md
+++ b/docs/src/contents.md
@@ -2,7 +2,7 @@
 
 Contents:
 
-DSP.jl provides a number of common DSP routines in Julia. So far, the following submodules are implemented:
+DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia. So far, the following submodules are implemented:
 
 ```@contents
 Pages = ["periodograms.md",


### PR DESCRIPTION
This PR replaces DSP by [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) in the Readme and on the start page of the docs. This way, people who aren't familiar with the abbreviation DSP can understand immediately what this package is about.

Originated from #249.