### PR TITLE
Check buffer lengths in stream filtering functions before access

### DIFF
--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -612,7 +612,6 @@ function filt!(
     kernel              = self.kernel
     pfb                 = kernel.pfb
     dpfb                = kernel.dpfb
-    bufLen              = length(buffer)
     xLen                = length(x)
     bufIdx              = 0
     history::Vector{Tx} = self.history

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -539,9 +539,12 @@ end
 
 function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRDecimator{Th}}, x::AbstractVector{Tx}) where {Tb,Th,Tx}
     kernel              = self.kernel
+    bufLen              = length(buffer)
     xLen                = length(x)
     history::Vector{Tx} = self.history
     bufIdx              = 0
+
+    bufLen >= xLen || error("buffer length must be >= x length")
 
     if xLen < kernel.inputDeficit
         self.history = shiftin!(history, x)
@@ -600,13 +603,20 @@ function update(kernel::FIRArbitrary)
     kernel.α    = kernel.ϕAccumulator - kernel.ϕIdx
 end
 
-function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRArbitrary{Th}}, x::AbstractVector{Tx}) where {Tb,Th,Tx}
+function filt!(
+    buffer::AbstractVector{Tb},
+    self::FIRFilter{FIRArbitrary{Th}},
+    x::AbstractVector{Tx}
+) where {Tb,Th,Tx}
     kernel              = self.kernel
     pfb                 = kernel.pfb
     dpfb                = kernel.dpfb
+    bufLen              = length(buffer)
     xLen                = length(x)
     bufIdx              = 0
     history::Vector{Tx} = self.history
+
+    bufLen >= xLen || error("buffer length must be >= x length")
 
     # Do we have enough input samples to produce one or more output samples?
     if xLen < kernel.inputDeficit

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -553,7 +553,7 @@ function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRDecimator{Th}}, x:
     outLen              = outputlength(self, xLen)
     inputIdx            = kernel.inputDeficit
 
-    nbufout = fld(xLen - inputIdx, kernel.decimation)
+    nbufout = fld(xLen - inputIdx, kernel.decimation) + 1
     bufLen >= nbufout || throw(ArgumentError("buffer length insufficient"))
 
     while inputIdx <= xLen

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -554,7 +554,7 @@ function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRDecimator{Th}}, x:
     inputIdx            = kernel.inputDeficit
 
     nbufout = fld(xLen - inputIdx, kernel.decimation)
-    bufLen >= nbufout || error("buffer length insufficient")
+    bufLen >= nbufout || throw(ArgumentError("buffer length insufficient"))
 
     while inputIdx <= xLen
         bufIdx += 1


### PR DESCRIPTION
A number of exported functions in `stream_filt.jl` use `@inbounds` access to
buffers without verifying their lengths. This can cause segfaults, as seen in
issue #262.