### PR TITLE
Ensure only valid xcorr results are returned

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -257,7 +257,9 @@ with the zero-lag condition at the center.
     in a future release of DSP. In preparation for this change, leaving
     `padmode` unspecified is currently deprecated.
 """
-function xcorr(u, v; padmode::Symbol = :default_longest)
+function xcorr(
+    u::AbstractVector, v::AbstractVector; padmode::Symbol = :default_longest
+)
     su = size(u,1); sv = size(v,1)
     padmode = check_padmode_kwarg(padmode, su, sv)
     if padmode == :longest

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -178,6 +178,9 @@ end
         @test size(@inferred(xcorr(su, x))) == (19,)
         @test size(@inferred(xcorr(x, su))) == (19,)
     end
+
+    # xcorr only supports 1d inputs at the moment
+    @test_throws MethodError xcorr(rand(2, 2), rand(2, 2))
 end
 
 @testset "deconv" begin


### PR DESCRIPTION
`xcorr` only works with 1d inputs at the moment, but because `conv` now takes ND
inputs, `xcorr` can no longer rely on `conv` to restrict input types. I have
narrowed the type bounds on `xcorr` until it properly supports ND cross
correlation.