### PR TITLE
Increase conv performance by making fewer intermediate arrays

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -128,11 +128,17 @@ function _circ_conv(
     upad::StridedVector{T}, vpad::StridedVector{T}, np2::Integer
 ) where T<:Real
     p = plan_rfft(upad)
-    irfft((p*upad).*(p*vpad), np2)
+    uf = p*upad
+    vf = p*vpad
+    uf .*= vf # Multiply in place
+    irfft(uf, np2)
 end
 function _circ_conv(upad, vpad, ::Integer)
     p = plan_fft!(upad)
-    ifft!((p*upad).*(p*vpad))
+    uf = p*upad
+    vf = p*vpad
+    uf .*= vf # Multiply in place
+    ifft!(uf)
 end
 
 """

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -136,13 +136,13 @@ function _conv(
     irfft(uf, npad)
 end
 function _conv(u, v, npad, nu, nv)
-    padded = _zeropad(u, npad, nu)
-    p! = plan_fft!(padded)
-    uf = copy(p! * padded)
-    _zeropad!(padded, v, npad, nv)
-    p! * padded # Operates in place on padded
-    uf .*= padded
-    ifft!(uf)
+    upad = _zeropad(u, npad, nu)
+    vpad = _zeropad(v, npad, nv)
+    p! = plan_fft!(upad)
+    p! * upad # Operates in place on upad
+    p! * vpad
+    upad .*= vpad
+    ifft!(upad)
 end
 
 """

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -148,7 +148,8 @@ function conv(u::StridedVector{T}, v::StridedVector{T}) where T<:BLAS.BlasFloat
     upad = _zeropad(u, np2, nu)
     vpad = _zeropad(v, np2, nv)
     y = _circ_conv(upad, vpad, np2)
-    return y[1:n]
+    resize!(y, n)
+    y
 end
 conv(u::StridedVector{T}, v::StridedVector{T}) where {T<:Integer} = round.(Int, conv(float(u), float(v)))
 conv(u::StridedVector{<:Integer}, v::StridedVector{<:BLAS.BlasFloat}) = conv(float(u), v)


### PR DESCRIPTION
`conv` pads its inputs to use fourier convolution with linear convolution.
Previously, this padding was done by making separate arrays for each pad, and
then concatenating them with the input arrays. I have eliminated the
intermediate pad arrays, and thereby eliminated the creation of two arrays for
each call of `conv`.

I have additionally added a new function, `_circ_conv`, which performs circular
convolution using fourier methods. By separating this out form the `conv`
function, dispatch on the element type can be done my Julia, instead of by a
branch in `conv`. This also allows future use of `_circ_conv` for intentional
circular convolution.