### PR TITLE
Abstract array conv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: julia
 os:
   - linux
 julia:
+  - 0.7
   - 1.0
   - 1.1
   - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 version = "0.5.2"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
@@ -12,12 +13,14 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+Compat = ">= 1.3.0"
 Polynomials = ">= 0.1.0"
 julia = "0.7,1"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DelimitedFiles", "Test"]
+test = ["DelimitedFiles", "OffsetArrays", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Polynomials 0.1.0
 Reexport
 SpecialFunctions
 FFTW
+Compat 1.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 1
 Polynomials 0.1.0
 Reexport
 SpecialFunctions

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 1
+julia 0.7
 Polynomials 0.1.0
 Reexport
 SpecialFunctions

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ Polynomials 0.1.0
 Reexport
 SpecialFunctions
 FFTW
-Compat 1.2
+Compat 1.3

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -4,6 +4,7 @@ module DSP
 
 using FFTW
 using LinearAlgebra: mul!, rmul!
+using Compat: range
 
 export conv, conv2, deconv, filt, filt!, xcorr
 

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -303,6 +303,16 @@ function check_padmode_kwarg(padmode::Symbol, su::Integer, sv::Integer)
     end
 end
 
+dsp_reverse(v, ::NTuple{<:Any, Base.OneTo{Int}}) = reverse(v, dims = 1)
+function dsp_reverse(v, vaxes)
+    vsize = length(v)
+    reflected_start = - first(vaxes[1]) - vsize + 1
+    reflected_axes = (range(reflected_start, reflected_start + vsize - 1),)
+    out = similar(v, reflected_axes)
+    copyto!(out, reflected_start, Iterators.reverse(v), 1, vsize)
+end
+
+
 """
     xcorr(u,v; padmode = :longest)
 
@@ -329,9 +339,9 @@ function xcorr(
         elseif sv < su
             v = _zeropad(v, su)
         end
-        conv(u, reverse(conj(v), dims=1))
+        conv(u, dsp_reverse(conj(v), axes(v)))
     elseif padmode == :none
-        conv(u, reverse(conj(v), dims=1))
+        conv(u, dsp_reverse(conj(v), axes(v)))
     else
         throw(ArgumentError("padmode keyword argument must be either :none or :longest"))
     end

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -133,7 +133,7 @@ function _zeropad!(padded::AbstractArray{<:Any, N},
                    u::AbstractArray{<:Any, N}) where N
     # Copy the data to the beginning of the padded array
     fill!(padded, zero(eltype(padded)))
-    pad_data_ranges = range.(1, size(u))
+    pad_data_ranges = UnitRange.(1, size(u))
     copyto!(padded, CartesianIndices(pad_data_ranges), u, CartesianIndices(u))
 
     padded
@@ -182,9 +182,9 @@ end
 # For arrays with weird offsets
 function _conv_clip!(y::AbstractArray, minpad, axesu, axesv)
     out_offsets = first.(axesu) .+ first.(axesv)
-    out_axes = range.(out_offsets, out_offsets .+ minpad .- 1)
+    out_axes = UnitRange.(out_offsets, out_offsets .+ minpad .- 1)
     out = similar(y, out_axes)
-    copyto!(out, CartesianIndices(out), y, CartesianIndices(range.(1, minpad)))
+    copyto!(out, CartesianIndices(out), y, CartesianIndices(UnitRange.(1, minpad)))
 end
 
 """

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -283,8 +283,8 @@ end
     xcorr(u,v; padmode = :longest)
 
 Compute the cross-correlation of two vectors, by calculating the similarity
-between `u` and `v` with various offsets of `v`. `v` is reversed, so delaying
-`u` relative to `v` will shift the result to the right.
+between `u` and `v` with various offsets of `v`. Delaying `u` relative to `v`
+will shift the result to the right.
 
 The size of the output depends on the padmode keyword argument: with padmode =
 :none the length of the result will be length(u) + length(v) - 1, as with conv.

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -222,6 +222,8 @@ the vectors `u` and `v`.
 Uses 2-D FFT algorithm.
 """
 function conv(u::AbstractVector{T}, v::AbstractVector{T}, A::AbstractMatrix{T}) where T
+    # Arbitrary indexing offsets not implemented
+    @assert !Base.has_offset_axes(u, v, A)
     m = length(u)+size(A,1)-1
     n = length(v)+size(A,2)-1
     B = zeros(T, m, n)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -180,7 +180,8 @@ _conv_clip!(y::AbstractArray, minpad) = y[CartesianIndices(minpad)]
 
 Convolution of two arrays. Uses FFT algorithm.
 """
-function conv(u::AbstractArray{T, N}, v::AbstractArray{T, N}) where {T<:BLAS.BlasFloat, N}
+function conv(u::AbstractArray{T, N},
+              v::AbstractArray{T, N}) where {T<:BLAS.BlasFloat, N}
     su = size(u)
     sv = size(v)
     minpad = su .+ sv .- 1
@@ -188,16 +189,22 @@ function conv(u::AbstractArray{T, N}, v::AbstractArray{T, N}) where {T<:BLAS.Bla
     y = _conv(u, v, padsize)
     _conv_clip!(y, minpad)
 end
-
+function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
+              v::AbstractArray{<:BLAS.BlasFloat, N}) where N
+    fu, fv = promote(u, v)
+    conv(fu, fv)
+end
+conv(u::AbstractArray{T, N}, v::AbstractArray{T, N}) where {T<:Number, N} =
+    conv(float(u), float(v))
 conv(u::AbstractArray{T, N}, v::AbstractArray{T, N}) where {T<:Integer, N} =
     round.(Int, conv(float(u), float(v)))
 function conv(
-    u::AbstractArray{<:Integer, N}, v::AbstractArray{<:BLAS.BlasFloat, N}
+    u::AbstractArray{<:Number, N}, v::AbstractArray{<:BLAS.BlasFloat, N}
 ) where N
     conv(float(u), v)
 end
 function conv(
-    u::AbstractArray{<:BLAS.BlasFloat, N}, v::AbstractArray{<:Integer, N}
+    u::AbstractArray{<:BLAS.BlasFloat, N}, v::AbstractArray{<:Number, N}
 ) where N
     conv(u, float(v))
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+OffsetArrays

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -55,7 +55,7 @@ end
 
         offset_arr = OffsetArray{Int}(undef, -1:2)
         offset_arr[:] = a
-        @test conv(offset_arr, 1:3) == expectation
+        @test conv(offset_arr, 1:3) == OffsetVector(expectation, 0:5)
     end
 
 
@@ -96,7 +96,7 @@ end
 
         offset_arr = OffsetArray{Int}(undef, -1:1, -1:1)
         offset_arr[:] = a
-        @test conv(offset_arr, b) == expectation
+        @test conv(offset_arr, b) == OffsetArray(expectation, 0:3, 0:3)
     end
 
     @testset "seperable conv" begin

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -1,6 +1,6 @@
 # This file was formerly a part of Julia. License is MIT: https://julialang.org/license
 # TODO: parameterize conv tests
-using Test, DSP
+using Test, DSP, OffsetArrays
 import DSP: filt, filt!, deconv, conv, xcorr
 
 
@@ -50,6 +50,10 @@ end
 
         @test conv(fa, b) ≈ fexp
         @test conv(fb, a) ≈ fexp
+
+        offset_arr = OffsetArray{Int}(undef, -1:2)
+        offset_arr[:] = a
+        @test conv(offset_arr, 1:3) == expectation
     end
 
 
@@ -85,6 +89,10 @@ end
                                                                im_fexp)
         @test conv(fa, b) ≈ fexp
         @test conv(fb, a) ≈ fexp
+
+        offset_arr = OffsetArray{Int}(undef, -1:1, -1:1)
+        offset_arr[:] = a
+        @test conv(offset_arr, b) == expectation
     end
 
     @testset "seperable conv" begin

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -42,6 +42,7 @@ end
         im_expectation = [1, 3, 6, 6, 5, 3]
         @test conv(a, b) == expectation
         fa = convert(Array{Float64}, a)
+        f32a = convert(Array{Float32}, a)
         fb = convert(Array{Float64}, b)
         fexp = convert(Array{Float64}, expectation)
         im_fexp = convert(Array{Float64}, im_expectation)
@@ -49,6 +50,7 @@ end
         @test conv(complex.(fa, 1.), complex.(fb)) ≈ complex.(fexp, im_fexp)
 
         @test conv(fa, b) ≈ fexp
+        @test conv(f32a, b) ≈ fexp
         @test conv(fb, a) ≈ fexp
 
         offset_arr = OffsetArray{Int}(undef, -1:2)
@@ -79,6 +81,7 @@ end
         @test conv(a, b) == expectation
         # Floats
         fa = convert(Array{Float64}, a)
+        f32a = convert(Array{Float32}, a)
         fb = convert(Array{Float64}, b)
         fexp = convert(Array{Float64}, expectation)
         im_fexp = convert(Array{Float64}, im_expectation)
@@ -88,6 +91,7 @@ end
         @test conv(complex.(fa, 1), complex.(fb)) == complex.(fexp,
                                                                im_fexp)
         @test conv(fa, b) ≈ fexp
+        @test conv(f32a, b) ≈ fexp
         @test conv(fb, a) ≈ fexp
 
         offset_arr = OffsetArray{Int}(undef, -1:1, -1:1)

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -167,10 +167,13 @@ end
 end
 
 @testset "xcorr" begin
+    a = [1, 2, 3]
+    b = [4, 5]
+    exp = [5, 14, 23, 12]
     @test xcorr([1, 2], [3, 4]) == [4, 11, 6]
-    @test xcorr([1, 2, 3], [4, 5]) == [0, 5, 14, 23, 12]
-    @test xcorr([1, 2, 3], [4, 5], padmode = :longest) == [0, 5, 14, 23, 12]
-    @test xcorr([1, 2, 3], [4, 5], padmode = :none) == [5, 14, 23, 12]
+    @test xcorr(a, b) == [0, 5, 14, 23, 12]
+    @test xcorr(a, b, padmode = :longest) == [0, 5, 14, 23, 12]
+    @test xcorr(a, b, padmode = :none) == exp
     @test xcorr([1, 2], [3, 4, 5]) == [5, 14, 11, 6, 0]
     @test xcorr([1, 2], [3, 4, 5], padmode = :longest) == [5, 14, 11, 6, 0]
     @test xcorr([1, 2], [3, 4, 5], padmode = :none) == [5, 14, 11, 6]
@@ -193,6 +196,10 @@ end
 
     # xcorr only supports 1d inputs at the moment
     @test_throws MethodError xcorr(rand(2, 2), rand(2, 2))
+
+    off_a = OffsetVector(a, -1:1)
+    off_b = OffsetVector(b, 0:1)
+    @test xcorr(off_a, off_b, padmode = :none) == OffsetVector(exp, -2:1)
 end
 
 @testset "deconv" begin

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -40,7 +40,9 @@ end
         b = [1, 2, 3]
         expectation = [1, 4, 8, 10, 7, 6]
         im_expectation = [1, 3, 6, 6, 5, 3]
+        a32 = convert(Array{Int32}, a)
         @test conv(a, b) == expectation
+        @test conv(a32, b) == expectation
         fa = convert(Array{Float64}, a)
         f32a = convert(Array{Float32}, a)
         fb = convert(Array{Float64}, b)
@@ -78,7 +80,9 @@ end
 
         # Integers
         # Real Integers
+        a32 = convert(Array{Int32}, a)
         @test conv(a, b) == expectation
+        @test conv(a32, b) == expectation
         # Floats
         fa = convert(Array{Float64}, a)
         f32a = convert(Array{Float32}, a)


### PR DESCRIPTION
This allows `conv` and friends to operate on arrays that don't start at index 1.
It also allows the use of other abstract vectors, such as ranges.

This makes it possible to convolutions with lots of different types of arrays:
```julia
julia> using DSP, OffsetArrays

julia> offset_arr = OffsetArray{Int}(undef, -1:2);

julia> offset_arr[:] = [1, 2, 1, 2];

julia> conv(offset_arr, 1:3)
6-element Array{Int64,1}:
  1
  4
  8
 10
  7
  6

```
It also fixes a problem with type promotion that existed prior to this commit. Previously, `conv` would fail for inputs with differing floating point element types. For example, using both `Float32` and `Float64` would cause method errors. This PR fixes this problem by adding an extra promotion method.

Finally, it allows other element types that are not BLAS floats or integers to be used. Due to the zero padding involved, and reuse of buffers for the different inputs, it is still necessary to have the core `conv` kernel operate on BLAS floats, but more types of inputs can now be accepted and converted to BLAS floats.