### PR TITLE
Release unused memory when using conv

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -163,7 +163,7 @@ function _conv(u, v, paddims)
     ifft!(upad)
 end
 
-_conv_clip!(y::AbstractVector, minpad) = resize!(y, minpad[1])
+_conv_clip!(y::AbstractVector, minpad) = sizehint!(resize!(y, minpad[1]), minpad[1])
 _conv_clip!(y::AbstractArray, minpad) = y[CartesianIndices(minpad)]
 
 """


### PR DESCRIPTION
`resize!` changes the length of an array, however it does not free the
underlying unused memory if the array is reduced in length. `sizehint!` will
free the memory corresponding to the portion of the array dropped by `resize!`.

`conv` drops the last portion of the result, corresponding to the padded portion
of the result. By using `sizehint!` after resizing the result, the padding is
freed from memory.