### PR TITLE
Small doc changes and more general coefa/b functions

### DIFF
--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -112,6 +112,7 @@ Coefficients of the numerator of a PolynomialRatio object, highest power
 first, i.e., the `b` passed to `filt()`
 """
 coefb(f::PolynomialRatio) = reverse(f.b.a)
+coefb(f::FilterCoefficients) = coefb(PolynomialRatio(f))
 
 """
     coefa(f)
@@ -120,6 +121,7 @@ Coefficients of the denominator of a PolynomialRatio object, highest power
 first, i.e., the `a` passed to `filt()`
 """
 coefa(f::PolynomialRatio) = reverse(f.a.a)
+coefa(f::FilterCoefficients) = coefa(PolynomialRatio(f))
 
 #
 # Biquad filter in transfer function form

--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -19,7 +19,7 @@ complextype(::Type{Complex{T}}) where {T} = Complex{T}
 Filter representation in terms of zeros `z`, poles `p`, and
 gain `k`:
 ```math
-H(x) = k\\frac{(x - \\verb!z[1]!) \\ldots (x - \\verb!z[end]!)}{(x - \\verb!p[1]!) \\ldots (x - \\verb!p[end]!)}
+H(x) = k\\frac{(x - \\verb!z[1]!) \\ldots (x - \\verb!z[m]!)}{(x - \\verb!p[1]!) \\ldots (x - \\verb!p[n]!)}
 ```
 """
 struct ZeroPoleGain{Z<:Number,P<:Number,K<:Number} <: FilterCoefficients
@@ -58,7 +58,7 @@ end
 Filter representation in terms of the coefficients of the numerator
 `b` and denominator `a` of the transfer function:
 ```math
-H(s) = \\frac{\\verb!b[1]! s^{n-1} + \\ldots + \\verb!b[n]!}{\\verb!a[1]! s^{n-1} + \\ldots + \\verb!a[n]!}
+H(s) = \\frac{\\verb!b[1]! s^{m-1} + \\ldots + \\verb!b[m]!}{\\verb!a[1]! s^{n-1} + \\ldots + \\verb!a[n]!}
 ```
 or equivalently:
 ```math

--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -461,7 +461,7 @@ Second-order digital IIR notch filter [^Orfandis] at frequency `Wn` with
 bandwidth `bandwidth`. If `fs` is not specified, `Wn` is
 interpreted as a normalized frequency in half-cycles/sample.
 
-[^Orfandis]:
+[^Orfandis]: 
 Orfanidis, S. J. (1996). Introduction to signal processing.
 Englewood Cliffs, N.J: Prentice Hall, p. 370.
 """

--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -290,7 +290,7 @@ struct Bandstop{T} <: FilterType
 end
 
 """
-Bandstop(Wn1, Wn2[; fs])
+    Bandstop(Wn1, Wn2[; fs])
 
 Band stop filter with normalized stop band (`Wn1`, `Wn2`). If
 `fs` is not specified, `Wn1` and `Wn2` are interpreted as
@@ -461,7 +461,7 @@ Second-order digital IIR notch filter [^Orfandis] at frequency `Wn` with
 bandwidth `bandwidth`. If `fs` is not specified, `Wn` is
 interpreted as a normalized frequency in half-cycles/sample.
 
-[^Orfandis]: 
+[^Orfandis]:
 Orfanidis, S. J. (1996). Introduction to signal processing.
 Englewood Cliffs, N.J: Prentice Hall, p. 370.
 """

--- a/src/Filters/response.jl
+++ b/src/Filters/response.jl
@@ -28,7 +28,7 @@ end
 """
     freqz(filter, w = range(0, stop=π, length=250))
 
-Frequency response of a digital `filter` at normalised frequency
+Frequency response of a digital `filter` at normalised angular frequency
 or frequencies `w` in radians/sample.
 """
 function freqz(filter::FilterCoefficients, w = Compat.range(0, stop=π, length=250))
@@ -49,7 +49,7 @@ end
 """
     phasez(filter, w = range(0, stop=π, length=250))
 
-Phase response of a digital `filter` at normalised frequency
+Phase response of a digital `filter` at normalised angular frequency
 or frequencies `w` in radians/sample.
 """
 function phasez(filter::FilterCoefficients, w = Compat.range(0, stop=π, length=250))
@@ -82,7 +82,7 @@ end
 """
     freqs(filter, w)
 
-Frequency response of an analog `filter` at normalised frequency
+Frequency response of an analog `filter` at normalised angular frequency
 or frequencies `w` in radians/sample.
 """
 function freqs(filter::FilterCoefficients, w::Number)

--- a/src/Filters/response.jl
+++ b/src/Filters/response.jl
@@ -28,7 +28,7 @@ end
 """
     freqz(filter, w = range(0, stop=π, length=250))
 
-Frequency response of a digital `filter` at normalised angular frequency
+Frequency response of a digital `filter` at normalised frequency
 or frequencies `w` in radians/sample.
 """
 function freqz(filter::FilterCoefficients, w = Compat.range(0, stop=π, length=250))
@@ -49,7 +49,7 @@ end
 """
     phasez(filter, w = range(0, stop=π, length=250))
 
-Phase response of a digital `filter` at normalised angular frequency
+Phase response of a digital `filter` at normalised frequency
 or frequencies `w` in radians/sample.
 """
 function phasez(filter::FilterCoefficients, w = Compat.range(0, stop=π, length=250))
@@ -82,7 +82,7 @@ end
 """
     freqs(filter, w)
 
-Frequency response of an analog `filter` at normalised angular frequency
+Frequency response of an analog `filter` at normalised frequency
 or frequencies `w` in radians/sample.
 """
 function freqs(filter::FilterCoefficients, w::Number)

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -210,3 +210,42 @@ end
     @test f1p.b == f1f.b
     @test f1p.a == f1f.a
 end
+
+@testset "coef() testing" begin
+    # relies on conversion for non-polynomial ratio filter coeff objects
+    # so no need to test conversion correctness
+
+    @testset "Biquad" begin
+        bs = [1, 2, 3, 4, 5]
+        B = Biquad(bs...)
+        @test coefa(B) == [1, 4, 5]
+        @test coefb(B) == [1, 2, 3]
+
+        bs = Float64[20, 16, 13, 31, 33]
+        B = Biquad(bs...)
+        @test coefa(B) == [1.0, 31, 33]
+        @test coefb(B) == [20.0, 16, 13]
+    end
+
+    @testset "SecondOrderSections" begin
+        bs = [2.0, 0, 0, 0, 0]
+        B = SecondOrderSections(repeat([Biquad(bs...)], 2), 0.25)
+        @test coefb(B) == [1.0]
+        @test coefa(B) == [1.0]
+
+        bs = [0, 1, 0, 0, 0]
+        B = SecondOrderSections(repeat([Biquad(bs...)], 2), 1)
+        @test coefb(B) == [1]
+        @test coefa(B) == [1, 0, 0]
+    end
+
+    @testset "ZeroPoleGain" begin
+        f = ZeroPoleGain([0], [-1, 1], 1)
+        @test coefa(f) == [1, 0, -1]
+        @test coefb(f) == [1, 0]
+
+        f = ZeroPoleGain(Int[], [-0.25, 0.25], 1)
+        @test coefa(f) == [1.0, 0, -1/16]
+        @test coefb(f) == [1.0]
+    end
+end


### PR DESCRIPTION
- Changed `ZeroPoleGain` indexing to be more inline with `FilterCoefficients` and typical math examples.
- Changed `FilterCoeffiecients` indexing to have `m` as index for numerator polynomial and `n` for denominator, to match typical examples and to differentiate the two. 
- added `coefa`/`coefb` for all filter types, not just `FilterCoefficients`
- felt calling `w` frequency was confusing, so added angular
