### PR TITLE
Remove Package Evaluator badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ DSP.jl
 
 [![Build Status](https://travis-ci.org/JuliaDSP/DSP.jl.svg?branch=master)](https://travis-ci.org/JuliaDSP/DSP.jl)
 [![Coverage Status](https://coveralls.io/repos/JuliaDSP/DSP.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaDSP/DSP.jl?branch=master)
-[![Package Evaluator](http://pkg.julialang.org/badges/DSP_0.6.svg)](http://pkg.julialang.org/?pkg=DSP)
 
 DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia. These include:
 


### PR DESCRIPTION
The badge doesn't show anymore and the link get redirected to the general https://pkg.julialang.org/docs/ which isn't very useful.