### PR TITLE
Minor deprecation fixes

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,8 +1,7 @@
-const ZPKFilter = ZeroPoleGain
-const TFFilter = PolynomialRatio
-const BiquadFilter = Biquad
-const SOSFilter = SecondOrderSections
-export ZPKFilter, TFFilter, BiquadFilter, SOSFilter
+Base.@deprecate_binding ZPKFilter ZeroPoleGain
+Base.@deprecate_binding TFFilter PolynomialRatio
+Base.@deprecate_binding BiquadFilter Biquad
+Base.@deprecate_binding SOSFilter SecondOrderSections
 
 @deprecate firfilt(h, x) filt(h, x)
 @deprecate conv2 conv

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,7 +1,7 @@
+# deprecations after 0.5
 Base.@deprecate_binding ZPKFilter ZeroPoleGain
 Base.@deprecate_binding TFFilter PolynomialRatio
 Base.@deprecate_binding BiquadFilter Biquad
 Base.@deprecate_binding SOSFilter SecondOrderSections
 
-@deprecate firfilt(h, x) filt(h, x)
 @deprecate conv2 conv

--- a/src/util.jl
+++ b/src/util.jl
@@ -361,11 +361,11 @@ julia> finddelay([1, 2, 3], [0, 0, 1, 2, 3])
 ```
 """
 function finddelay(x::AbstractVector{<: Real}, y::AbstractVector{<: Real})
-    s = xcorr(y, x)
+    s = xcorr(y, x, padmode=:none)
     max_corr = maximum(abs, s)
     max_idxs = findall(x -> abs(x) == max_corr, s)
 
-    center_idx = cld(length(s), 2)
+    center_idx = length(x)
     # Delay is position of peak cross-correlation relative to center.
     # If the maximum cross-correlation is not unique, use the position
     # closest to the center.

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -178,7 +178,7 @@ end
     x = randn(100)
     f1 = digitalfilter(Lowpass(0.3), Butterworth(2))
     y = filt(f1, x)
-    for ty in (ZPKFilter, PolynomialRatio, Biquad, SecondOrderSections)
+    for ty in (ZeroPoleGain, PolynomialRatio, Biquad, SecondOrderSections)
         @test filt(3*convert(ty, f1), x) ≈ 3*y
         @test filt(convert(ty, f1)*3, x) ≈ 3*y
     end
@@ -186,13 +186,13 @@ end
     # Test composing filters
     f2 = digitalfilter(Highpass(0.5), Butterworth(1))
     y = filt(f2, y)
-    for ty in (ZPKFilter, PolynomialRatio, Biquad, SecondOrderSections)
+    for ty in (ZeroPoleGain, PolynomialRatio, Biquad, SecondOrderSections)
         @test filt(convert(ty, f1)*convert(ty, f2), x) ≈ y
     end
 
     f3 = digitalfilter(Bandstop(0.35, 0.4), Butterworth(1))
     y = filt(f3, y)
-    for ty in (ZPKFilter, PolynomialRatio, Biquad, SecondOrderSections)
+    for ty in (ZeroPoleGain, PolynomialRatio, Biquad, SecondOrderSections)
         @test filt(convert(ty, f1)*convert(ty, f2)*convert(ty, f3), x) ≈ y
     end
     @test filt(convert(Biquad, f1)*(convert(Biquad, f2)*convert(Biquad, f3)), x) ≈ y
@@ -236,8 +236,8 @@ end
     empty!(f.b.a)
     empty!(f.a.a)
     @test_throws ArgumentError convert(Biquad, f)
-    @test_throws ArgumentError convert(SOSFilter, ZPKFilter([0.5 + 0.5im, 0.5 + 0.5im], [0.5 + 0.5im, 0.5 - 0.5im], 1))
-    @test_throws ArgumentError convert(SOSFilter, ZPKFilter([0.5 + 0.5im, 0.5 - 0.5im], [0.5 + 0.5im, 0.5 + 0.5im], 1))
+    @test_throws ArgumentError convert(SecondOrderSections, ZeroPoleGain([0.5 + 0.5im, 0.5 + 0.5im], [0.5 + 0.5im, 0.5 - 0.5im], 1))
+    @test_throws ArgumentError convert(SecondOrderSections, ZeroPoleGain([0.5 + 0.5im, 0.5 - 0.5im], [0.5 + 0.5im, 0.5 + 0.5im], 1))
 
     @test promote_type(SecondOrderSections{Float64,Float32}, SecondOrderSections{Float32,Float64}) == SecondOrderSections{Float64,Float64}
     @test convert(SecondOrderSections{Float32,Float32}, convert(SecondOrderSections, b)).biquads == convert(SecondOrderSections, convert(Biquad{Float32}, b)).biquads


### PR DESCRIPTION
* Use `@deprecate_binding` for the old filter coefficient names and stop using them in tests.
* Drop the deprecation for `firfilt` (deprecated in v0.0.9!)
* Use `xcorr` with `padmode` argument in `finddelay` (apparently missed in #266).