### PR TITLE
Remove `complextype`/`realtype` functions

### DIFF
--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -4,10 +4,6 @@ abstract type FilterCoefficients end
 
 Base.convert(::Type{T}, f::FilterCoefficients) where {T<:FilterCoefficients} = T(f)
 
-realtype(x::DataType) = x
-realtype(::Type{Complex{T}}) where {T} = T
-complextype(T::DataType) = Complex{T}
-complextype(::Type{Complex{T}}) where {T} = Complex{T}
 
 #
 # Zero-pole gain form
@@ -92,12 +88,12 @@ function PolynomialRatio{T}(f::ZeroPoleGain) where T<:Real
     PolynomialRatio{T}(Poly(real(b.a)), Poly(real(a.a)))
 end
 PolynomialRatio(f::ZeroPoleGain{Z,P,K}) where {Z,P,K} =
-    PolynomialRatio{promote_type(realtype(Z),realtype(P),K)}(f)
+    PolynomialRatio{promote_type(real(Z),real(P),K)}(f)
 
 ZeroPoleGain{Z,P,K}(f::PolynomialRatio) where {Z,P,K} =
     ZeroPoleGain{Z,P,K}(roots(f.b), roots(f.a), real(f.b[end]))
 ZeroPoleGain(f::PolynomialRatio{T}) where {T} =
-    ZeroPoleGain{complextype(T),complextype(T),T}(f)
+    ZeroPoleGain{complex(T),complex(T),T}(f)
 
 *(f::PolynomialRatio, g::Number) = PolynomialRatio(g*f.b, f.a)
 *(g::Number, f::PolynomialRatio) = PolynomialRatio(g*f.b, f.a)
@@ -236,7 +232,7 @@ function ZeroPoleGain{Z,P,K}(f::SecondOrderSections) where {Z,P,K}
     ZeroPoleGain{Z,P,K}(z, p, k)
 end
 ZeroPoleGain(f::SecondOrderSections{T,G}) where {T,G} =
-    ZeroPoleGain{complextype(T),complextype(T),G}(f)
+    ZeroPoleGain{complex(T),complex(T),G}(f)
 
 function Biquad{T}(f::SecondOrderSections) where T
     if length(f.biquads) != 1
@@ -366,7 +362,7 @@ function SecondOrderSections{T,G}(f::ZeroPoleGain{Z,P}) where {T,G,Z,P}
     SecondOrderSections{T,G}(biquads, f.k)
 end
 SecondOrderSections(f::ZeroPoleGain{Z,P,K}) where {Z,P,K} =
-    SecondOrderSections{promote_type(realtype(Z), realtype(P)), K}(f)
+    SecondOrderSections{promote_type(real(Z), real(P)), K}(f)
 
 
 SecondOrderSections{T,G}(f::Biquad) where {T,G} = SecondOrderSections{T,G}([f], one(G))


### PR DESCRIPTION
`complextype` & `realtype` replicate `Base.complex`, `Base.real` functionality, and have no tests 
(Last of the branches pulled out of #259)