### PR TITLE
Make xcorr padding optional

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -250,7 +250,7 @@ function xcorr(u, v; padmode::Symbol = :default_longest)
         if su < sv
             u = _zeropad(u, sv, su)
         elseif sv < su
-            u = _zeropad(v, su, sv)
+            v = _zeropad(v, su, sv)
         end
         conv(u, Compat.reverse(conj(v), dims=1))
     elseif padmode == :none

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -207,14 +207,14 @@ conv2(A::StridedMatrix{T}, B::StridedMatrix{T}) where {T<:Integer} =
 conv2(u::StridedVector{T}, v::StridedVector{T}, A::StridedMatrix{T}) where {T<:Integer} =
     round.(Int, conv2(float(u), float(v), float(A)))
 
-function check_mode_kwarg(mode::Symbol, su::Integer, sv::Integer)
-    if mode == :default_longest
+function check_padmode_kwarg(padmode::Symbol, su::Integer, sv::Integer)
+    if padmode == :default_longest
         if su != sv
             Base.depwarn(
             """
             The default behavior for xcorr will changed in future versions.
             For more details, see the documentation for xcorr. To avoid this
-            warning, specify mode = :full or mode = :longest where
+            warning, specify padmode = :none or padmode = :longest where
             appropriate
             """
                 ,
@@ -223,32 +223,32 @@ function check_mode_kwarg(mode::Symbol, su::Integer, sv::Integer)
         end
         :longest
     else
-        mode
+        padmode
     end
 end
 
 """
-    xcorr(u,v; mode = :longest)
+    xcorr(u,v; padmode = :longest)
 
 Compute the cross-correlation of two vectors. The size of the output depends on
-`mode` keyword argument: if `mode = :full` then the result will be the same size
-as [`conv`](@ref) of `u` and `v`. If `mode = :longest` then the result will have
+`padmode` keyword argument: if `padmode = :none` then the result will be the same size
+as [`conv`](@ref) of `u` and `v`. If `padmode = :longest` then the result will have
 length `2*max(length(X), length(Y))-1`, where the beginning of the result will
-be padded with zeros. If `mode = :full`, it will be `length(X) - length(Y) - 1`.
+be padded with zeros. If `padmode = :none`, it will be `length(X) - length(Y) - 1`.
 """
-function xcorr(u, v; mode::Symbol = :default_longest)
+function xcorr(u, v; padmode::Symbol = :default_longest)
     su = size(u,1); sv = size(v,1)
-    mode = check_mode_kwarg(mode, su, sv)
-    if mode == :longest
+    padmode = check_padmode_kwarg(padmode, su, sv)
+    if padmode == :longest
         if su < sv
             u = [u;zeros(eltype(u),sv-su)]
         elseif sv < su
             v = [v;zeros(eltype(v),su-sv)]
         end
         conv(u, Compat.reverse(conj(v), dims=1))
-    elseif mode == :full
+    elseif padmode == :none
         conv(u, Compat.reverse(conj(v), dims=1))
     else
-        throw(ArgumentError("mode keyword argument must be either :full or :longest"))
+        throw(ArgumentError("padmode keyword argument must be either :none or :longest"))
     end
 end

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -211,10 +211,13 @@ function check_mode_kwarg(mode::Symbol, su::Integer, sv::Integer)
     if mode == :default_longest
         if su != sv
             Base.depwarn(
-                "The default behavior for xcorr has changed. For more " *
-                "details, see the documentation for xcorr. To avoid this " *
-                "warning, specify mode = :full or mode = :longest where " *
-                "appropriate",
+            """
+            The default behavior for xcorr will changed in future versions.
+            For more details, see the documentation for xcorr. To avoid this
+            warning, specify mode = :full or mode = :longest where
+            appropriate
+            """
+                ,
                 :xcorr
             )
         end
@@ -225,13 +228,13 @@ function check_mode_kwarg(mode::Symbol, su::Integer, sv::Integer)
 end
 
 """
-    xcorr(u,v; mode = :full)
+    xcorr(u,v; mode = :longest)
 
 Compute the cross-correlation of two vectors. The size of the output depends on
 `mode` keyword argument: if `mode = :full` then the result will be the same size
 as [`conv`](@ref) of `u` and `v`. If `mode = :longest` then the result will have
 length `2*max(length(X), length(Y))-1`, where the beginning of the result will
-be padded with zeros.
+be padded with zeros. If `mode = :full`, it will be `length(X) - length(Y) - 1`.
 """
 function xcorr(u, v; mode::Symbol = :default_longest)
     su = size(u,1); sv = size(v,1)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -207,17 +207,45 @@ conv2(A::StridedMatrix{T}, B::StridedMatrix{T}) where {T<:Integer} =
 conv2(u::StridedVector{T}, v::StridedVector{T}, A::StridedMatrix{T}) where {T<:Integer} =
     round.(Int, conv2(float(u), float(v), float(A)))
 
-"""
-    xcorr(u,v)
-
-Compute the cross-correlation of two vectors.
-"""
-function xcorr(u, v)
-    su = size(u,1); sv = size(v,1)
-    if su < sv
-        u = [u;zeros(eltype(u),sv-su)]
-    elseif sv < su
-        v = [v;zeros(eltype(v),su-sv)]
+function check_mode_kwarg(mode::Symbol, su::Integer, sv::Integer)
+    if mode == :default_full
+        if su != sv
+            Base.depwarn(
+                "The default behavior for xcorr has changed. For more " *
+                "details, see the documentation for xcorr. To avoid this " *
+                "warning, specify mode = :full or mode = :legacy where " *
+                "appropriate",
+                :xcorr
+            )
+        end
+        :full
+    else
+        mode
     end
-    conv(u, Compat.reverse(conj(v), dims=1))
+end
+
+"""
+    xcorr(u,v; mode = :full)
+
+Compute the cross-correlation of two vectors. The size of the output depends on
+`mode` keyword argument: if `mode = :full` then the result will be the same size
+as [`conv`](@ref) of `u` and `v`. If `mode = :legacy` then the result will have
+length `2*max(length(X), length(Y))-1`, where the beginning of the result will
+be padded with zeros.
+"""
+function xcorr(u, v; mode::Symbol = :default_full)
+    su = size(u,1); sv = size(v,1)
+    mode = check_mode_kwarg(mode, su, sv)
+    if mode == :legacy
+        if su < sv
+            u = [u;zeros(eltype(u),sv-su)]
+        elseif sv < su
+            v = [v;zeros(eltype(v),su-sv)]
+        end
+        conv(u, Compat.reverse(conj(v), dims=1))
+    elseif mode == :full
+        conv(u, Compat.reverse(conj(v), dims=1))
+    else
+        throw(ArgumentError("mode keyword argument must be either :full or :legacy"))
+    end
 end

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -208,17 +208,17 @@ conv2(u::StridedVector{T}, v::StridedVector{T}, A::StridedMatrix{T}) where {T<:I
     round.(Int, conv2(float(u), float(v), float(A)))
 
 function check_mode_kwarg(mode::Symbol, su::Integer, sv::Integer)
-    if mode == :default_full
+    if mode == :default_longest
         if su != sv
             Base.depwarn(
                 "The default behavior for xcorr has changed. For more " *
                 "details, see the documentation for xcorr. To avoid this " *
-                "warning, specify mode = :full or mode = :legacy where " *
+                "warning, specify mode = :full or mode = :longest where " *
                 "appropriate",
                 :xcorr
             )
         end
-        :full
+        :longest
     else
         mode
     end
@@ -229,14 +229,14 @@ end
 
 Compute the cross-correlation of two vectors. The size of the output depends on
 `mode` keyword argument: if `mode = :full` then the result will be the same size
-as [`conv`](@ref) of `u` and `v`. If `mode = :legacy` then the result will have
+as [`conv`](@ref) of `u` and `v`. If `mode = :longest` then the result will have
 length `2*max(length(X), length(Y))-1`, where the beginning of the result will
 be padded with zeros.
 """
-function xcorr(u, v; mode::Symbol = :default_full)
+function xcorr(u, v; mode::Symbol = :default_longest)
     su = size(u,1); sv = size(v,1)
     mode = check_mode_kwarg(mode, su, sv)
-    if mode == :legacy
+    if mode == :longest
         if su < sv
             u = [u;zeros(eltype(u),sv-su)]
         elseif sv < su
@@ -246,6 +246,6 @@ function xcorr(u, v; mode::Symbol = :default_full)
     elseif mode == :full
         conv(u, Compat.reverse(conj(v), dims=1))
     else
-        throw(ArgumentError("mode keyword argument must be either :full or :legacy"))
+        throw(ArgumentError("mode keyword argument must be either :full or :longest"))
     end
 end

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -35,11 +35,11 @@ if :xcorr in names(DSP) # VERSION >= v"0.7.0-DEV.602"
     @testset "xcorr" begin
         @test xcorr([1, 2], [3, 4]) == [4, 11, 6]
         @test xcorr([1, 2, 3], [4, 5]) == [0, 5, 14, 23, 12]
-        @test xcorr([1, 2, 3], [4, 5], mode = :longest) == [0, 5, 14, 23, 12]
-        @test xcorr([1, 2, 3], [4, 5], mode = :none) == [5, 14, 23, 12]
+        @test xcorr([1, 2, 3], [4, 5], padmode = :longest) == [0, 5, 14, 23, 12]
+        @test xcorr([1, 2, 3], [4, 5], padmode = :none) == [5, 14, 23, 12]
         @test xcorr([1, 2], [3, 4, 5]) == [5, 14, 11, 6, 0]
-        @test xcorr([1, 2], [3, 4, 5], mode = :longest) == [5, 14, 11, 6, 0]
-        @test xcorr([1, 2], [3, 4, 5], mode = :none) == [5, 14, 11, 6]
+        @test xcorr([1, 2], [3, 4, 5], padmode = :longest) == [5, 14, 11, 6, 0]
+        @test xcorr([1, 2], [3, 4, 5], padmode = :none) == [5, 14, 11, 6]
         @test xcorr([1.0im], [1.0im]) == [1]
         @test xcorr([1, 2, 3]*1.0im, ComplexF64[4, 5]) ≈ [0, 5, 14, 23, 12]*im
         @test xcorr([1, 2]*1.0im, ComplexF64[3, 4, 5]) ≈ [5, 14, 11, 6, 0]*im

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -36,10 +36,10 @@ if :xcorr in names(DSP) # VERSION >= v"0.7.0-DEV.602"
         @test xcorr([1, 2], [3, 4]) == [4, 11, 6]
         @test xcorr([1, 2, 3], [4, 5]) == [0, 5, 14, 23, 12]
         @test xcorr([1, 2, 3], [4, 5], mode = :longest) == [0, 5, 14, 23, 12]
-        @test xcorr([1, 2, 3], [4, 5], mode = :full) == [5, 14, 23, 12]
+        @test xcorr([1, 2, 3], [4, 5], mode = :none) == [5, 14, 23, 12]
         @test xcorr([1, 2], [3, 4, 5]) == [5, 14, 11, 6, 0]
         @test xcorr([1, 2], [3, 4, 5], mode = :longest) == [5, 14, 11, 6, 0]
-        @test xcorr([1, 2], [3, 4, 5], mode = :full) == [5, 14, 11, 6]
+        @test xcorr([1, 2], [3, 4, 5], mode = :none) == [5, 14, 11, 6]
         @test xcorr([1.0im], [1.0im]) == [1]
         @test xcorr([1, 2, 3]*1.0im, ComplexF64[4, 5]) ≈ [0, 5, 14, 23, 12]*im
         @test xcorr([1, 2]*1.0im, ComplexF64[3, 4, 5]) ≈ [5, 14, 11, 6, 0]*im

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -35,7 +35,11 @@ if :xcorr in names(DSP) # VERSION >= v"0.7.0-DEV.602"
     @testset "xcorr" begin
         @test xcorr([1, 2], [3, 4]) == [4, 11, 6]
         @test xcorr([1, 2, 3], [4, 5]) == [0, 5, 14, 23, 12]
+        @test xcorr([1, 2, 3], [4, 5], mode = :longest) == [0, 5, 14, 23, 12]
+        @test xcorr([1, 2, 3], [4, 5], mode = :full) == [5, 14, 23, 12]
         @test xcorr([1, 2], [3, 4, 5]) == [5, 14, 11, 6, 0]
+        @test xcorr([1, 2], [3, 4, 5], mode = :longest) == [5, 14, 11, 6, 0]
+        @test xcorr([1, 2], [3, 4, 5], mode = :full) == [5, 14, 11, 6]
         @test xcorr([1.0im], [1.0im]) == [1]
         @test xcorr([1, 2, 3]*1.0im, ComplexF64[4, 5]) ≈ [0, 5, 14, 23, 12]*im
         @test xcorr([1, 2]*1.0im, ComplexF64[3, 4, 5]) ≈ [5, 14, 11, 6, 0]*im


### PR DESCRIPTION
As brought up in #253, xcorr currently has the unintuitive behavior of doing
padding in addition to the padding done by `conv`. This means that for inputs of
different lengths, `xcorr` results are not the same length as `conv`, and that
the beginning of the result is filled with zeros. While Numpy and Matlab both
return padded results, they both fill the end of result with zeros, instead of
the beginning.

This commit changes the default behavior to be more in line with the
mathematical definition of cross-correlations, and also makes `xcorr` more in
line with the behavior of `conv`. This new behvaior can be disabled by
setting the new `mode` keyword to `:legacy`. Deprecation warnings are thrown if
the result of `xcorr` would be altered by the new behavior.