### PR TITLE
fix missed case of #263

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -219,7 +219,7 @@ function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
     conv(u, float(v))
 end
 
-function conv(A::AbstractArray{T}, B::AbstractArray{T}) where T
+function conv(A::AbstractArray, B::AbstractArray)
     maxnd = max(ndims(A), ndims(B))
     return conv(cat(A, dims=maxnd), cat(B, dims=maxnd))
 end

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -160,13 +160,14 @@ end
         b = ones(1, 1, 1, 1, 1, 1)
         @test conv(a, b) == a
 
-
+        # promote dims to largest
         a = cat([fill(n, 3, 3) for n in 1:6]..., dims=3)
         b = ones(Int64, 2, 2)
         expf1 = conv(a[:, :, 1], b)
         exp = cat([expf1 * n for n in 1:6]..., dims=3)
         @test conv(a, b) == exp
-
+        fb = convert(Array{Float64}, b)
+        @test conv(a, fb) == convert(Array{Float64}, exp)
     end
 end
 

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -167,7 +167,7 @@ end
         exp = cat([expf1 * n for n in 1:6]..., dims=3)
         @test conv(a, b) == exp
         fb = convert(Array{Float64}, b)
-        @test conv(a, fb) == convert(Array{Float64}, exp)
+        @test conv(a, fb) ≈ convert(Array{Float64}, exp)
     end
 end
 


### PR DESCRIPTION
in working on implementing #202 I allowed for arrays of different dimensionalities to be convolved by adding size-1 dimensions to the lower-dimension one. In this I missed a case for #263 , where if a float array and int array have different number of dimensions they could not be convolved. 
This PR fixes that oversight and includes a test to avoid the problem with future changes.

