### PR TITLE
Improve decision boundary between time domain and frequency filtering

### DIFF
--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -391,10 +391,11 @@ const SMALL_FILT_CUTOFF = 54
 #
 # filt implementation for FIR filters (faster than Base)
 #
-@generated function filt!(out, b::NTuple{N,T}, x) where {N, T}
-    silen = N-1
+
+for n = 2:SMALL_FILT_CUTOFF
+    silen = n-1
     si = [Symbol("si$i") for i = 1:silen]
-    return quote
+    @eval function filt!(out, b::NTuple{$n,T}, x) where T
         size(x) != size(out) && error("out size must match x")
         ncols = Base.trailingsize(x, 2)
         for col = 0:ncols-1

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -386,7 +386,7 @@ function filt_stepstate(f::SecondOrderSections{T}) where T
     si
 end
 
-const SMALL_FILT_CUTOFF = 15
+const SMALL_FILT_CUTOFF = 54
 
 #
 # filt implementation for FIR filters (faster than Base)

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -391,11 +391,10 @@ const SMALL_FILT_CUTOFF = 15
 #
 # filt implementation for FIR filters (faster than Base)
 #
-
-for n = 2:SMALL_FILT_CUTOFF
-    silen = n-1
+@generated function filt!(out, b::NTuple{N,T}, x) where {N, T}
+    silen = N-1
     si = [Symbol("si$i") for i = 1:silen]
-    @eval function filt!(out, b::NTuple{$n,T}, x) where T
+    return quote
         size(x) != size(out) && error("out size must match x")
         ncols = Base.trailingsize(x, 2)
         for col = 0:ncols-1

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -386,11 +386,13 @@ function filt_stepstate(f::SecondOrderSections{T}) where T
     si
 end
 
+const SMALL_FILT_CUTOFF = 15
+
 #
 # filt implementation for FIR filters (faster than Base)
 #
 
-for n = 2:15
+for n = 2:SMALL_FILT_CUTOFF
     silen = n-1
     si = [Symbol("si$i") for i = 1:silen]
     @eval function filt!(out, b::NTuple{$n,T}, x) where T
@@ -412,7 +414,7 @@ for n = 2:15
 end
 
 let chain = :(throw(ArgumentError("invalid tuple size")))
-    for n = 15:-1:2
+    for n = SMALL_FILT_CUTOFF:-1:2
         chain = quote
             if length(h) == $n
                 filt!(out, ($([:(h[$i]) for i = 1:n]...),), x)
@@ -452,7 +454,7 @@ end
 function _tdfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
     if length(h) == 1
         return mul!(out, h[1], x)
-    elseif length(h) <= 15
+    elseif length(h) <= SMALL_FILT_CUTOFF
         return small_filt!(out, h, x)
     end
 

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -607,14 +607,10 @@ function filt_choose_alg!(
     x::AbstractArray{<:Real}
 )
     nb = length(b)
-    nx = size(x, 1)
 
-    filtops_per_sample = min(nx, nb)
-
-    nfft = optimalfftfiltlength(nb, nx)
-    fftops_per_sample = os_fft_complexity(log2(nfft), nb)
-
-    if filtops_per_sample > fftops_per_sample
+    if nb > SMALL_FILT_CUTOFF
+        nx = size(x, 1)
+        nfft = optimalfftfiltlength(nb, nx)
         _fftfilt!(out, b, x, nfft)
     else
         _tdfilt!(out, b, x)


### PR DESCRIPTION
In my testing, `filt` is choosing to use frequency domain filtering in instances when time domain filtering would be faster. I have moved the decision boundary between the two algorithms to be better reflect benchmarking results from my laptop. To be honest, I'm not sure how well these benchmarks generalize.

In the process, I have also changed how `nfft` is chosen for the overlap-save algorithm. The new heuristic is simpler, and seems to follow the cost estimates provided by FFTW.

The choice between time and frequency domain filtering is still not perfect. Right now the decision seems to be correct when filtering large amounts of data. However, for smaller amounts of data, it may be advantageous to do time domain filtering to avoid the overhead of frequency domain filtering, even if it would be more expensive per output sample for large amounts of data.