### PR TITLE
Overlap-save convolution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 
 [compat]
 FFTW = "1.1"
@@ -18,6 +19,7 @@ Polynomials = "0.6"
 Reexport = "0.2"
 SpecialFunctions = "0.8"
 julia = "1"
+IterTools = "1"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -2,6 +2,7 @@ module DSP
 
 using FFTW
 using LinearAlgebra: mul!, rmul!
+using IterTools: subsets
 
 export conv, conv2, deconv, filt, filt!, xcorr
 

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -4,7 +4,7 @@ using Polynomials, ..Util
 import Base: *
 using LinearAlgebra: I, mul!, rmul!
 using Statistics: middle
-import ..DSP: filt, filt!, SMALL_FILT_CUTOFF
+import ..DSP: filt, filt!, optimalfftfiltlength, os_fft_complexity, SMALL_FILT_CUTOFF
 using FFTW
 
 include("coefficients.jl")

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -414,32 +414,6 @@ filt(h::AbstractArray, x::AbstractArray) =
 # fftfilt and filt
 #
 
-# Rough estimate of number of multiplications per output sample
-os_fft_complexity(nfft, nb) =  (nfft * log2(nfft) + nfft) / (nfft - nb + 1)
-
-# Determine optimal length of the FFT for fftfilt
-function optimalfftfiltlength(nb, nx)
-    first_pow2 = ceil(Int, log2(nb))
-    last_pow2 = ceil(Int, log2(nx + nb - 1))
-    last_complexity = os_fft_complexity(2 ^ first_pow2, nb)
-    pow2 = first_pow2 + 1
-    while pow2 <= last_pow2
-        new_complexity = os_fft_complexity(2 ^ pow2, nb)
-        new_complexity > last_complexity && break
-        last_complexity = new_complexity
-        pow2 += 1
-    end
-    nfft = pow2 > last_pow2 ? 2 ^ last_pow2 : 2 ^ (pow2 - 1)
-
-    L = nfft - nb + 1
-    if L > nx
-        # If L > nx, better to find next fast power
-        nfft = nextfastfft(nx + nb - 1)
-    end
-
-    nfft
-end
-
 """
     fftfilt(h, x)
 

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -1,6 +1,6 @@
 # This file was formerly a part of Julia. License is MIT: https://julialang.org/license
 
-import Base.trailingsize
+import Base: trailingsize
 import LinearAlgebra.BLAS
 
 const SMALL_FILT_CUTOFF = 58
@@ -170,138 +170,533 @@ function deconv(b::StridedVector{T}, a::StridedVector{T}) where T
     filt(b, a, x)
 end
 
-function _zeropad!(
-    padded::AbstractVector, u::AbstractVector, ::Tuple{Base.OneTo{Int}}
+
+"""
+    _zeropad!(padded::AbstractVector,
+              u::AbstractVector,
+              data_dest::Tuple = (1,),
+              data_region = CartesianIndices(u),
+              ::Tuple{Base.OneTo{Int}})
+
+Place the portion of `u` specified by `data_region` into `padded` starting at
+location `data_dest`, and set the rest of `padded` to zero. This will mutate
+`padded`.
+
+This method handles the case where `padded` uses 1-based indexing, but `u` can
+have arbitrary axes.
+"""
+@inline function _zeropad!(
+    padded::AbstractVector,
+    u::AbstractVector,
+    padded_axes = axes(padded),
+    data_dest::Tuple = (first(padded_axes[1]),),
+    data_region = CartesianIndices(u),
 )
-    datasize = length(u)
+    datasize = length(data_region)
     # Use axes to accommodate arrays that do not start at index 1
-    padsize = length(padded)
-    data_first_i = first(axes(u, 1))
-    copyto!(padded, 1, u, data_first_i, datasize)
-    padded[1 + datasize:padsize] .= 0
+    data_first_i = first(data_region)[1]
+    dest_first_i = data_dest[1]
+    copyto!(padded, dest_first_i, u, data_first_i, datasize)
+    padded[first(padded_axes[1]):dest_first_i - 1] .= 0
+    padded[dest_first_i + datasize : end] .= 0
 
     padded
 end
 
-function _zeropad!(
-    padded::AbstractVector, u::AbstractVector, pad_axes
+@inline function _zeropad!(
+    padded::AbstractArray,
+    u::AbstractArray,
+    padded_axes = axes(padded),
+    data_dest::Tuple = first.(padded_axes),
+    data_region = CartesianIndices(u),
 )
-    datasize = length(u)
-    # Use axes to accommodate arrays that do not start at index 1
-    data_first_i = first(axes(u, 1))
-    pad_first_i = first(pad_axes[1])
-    copyto!(padded, pad_first_i, u, data_first_i, datasize)
-    padded[pad_first_i + datasize : last(pad_axes[1])] .= 0
-
-    padded
-end
-
-function _zeropad!(
-    padded::AbstractArray{<:Any, N},
-    u::AbstractArray{<:Any, N},
-    ::NTuple{<:Any, Base.OneTo{Int}}
-) where N
-    # Copy the data to the beginning of the padded array
     fill!(padded, zero(eltype(padded)))
-    pad_data_ranges = UnitRange.(1, size(u))
-    copyto!(padded, CartesianIndices(pad_data_ranges), u, CartesianIndices(u))
+    dest_axes = UnitRange.(data_dest, data_dest .+ size(data_region) .- 1)
+    dest_region = CartesianIndices(dest_axes)
+    copyto!(padded, dest_region, u, data_region)
 
     padded
 end
 
-function _zeropad!(
-    padded::AbstractArray{<:Any, N},
-    u::AbstractArray{<:Any, N},
-    pad_axes
-) where N
-    # Copy the data to the beginning of the padded array
-    fill!(padded, zero(eltype(padded)))
-    pad_first_i = first.(pad_axes)
-    pad_data_ranges = UnitRange.(pad_first_i, pad_first_i .+ size(u) .- 1)
-    copyto!(padded, CartesianIndices(pad_data_ranges), u, CartesianIndices(u))
+"""
+    _zeropad(u, padded_size, [data_dest, data_region])
 
-    padded
+Creates and returns a new base-1 index array of size `padded_size`, with the
+section of `u` specified by `data_region` copied into the region of the new
+ array as specified by `data_dest`. All other values will be initialized to
+ zero.
+
+If either `data_dest` or `data_region` is not specified, then the defaults
+described in [`_zeropad!`](@ref) will be used.
+"""
+function _zeropad(u, padded_size, args...)
+    padded = similar(u, padded_size)
+    _zeropad!(padded, u, axes(padded), args...)
 end
 
-_zeropad!(padded, u) = _zeropad!(padded, u, axes(padded))
-
-function _zeropad(u, padded_size)
-    _zeropad!(similar(u, padded_size), u)
-end
-
-function _zeropad_keep_offset(u, padded_size, ::NTuple{<:Any, Base.OneTo{Int}})
-    _zeropad(u, padded_size)
-end
-
-function _zeropad_keep_offset(u, padded_size, axes_u)
-    ax_starts = first.(axes_u)
+function _zeropad_keep_offset(u, padded_size, u_axes, args...)
+    ax_starts = first.(u_axes)
     new_axes = UnitRange.(ax_starts, ax_starts .+ padded_size .- 1)
-    _zeropad!(similar(u, new_axes), u, new_axes)
+    _zeropad!(similar(u, new_axes), u, args...)
 end
 
-_zeropad_keep_offset(u, padded_size) = _zeropad_keep_offset(
-    u, padded_size, axes(u)
+function _zeropad_keep_offset(
+    u, padded_size, ::NTuple{<:Any, Base.OneTo{Int}}, args...
 )
+    _zeropad(u, padded_size, args...)
+end
 
-function _conv(
-    u::AbstractArray{T, N}, v::AbstractArray{T, N}, paddims
-) where {T<:Real, N}
-    padded = _zeropad(u, paddims)
+"""
+    _zeropad_keep_offset(u, padded_size, [data_dest, dat_region])
+
+Like [`_zeropad`](@ref), but retains the first index of `u` when creating a new
+array.
+"""
+function _zeropad_keep_offset(u, padded_size, args...)
+    _zeropad_keep_offset(u, padded_size, axes(u), args...)
+end
+
+"""
+Estimate the number of floating point multiplications per output sample for an
+overlap-save algorithm with fft size `nfft`, and filter size `nb`.
+"""
+os_fft_complexity(nfft, nb) =  (nfft * log2(nfft) + nfft) / (nfft - nb + 1)
+
+"""
+Determine the length of FFT that minimizes the number of multiplications per
+output sample for an overlap-save convolution of vectors of size `nb` and `nx`.
+"""
+function optimalfftfiltlength(nb, nx)
+    nfull = nb + nx - 1
+
+    # Step through possible nffts and find the nfft that minimizes complexity
+    # Assumes that complexity is convex
+    first_pow2 = ceil(Int, log2(nb))
+    prev_pow2 = ceil(Int, log2(nfull))
+    prev_complexity = os_fft_complexity(2 ^ first_pow2, nb)
+    pow2 = first_pow2 + 1
+    while pow2 <= prev_pow2
+        new_complexity = os_fft_complexity(2 ^ pow2, nb)
+        new_complexity > prev_complexity && break
+        prev_complexity = new_complexity
+        pow2 += 1
+    end
+    nfft = pow2 > prev_pow2 ? 2 ^ prev_pow2 : 2 ^ (pow2 - 1)
+
+    # L is the number of usable samples produced by each block
+    L = nfft - nb + 1
+    if L > nx
+        # If L > nx, better to find next fast power
+        nfft = nextfastfft(nfull)
+    end
+
+    nfft
+end
+
+"""
+Prepare buffers and FFTW plans for convolution. The two buffers, tdbuff and
+fdbuff may be an alias of each other, because complex convolution only requires
+one buffer. The plans are mutating where possible, and the inverse plan is
+unnormalized.
+"""
+@inline function os_prepare_conv(u::AbstractArray{T, N},
+                                 nffts) where {T<:Real, N}
+    tdbuff = similar(u, nffts)
+    bufsize = ntuple(i -> i == 1 ? nffts[i] >> 1 + 1 : nffts[i], N)
+    fdbuff = similar(u, Complex{T}, NTuple{N, Int}(bufsize))
+
+    p = plan_rfft(tdbuff)
+    ip = plan_brfft(fdbuff, nffts[1])
+
+    tdbuff, fdbuff, p, ip
+end
+
+@inline function os_prepare_conv(u::AbstractArray{<:Complex}, nffts)
+    buff = similar(u, nffts)
+
+    p = plan_fft!(buff)
+    ip = plan_bfft!(buff)
+
+    buff, buff, p, ip # Only one buffer for complex
+end
+
+"""
+Transform the smaller convolution input to frequency domain, and return it in a
+new array. However, the contents of `buff` may be modified.
+"""
+@inline function os_filter_transform!(buff::AbstractArray{<:Real}, p)
+    p * buff
+end
+
+@inline function os_filter_transform!(buff::AbstractArray{<:Complex}, p!)
+    copy(p! * buff) # p operates in place on buff
+end
+
+"""
+Take a block of data, and convolve it with the smaller convolution input. This
+may modify the contents of `tdbuff` and `fdbuff`, and the result will be in
+`tdbuff`.
+"""
+@inline function os_conv_block!(tdbuff::AbstractArray{<:Real},
+                                fdbuff::AbstractArray,
+                                filter_fd,
+                                p,
+                                ip)
+    mul!(fdbuff, p, tdbuff)
+    fdbuff .*= filter_fd
+    mul!(tdbuff, ip, fdbuff)
+end
+
+"Like the real version, but only operates on one buffer"
+@inline function os_conv_block!(buff::AbstractArray{<:Complex},
+                                ::AbstractArray, # Only one buffer for complex
+                                filter_fd,
+                                p!,
+                                ip!)
+    p! * buff # p! operates in place on buff
+    buff .*= filter_fd
+    ip! * buff # ip! operates in place on buff
+end
+
+# Used by `unsafe_conv_kern_os!` to handle blocks of input data that need to be padded.
+#
+# For a given number of edge dimensions, convolve all regions along the
+# perimeter that have that number of edge dimensions
+#
+# For a 3d cube, if n_edges = 1, this means all faces. If n_edges = 2, then
+# all edges. Finally, if n_edges = 3, then all corners.
+#
+# This needs to be a separate function for subsets to generate tuple elements,
+# which is only the case if the number of edges is a Val{n} type. Iterating over
+# the number of edges with Val{n} is inherently type unstable, so this function
+# boundary allows dispatch to make efficient code for each number of edge
+# dimensions.
+function unsafe_conv_kern_os_edge!(
+    # These arrays and buffers will be mutated
+    out::AbstractArray{<:Any, N},
+    tdbuff,
+    fdbuff,
+    perimeter_range,
+    # Number of edge dimensions to pad and convolve
+    n_edges::Val,
+    # Data to be convolved
+    u,
+    filter_fd,
+    # FFTW plans
+    p,
+    ip,
+    # Sizes, ranges, and other pre-calculated constants
+    #
+    ## ranges listing center and edge blocks
+    edge_ranges,
+    center_block_ranges,
+    ## size and axis information
+    all_dims, # 1:N
+    su,
+    u_start,
+    sv,
+    nffts,
+    out_start,
+    out_stop,
+    save_blocksize,
+    sout_deficit, # How many output samples are missing if nffts > sout
+    tdbuff_axes,
+) where N
+    # Iterate over all possible combinations of edge dimensions for a number of
+    # edges
+    #
+    # For a 3d cube with n_edges = 1, this will specify the top and bottom faces
+    # (edge_dims = (1,)), then the left and right faces (edge_dims = (2,)), then
+    # the front and back faces (edge_dims = (3,))
+    for edge_dims in subsets(all_dims, n_edges)
+        # Specify a region on the perimeter by combining an edge block index for
+        # each dimension on an edge, and the central blocks for dimensions not
+        # on an edge.
+        #
+        # First make all entries equal to the center blocks:
+        @inbounds copyto!(perimeter_range, 1, center_block_ranges, 1, N)
+
+        # For the dimensions chosen to be on an edge (edge_dims), get the
+        # ranges of the blocks that would need to be padded (lie on an edge)
+        # in that dimension.
+        #
+        # There can be one to two such ranges for each dimension, because with
+        # some inputs sizes the whole convolution is just one range
+        # (one edge block), or the padding will be needed at both the leading
+        # and trailing side of that dimension
+        selected_edge_ranges = getindex.(Ref(edge_ranges), edge_dims)
+
+        # Visit each combination of edge ranges for the edge dimensions chosen.
+        # For a 3d cube with n_edges = 1 and edge_dims = (1,), this will visit
+        # the top face, and then the bottom face.
+        for perimeter_edge_ranges in Iterators.ProductIterator(selected_edge_ranges)
+            # The center region for non-edge dimensions has been specified above,
+            # so finish specifying the region of the perimeter for this edge
+            # block
+            @inbounds for (i, dim) in enumerate(edge_dims)
+                perimeter_range[dim] = perimeter_edge_ranges[i]
+            end
+
+            # Region of block indices, not data indices!
+            block_region = CartesianIndices(
+                NTuple{N, UnitRange{Int}}(perimeter_range)
+            )
+            @inbounds for block_pos in block_region
+                # Figure out which portion of the input data should be transformed
+
+                block_idx = convert(NTuple{N, Int}, block_pos)
+                ## data_offset is NOT the beginning of the region that will be
+                ## convolved, but is instead the beginning of the unaliased data.
+                data_offset = save_blocksize .* (block_idx .- 1)
+                ## How many zeros will need to be added before the data
+                pad_before = max.(0, sv .- data_offset .- 1)
+                data_ideal_stop = data_offset .+ save_blocksize
+                ## How many zeros will need to be added after the data
+                pad_after = max.(0, data_ideal_stop .- su)
+
+                ## Data indices, not block indices
+                data_region = CartesianIndices(
+                    UnitRange.(
+                        u_start .+ data_offset .- sv .+ pad_before .+ 1,
+                        u_start .+ data_ideal_stop .- pad_after .- 1
+                    )
+                )
+
+                # Convolve portion of input
+
+                _zeropad!(tdbuff, u, tdbuff_axes, pad_before .+ 1, data_region)
+                os_conv_block!(tdbuff, fdbuff, filter_fd, p, ip)
+
+                # Save convolved result to output
+
+                block_out_stop = min.(
+                    out_start .+ data_offset .+ save_blocksize .- 1,
+                    out_stop
+                )
+                block_out_region = CartesianIndices(
+                    UnitRange.(out_start .+ data_offset, block_out_stop)
+                )
+                ## If the input could not fill tdbuff, account for that before
+                ## copying the convolution result to the output
+                u_deficit = max.(0, pad_after .- sv .+ 1)
+                valid_buff_region = CartesianIndices(
+                    UnitRange.(sv, nffts .- u_deficit .- sout_deficit)
+                )
+                copyto!(out, block_out_region, tdbuff, valid_buff_region)
+            end
+        end
+    end
+end
+
+# Assumes u is larger than, or the same size as, v
+function unsafe_conv_kern_os!(out,
+                        u::AbstractArray{<:Any, N},
+                        v,
+                        su,
+                        sv,
+                        sout,
+                        nffts) where N
+    u_start = first.(axes(u))
+    out_axes = axes(out)
+    out_start = first.(out_axes)
+    out_stop = last.(out_axes)
+    ideal_save_blocksize = nffts .- sv .+ 1
+    # Number of samples that are "missing" if the valid portion of the
+    # convolution is smaller than the output
+    sout_deficit = max.(0, ideal_save_blocksize .- sout)
+    # Size of the valid portion of the convolution result
+    save_blocksize = ideal_save_blocksize .- sout_deficit
+    nblocks = cld.(sout, save_blocksize)
+
+    # Pre-allocation
+    tdbuff, fdbuff, p, ip = os_prepare_conv(u, nffts)
+    tdbuff_axes = axes(tdbuff)
+
+    # Transform the smaller filter
+    _zeropad!(tdbuff, v)
+    filter_fd = os_filter_transform!(tdbuff, p)
+    filter_fd .*= 1 / prod(nffts) # Normalize once for brfft
+
+    last_full_blocks = fld.(su, save_blocksize)
+    # block indices for center blocks, which need no padding
+    center_block_ranges = UnitRange.(2, last_full_blocks)
+    # block index ranges for blocks that need to be padded
+    # Corresponds to the leading and trailing side of a dimension, or if there
+    # are no center blocks, corresponds to the whole dimension
+    edge_ranges = map(nblocks, last_full_blocks) do nblock, lastfull
+        lastfull > 1 ? [1:1, lastfull + 1 : nblock] : [1:nblock]
+    end
+    all_dims = 1:N
+    # Buffer to store ranges of indices for a single region of the perimeter
+    perimeter_range = Vector{UnitRange{Int}}(undef, N)
+
+    # Convolve all blocks that require padding.
+    #
+    # This is accomplished by dividing the perimeter of the volume into
+    # subsections, where the division is done by the number of edge dimensions.
+    # For a 3d cube, this convolves the perimeter in the following order:
+    #
+    # Number of Edge Dimensions | Convolved Region
+    # --------------------------+-----------------
+    #                         1 | Faces of Cube
+    #                         2 | Edges of Cube
+    #                         3 | Corners of Cube
+    #
+    for n_edges in all_dims
+        unsafe_conv_kern_os_edge!(
+            # These arrays and buffers will be mutated
+            out,
+            tdbuff,
+            fdbuff,
+            perimeter_range,
+            # Number of edge dimensions to pad and convolve
+            Val(n_edges),
+            # Data to be convolved
+            u,
+            filter_fd,
+            # FFTW plans
+            p,
+            ip,
+            # Sizes, ranges, and other pre-calculated constants
+            #
+            ## ranges listing center and edge blocks
+            edge_ranges,
+            center_block_ranges,
+            ## size and axis information
+            all_dims, # 1:N
+            su,
+            u_start,
+            sv,
+            nffts,
+            out_start,
+            out_stop,
+            save_blocksize,
+            sout_deficit,
+            tdbuff_axes) # How many output samples are missing if nffts > sout
+    end
+
+    tdbuff_region = CartesianIndices(tdbuff)
+    # Portion of buffer with valid result of convolution
+    valid_buff_region = CartesianIndices(UnitRange.(sv, nffts))
+    # Iterate over block indices (not data indices) that do not need to be padded
+    @inbounds for block_pos in CartesianIndices(center_block_ranges)
+        # Calculate portion of data to transform
+
+        block_idx = convert(NTuple{N, Int}, block_pos)
+        ## data_offset is NOT the beginning of the region that will be
+        ## convolved, but is instead the beginning of the unaliased data.
+        data_offset = save_blocksize .* (block_idx .- 1)
+        data_stop = data_offset .+ save_blocksize
+        data_region = CartesianIndices(
+            UnitRange.(u_start .+ data_offset .- sv .+ 1, u_start .+ data_stop .- 1)
+        )
+
+        # Convolve this portion of the data
+
+        copyto!(tdbuff, tdbuff_region, u, data_region)
+        os_conv_block!(tdbuff, fdbuff, filter_fd, p, ip)
+
+        # Save convolved result to output
+
+        block_out_region = CartesianIndices(
+            UnitRange.(data_offset .+ out_start, data_stop .+ out_start .- 1)
+        )
+        copyto!(out, block_out_region, tdbuff, valid_buff_region)
+    end
+
+    out
+end
+
+function _conv_kern_fft!(out,
+                         u::AbstractArray{T, N},
+                         v::AbstractArray{T, N},
+                         su,
+                         sv,
+                         outsize,
+                         nffts) where {T<:Real, N}
+    padded = _zeropad(u, nffts)
     p = plan_rfft(padded)
     uf = p * padded
     _zeropad!(padded, v)
     vf = p * padded
     uf .*= vf
-    irfft(uf, paddims[1])
+    raw_out = irfft(uf, nffts[1])
+    copyto!(out,
+            CartesianIndices(out),
+            raw_out,
+            CartesianIndices(UnitRange.(1, outsize)))
 end
-function _conv(u, v, paddims)
-    upad = _zeropad(u, paddims)
-    vpad = _zeropad(v, paddims)
+function _conv_kern_fft!(out, u, v, su, sv, outsize, nffts)
+    upad = _zeropad(u, nffts)
+    vpad = _zeropad(v, nffts)
     p! = plan_fft!(upad)
     p! * upad # Operates in place on upad
     p! * vpad
     upad .*= vpad
     ifft!(upad)
+    copyto!(out,
+            CartesianIndices(out),
+            upad,
+            CartesianIndices(UnitRange.(1, outsize)))
 end
 
-function _conv_clip!(
-    y::AbstractVector,
-    minpad,
-    ::NTuple{<:Any, Base.OneTo{Int}},
-    ::NTuple{<:Any, Base.OneTo{Int}}
-)
-    sizehint!(resize!(y, minpad[1]), minpad[1])
+# v should be smaller than u for good performance
+function _conv_fft!(out, u, v, su, sv, outsize)
+    os_nffts = map(optimalfftfiltlength, sv, su)
+    if any(os_nffts .< outsize)
+        unsafe_conv_kern_os!(out, u, v, su, sv, outsize, os_nffts)
+    else
+        nffts = nextfastfft(outsize)
+        _conv_kern_fft!(out, u, v, su, sv, outsize, nffts)
+    end
 end
-function _conv_clip!(
-    y::AbstractArray,
-    minpad,
-    ::NTuple{<:Any, Base.OneTo{Int}},
-    ::NTuple{<:Any, Base.OneTo{Int}}
-)
-    y[CartesianIndices(minpad)]
-end
+
+
 # For arrays with weird offsets
-function _conv_clip!(y::AbstractArray, minpad, axesu, axesv)
+function _conv_similar(u, outsize, axesu, axesv)
     out_offsets = first.(axesu) .+ first.(axesv)
-    out_axes = UnitRange.(out_offsets, out_offsets .+ minpad .- 1)
-    out = similar(y, out_axes)
-    copyto!(out, CartesianIndices(out), y, CartesianIndices(UnitRange.(1, minpad)))
+    out_axes = UnitRange.(out_offsets, out_offsets .+ outsize .- 1)
+    similar(u, out_axes)
+end
+function _conv_similar(
+    u, outsize, ::NTuple{<:Any, Base.OneTo{Int}}, ::NTuple{<:Any, Base.OneTo{Int}}
+)
+    similar(u, outsize)
+end
+_conv_similar(u, v, outsize) = _conv_similar(u, outsize, axes(u), axes(v))
+
+# Does convolution, will not switch argument order
+function _conv!(out, u, v, su, sv, outsize)
+    # TODO: Add spatial / time domain algorithm
+    _conv_fft!(out, u, v, su, sv, outsize)
 end
 
+# Does convolution, will not switch argument order
+function _conv(u, v, su, sv)
+    outsize = su .+ sv .- 1
+    out = _conv_similar(u, v, outsize)
+    _conv!(out, u, v, su, sv, outsize)
+end
+
+# May switch argument order
 """
     conv(u,v)
 
-Convolution of two arrays. Uses FFT algorithm.
+Convolution of two arrays. Uses either FFT convolution or overlap-save,
+depending on the size of the input. `u` and `v` can be  N-dimensional arrays,
+with arbitrary indexing offsets, but their axes must be a `UnitRange`.
 """
 function conv(u::AbstractArray{T, N},
               v::AbstractArray{T, N}) where {T<:BLAS.BlasFloat, N}
     su = size(u)
     sv = size(v)
-    minpad = su .+ sv .- 1
-    padsize = map(n -> n > 1024 ? nextprod([2,3,5], n) : nextpow(2, n), minpad)
-    y = _conv(u, v, padsize)
-    _conv_clip!(y, minpad, axes(u), axes(v))
+    if prod(su) >= prod(sv)
+        _conv(u, v, su, sv)
+    else
+        _conv(v, u, sv, su)
+    end
 end
+
 function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
               v::AbstractArray{<:BLAS.BlasFloat, N}) where N
     fu, fv = promote(u, v)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -283,10 +283,8 @@ function optimalfftfiltlength(nb, nx)
     end
     nfft = pow2 > prev_pow2 ? 2 ^ prev_pow2 : 2 ^ (pow2 - 1)
 
-    # L is the number of usable samples produced by each block
-    L = nfft - nb + 1
-    if L > nx
-        # If L > nx, better to find next fast power
+    if nfft > nfull
+        # If nfft > nfull, then it's better to find next fast power
         nfft = nextfastfft(nfull)
     end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -119,8 +119,8 @@ computes Fourier transforms of input that is a product of these
 sizes faster than for input of other sizes.
 """
 nextfastfft(n) = nextprod(FAST_FFT_SIZES, n)
-nextfastfft(n1, n2...) = tuple(nextfastfft(n1), nextfastfft(n2...)...)
-nextfastfft(n::Tuple) = nextfastfft(n...)
+nextfastfft(ns::Tuple) = nextfastfft.(ns)
+nextfastfft(ns...) = nextfastfft(ns)
 
 
 ## COMMON DSP TOOLS

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -36,7 +36,7 @@ end
 
 @testset "conv" begin
 
-    @test optimalfftfiltlength(3, 1) == 3 # Should be at least the first input
+    @test optimalfftfiltlength(1, 3) == 1 # Should be at least the first input
 
     @testset "conv-1D" begin
         # Convolution
@@ -201,7 +201,7 @@ end
         for numdim in Ns
             for elt in eltypes
                 for nsmall in regular_nsmall
-                    nfft = optimalfftfiltlength(nlarge, nsmall)
+                    nfft = optimalfftfiltlength(nsmall, nlarge)
                     test_os(elt, nlarge, nsmall, Val{numdim}(), nfft)
                 end
             end

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -2,6 +2,8 @@
 # TODO: parameterize conv tests
 using Test, DSP, OffsetArrays
 import DSP: filt, filt!, deconv, conv, xcorr
+using DSP: optimalfftfiltlength, unsafe_conv_kern_os!, _conv_kern_fft!, _conv_similar,
+    nextfastfft
 
 
 
@@ -33,6 +35,8 @@ import DSP: filt, filt!, deconv, conv, xcorr
 end
 
 @testset "conv" begin
+
+    @test optimalfftfiltlength(3, 1) == 3 # Should be at least the first input
 
     @testset "conv-1D" begin
         # Convolution
@@ -168,6 +172,56 @@ end
         @test conv(a, b) == exp
         fb = convert(Array{Float64}, b)
         @test conv(a, fb) ≈ convert(Array{Float64}, exp)
+    end
+
+    @testset "Overlap-Save" begin
+        to_sizetuple = (diml, N) -> ntuple(_ -> diml, N)
+        function os_test_data(eltype, diml, N)
+            s = to_sizetuple(diml, N)
+            arr = rand(eltype, s)
+            s, arr
+        end
+        function test_os(eltype, nu, nv, N, nfft)
+            nffts = to_sizetuple(nfft, N)
+            su, u = os_test_data(eltype, nu, N)
+            sv, v = os_test_data(eltype, nv, N)
+            sout = su .+ sv .- 1
+            out = _conv_similar(u, sout, axes(u), axes(v))
+            unsafe_conv_kern_os!(out, u, v, su, sv, sout, nffts)
+            os_out = copy(out)
+            fft_nfft = nextfastfft(sout)
+            _conv_kern_fft!(out, u, v, su, sv, sout, fft_nfft)
+            @test out ≈ os_out
+        end
+        Ns = [1, 2, 3]
+        eltypes = [Float32, Float64, Complex{Float64}]
+        nlarge = 128
+
+        regular_nsmall = [12, 128]
+        for numdim in Ns
+            for elt in eltypes
+                for nsmall in regular_nsmall
+                    nfft = optimalfftfiltlength(nlarge, nsmall)
+                    test_os(elt, nlarge, nsmall, Val{numdim}(), nfft)
+                end
+            end
+        end
+
+        # small = 12, fft = 256 exercises output being smaller than the normal
+        # valid region of OS convolution block
+        #
+        # small = 13, fft = 32 makes sout evenly divisble by nfft - sv + 1
+        # small = 12, fft = 32 does not
+        adversarial_nsmall_nfft = [(12, 256), (13, 32), (12, 32)]
+        for (nsmall, nfft) in adversarial_nsmall_nfft
+            test_os(Float64, nlarge, nsmall, Val{1}(), nfft)
+        end
+
+        # Should not bug:
+        conv(zeros(4, 7, 1), zeros(3, 3, 3))
+
+        # three blocks need to be padded in the following case:
+        test_os(Float64, 25, 4, Val{1}(), 16)
     end
 end
 


### PR DESCRIPTION
I have added an overlap-save algorithm to convolution, which is substantially faster (~2x) for large convolution problems. It is also substantially faster than other packages like ImageFiltering.jl. For smaller convolutions, it is about the same or a little bit slower than standard fft convolution. The cutoff between overlap-save and simple fft convolution is pretty arbitrary at the moment, so it would be nice to add some benchmarking to allow DSP.jl to choose between the two algorithms depending on the size of the input. It would also be nice to add spatial/time domain filtering for small convolutions, as it would almost certainly be faster than fft convolutions. This is relevant to #224.