### PR TITLE
Combine FIR filtering from dspbase and DSP.jl

### DIFF
--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -4,7 +4,7 @@ using Polynomials, ..Util
 import Base: *
 using LinearAlgebra: I, mul!, rmul!
 using Statistics: middle
-import ..DSP: filt, filt!
+import ..DSP: filt, filt!, SMALL_FILT_CUTOFF
 using FFTW
 
 include("coefficients.jl")

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -387,49 +387,6 @@ function filt_stepstate(f::SecondOrderSections{T}) where T
     si
 end
 
-const SMALL_FILT_CUTOFF = 54
-
-#
-# filt implementation for FIR filters (faster than Base)
-#
-
-for n = 2:SMALL_FILT_CUTOFF
-    silen = n-1
-    si = [Symbol("si$i") for i = 1:silen]
-    @eval function filt!(out, b::NTuple{$n,T}, x) where T
-        size(x) != size(out) && error("out size must match x")
-        ncols = Base.trailingsize(x, 2)
-        for col = 0:ncols-1
-            $(Expr(:block, [:($(si[i]) = zero(b[$i])*zero(x[1])) for i = 1:silen]...))
-            offset = col*size(x, 1)
-            @inbounds for i=1:size(x, 1)
-                xi = x[i+offset]
-                val = $(si[1]) + b[1]*xi
-                $(Expr(:block, [:($(si[j]) = $(si[j+1]) + b[$(j+1)]*xi) for j = 1:(silen-1)]...))
-                $(si[silen]) = b[$(silen+1)]*xi
-                out[i+offset] = val
-            end
-        end
-        out
-    end
-end
-
-let chain = :(throw(ArgumentError("invalid tuple size")))
-    for n = SMALL_FILT_CUTOFF:-1:2
-        chain = quote
-            if length(h) == $n
-                filt!(out, ($([:(h[$i]) for i = 1:n]...),), x)
-            else
-                $chain
-            end
-        end
-    end
-
-    @eval function small_filt!(out::AbstractArray, h::AbstractVector{T}, x::AbstractArray) where T
-        $chain
-    end
-end
-
 """
     tdfilt(h, x)
 
@@ -437,7 +394,7 @@ Apply filter or filter coefficients `h` along the first dimension
 of array `x` using a naïve time-domain algorithm
 """
 function tdfilt(h::AbstractVector, x::AbstractArray{T}) where T<:Real
-    _tdfilt!(Array{T}(undef, size(x)), h, x)
+    filt!(Array{T}(undef, size(x)), h, ones(eltype(h), 1), x)
 end
 
 """
@@ -447,37 +404,7 @@ Like `tdfilt`, but writes the result into array `out`. Output array `out` may
 not be an alias of `x`, i.e. filtering may not be done in place.
 """
 function tdfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
-    size(x) != size(out) && error("out size must match x")
-    _tdfilt!(out, h, x)
-end
-
-# Does not check that 'out' and 'x' are the same length
-function _tdfilt!(out::AbstractArray, h::AbstractVector, x::AbstractArray)
-    if length(h) == 1
-        return mul!(out, h[1], x)
-    elseif length(h) <= SMALL_FILT_CUTOFF
-        return small_filt!(out, h, x)
-    end
-
-    h = reverse(h)
-    hLen = length(h)
-    xLen = size(x, 1)
-    ncols = Base.trailingsize(x, 2)
-
-    for col = 0:ncols-1
-        offset = col*size(x, 1)
-        for i = 1:min(hLen-1, xLen)
-            dotprod = zero(eltype(h))*zero(eltype(x))
-            @simd for j = 1:i
-                @inbounds dotprod += h[hLen-i+j] * x[j+offset]
-            end
-            @inbounds out[i+offset] = dotprod
-        end
-        for i = hLen:xLen
-            @inbounds out[i+offset] = unsafe_dot(h, x, i+offset)
-        end
-    end
-    out
+    filt!(out, h, ones(eltype(h), 1), x)
 end
 
 filt(h::AbstractArray, x::AbstractArray) =
@@ -615,10 +542,10 @@ function filt_choose_alg!(
         nfft = optimalfftfiltlength(nb, nx)
         _fftfilt!(out, b, x, nfft)
     else
-        _tdfilt!(out, b, x)
+        tdfilt!(out, b, x)
     end
 end
 
 function filt_choose_alg!(out::AbstractArray, b::AbstractArray, x::AbstractArray)
-    _tdfilt!(out, b, x)
+    tdfilt!(out, b, x)
 end

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -3,52 +3,7 @@
 import Base.trailingsize
 import LinearAlgebra.BLAS
 
-const SMALL_FILT_CUTOFF = 54
-
-#
-# filt implementation for FIR filters (faster than Base)
-#
-
-for n = 2:SMALL_FILT_CUTOFF
-    silen = n-1
-    si = [Symbol("si$i") for i = 1:silen]
-    @eval function _filt_fir!(out, b::NTuple{$n,T}, x, siarr, col) where {T}
-        offset = (col - 1) * size(x, 1)
-
-        $(Expr(:block, [:(@inbounds $(si[i]) = siarr[$i]) for i = 1:silen]...))
-        @inbounds for i=1:size(x, 1)
-            xi = x[i+offset]
-            val = muladd(xi, b[1], $(si[1]))
-            $(Expr(:block, [:($(si[j]) = muladd(xi, b[$(j+1)], $(si[j+1]))) for j = 1:(silen-1)]...))
-            $(si[silen]) = b[$(silen+1)]*xi
-            out[i+offset] = val
-        end
-    end
-end
-
-let chain = :(throw(ArgumentError("invalid tuple size")))
-    for n = SMALL_FILT_CUTOFF:-1:2
-        chain = quote
-            if length(h) == $n
-                _filt_fir!(
-                    out,
-                    ($([:(@inbounds(h[$i])) for i = 1:n]...),),
-                    x,
-                    si,
-                    col
-                )
-            else
-                $chain
-            end
-        end
-    end
-
-    @eval function _small_filt_fir!(
-        out::AbstractArray, h::AbstractVector{T}, x::AbstractArray, si, col
-    ) where T
-        $chain
-    end
-end
+const SMALL_FILT_CUTOFF = 58
 
 _zerosi(b,a,T) = zeros(promote_type(eltype(b), eltype(a), T), max(length(a), length(b))-1)
 
@@ -122,6 +77,7 @@ function filt!(out::AbstractArray, b::Union{AbstractVector, Number}, a::Union{Ab
     return out
 end
 
+# Transposed direct form II
 function _filt_iir!(out, b, a, x, si, col)
     silen = length(si)
     @inbounds for i=1:size(x, 1)
@@ -135,6 +91,7 @@ function _filt_iir!(out, b, a, x, si, col)
     end
 end
 
+# Transposed direct form II
 function _filt_fir!(out, b, x, si, col)
     silen = length(si)
     @inbounds for i=1:size(x, 1)
@@ -145,6 +102,53 @@ function _filt_fir!(out, b, x, si, col)
         end
         si[silen] = b[silen+1]*xi
         out[i,col] = val
+    end
+end
+
+#
+# filt implementation for FIR filters (faster than Base)
+#
+
+for n = 2:SMALL_FILT_CUTOFF
+    silen = n-1
+    si = [Symbol("si$i") for i = 1:silen]
+    # Transposed direct form II
+    @eval function _filt_fir!(out, b::NTuple{$n,T}, x, siarr, col) where {T}
+        offset = (col - 1) * size(x, 1)
+
+        $(Expr(:block, [:(@inbounds $(si[i]) = siarr[$i]) for i = 1:silen]...))
+        @inbounds for i=1:size(x, 1)
+            xi = x[i+offset]
+            val = muladd(xi, b[1], $(si[1]))
+            $(Expr(:block, [:($(si[j]) = muladd(xi, b[$(j+1)], $(si[j+1]))) for j = 1:(silen-1)]...))
+            $(si[silen]) = b[$(silen+1)]*xi
+            out[i+offset] = val
+        end
+    end
+end
+
+# Convert array filter tap input to tuple for small-filtering
+let chain = :(throw(ArgumentError("invalid tuple size")))
+    for n = SMALL_FILT_CUTOFF:-1:2
+        chain = quote
+            if length(h) == $n
+                _filt_fir!(
+                    out,
+                    ($([:(@inbounds(h[$i])) for i = 1:n]...),),
+                    x,
+                    si,
+                    col
+                )
+            else
+                $chain
+            end
+        end
+    end
+
+    @eval function _small_filt_fir!(
+        out::AbstractArray, h::AbstractVector{T}, x::AbstractArray, si, col
+    ) where T
+        $chain
     end
 end
 

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -3,6 +3,53 @@
 import Base.trailingsize
 import LinearAlgebra.BLAS
 
+const SMALL_FILT_CUTOFF = 54
+
+#
+# filt implementation for FIR filters (faster than Base)
+#
+
+for n = 2:SMALL_FILT_CUTOFF
+    silen = n-1
+    si = [Symbol("si$i") for i = 1:silen]
+    @eval function _filt_fir!(out, b::NTuple{$n,T}, x, siarr, col) where {T}
+        offset = (col - 1) * size(x, 1)
+
+        $(Expr(:block, [:(@inbounds $(si[i]) = siarr[$i]) for i = 1:silen]...))
+        @inbounds for i=1:size(x, 1)
+            xi = x[i+offset]
+            val = muladd(xi, b[1], $(si[1]))
+            $(Expr(:block, [:($(si[j]) = muladd(xi, b[$(j+1)], $(si[j+1]))) for j = 1:(silen-1)]...))
+            $(si[silen]) = b[$(silen+1)]*xi
+            out[i+offset] = val
+        end
+    end
+end
+
+let chain = :(throw(ArgumentError("invalid tuple size")))
+    for n = SMALL_FILT_CUTOFF:-1:2
+        chain = quote
+            if length(h) == $n
+                _filt_fir!(
+                    out,
+                    ($([:(@inbounds(h[$i])) for i = 1:n]...),),
+                    x,
+                    si,
+                    col
+                )
+            else
+                $chain
+            end
+        end
+    end
+
+    @eval function _small_filt_fir!(
+        out::AbstractArray, h::AbstractVector{T}, x::AbstractArray, si, col
+    ) where T
+        $chain
+    end
+end
+
 _zerosi(b,a,T) = zeros(promote_type(eltype(b), eltype(a), T), max(length(a), length(b))-1)
 
 """
@@ -66,6 +113,8 @@ function filt!(out::AbstractArray, b::Union{AbstractVector, Number}, a::Union{Ab
         si = initial_si[:, N > 1 ? col : 1]
         if as > 1
             _filt_iir!(out, b, a, x, si, col)
+        elseif bs <= SMALL_FILT_CUTOFF
+            _small_filt_fir!(out, b, x, si, col)
         else
             _filt_fir!(out, b, x, si, col)
         end
@@ -77,11 +126,11 @@ function _filt_iir!(out, b, a, x, si, col)
     silen = length(si)
     @inbounds for i=1:size(x, 1)
         xi = x[i,col]
-        val = si[1] + b[1]*xi
+        val = muladd(xi, b[1], si[1])
         for j=1:(silen-1)
-            si[j] = si[j+1] + b[j+1]*xi - a[j+1]*val
+            si[j] = muladd(val, -a[j+1], muladd(xi, b[j+1], si[j+1]))
         end
-        si[silen] = b[silen+1]*xi - a[silen+1]*val
+        si[silen] = muladd(xi, b[silen+1], -a[silen+1]*val)
         out[i,col] = val
     end
 end
@@ -90,9 +139,9 @@ function _filt_fir!(out, b, x, si, col)
     silen = length(si)
     @inbounds for i=1:size(x, 1)
         xi = x[i,col]
-        val = si[1] + b[1]*xi
+        val = muladd(xi, b[1], si[1])
         for j=1:(silen-1)
-            si[j] = si[j+1] + b[j+1]*xi
+            si[j] = muladd(xi, b[j+1], si[j+1])
         end
         si[silen] = b[silen+1]*xi
         out[i,col] = val

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -30,20 +30,20 @@ using DSP, Test, Random, FilterTestHelpers
                 @test res ≈ filt(bq, x)
                 @test res ≈ filt!(similar(x), bq, x)
                 f = DF2TFilter(bq)
-                @test tfres == [filt(f, x[1:50]); filt(f, x[51:end])]
+                @test tfres ≈ [filt(f, x[1:50]); filt(f, x[51:end])]
             end
 
             # Test that filt with zpk converts
-            @test res == filt(zpk, x)
-            @test res == filt!(similar(x), zpk, x)
+            @test res ≈ filt(zpk, x)
+            @test res ≈ filt!(similar(x), zpk, x)
 
             # Test with DF2TFilter
             f = DF2TFilter(sos)
-            @test res == [filt(f, x[1:50]); filt(f, x[51:end])]
+            @test res ≈ [filt(f, x[1:50]); filt(f, x[51:end])]
             f = DF2TFilter(tf)
-            @test tfres == [filt(f, x[1:50]); filt(f, x[51:end])]
+            @test tfres ≈ [filt(f, x[1:50]); filt(f, x[51:end])]
             f = DF2TFilter(zpk)
-            @test res == [filt(f, x[1:50]); filt(f, x[51:end])]
+            @test res ≈ [filt(f, x[1:50]); filt(f, x[51:end])]
         end
     end
 


### PR DESCRIPTION
There were two identical functions, `_tdfilt!`, and `filt!` that both accomplished
FIR filtering. It turns out that the function in dspbase, `filt!` was faster,
and also allowed you to change the initial filter state to achieve, e.g., a steady state
step response. I therefore removed the implementation in `_tdfilt!` in favor of
`filt!`.

The one benefit that `_tdfilt!` had over `filt!` was a set of small-kernel
filtering functions with an unrolled loop. I have combined the functionality of
these small filter functions with `filt!`, while making these small filter
functions also accept some initial state.

Finally, I have added `muladd` in the direct form filtering kernels, where
possible. This makes a big performance difference for the unrolled loop kernel,
but for the other kernels it doesn't seem to matter much. However, it should
produce more accurate filtering results on platforms that support fma
instructions.