### PR TITLE
Accommodate AbstractFFTs.jl#26 fftfreq etc.

### DIFF
--- a/docs/src/util.md
+++ b/docs/src/util.md
@@ -9,8 +9,6 @@ end
 unwrap
 unwrap!
 hilbert
-fftfreq
-rfftfreq
 nextfastfft
 pow2db
 amp2db

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -19,6 +19,7 @@ include("lpc.jl")
 include("estimation.jl")
 
 using Reexport
+import .Util: Frequencies, fftfreq, rfftfreq
 @reexport using .Util, .Windows, .Periodograms, .Filters, .LPC, .Unwrap, .Estimation
 
 include("deprecated.jl")

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -19,7 +19,6 @@ include("lpc.jl")
 include("estimation.jl")
 
 using Reexport
-import .Util: Frequencies, fftfreq, rfftfreq
 @reexport using .Util, .Windows, .Periodograms, .Filters, .LPC, .Unwrap, .Estimation
 
 include("deprecated.jl")

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -4,4 +4,8 @@ Base.@deprecate_binding TFFilter PolynomialRatio
 Base.@deprecate_binding BiquadFilter Biquad
 Base.@deprecate_binding SOSFilter SecondOrderSections
 
+Base.@deprecate Frequencies(nreal::Int, n::Int, multiplier::Float64) FFTW.Frequencies(nreal, n, multiplier)
+Base.@deprecate fftfreq(n::Int, fs::Real=1) FFTW.fftfreq(n, fs)
+Base.@deprecate rfftfreq(n::Int, fs::Real=1) FFTW.rfftfreq(n, fs)
+
 @deprecate conv2 conv

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -218,11 +218,11 @@ See also: [`fftfreq`](@ref), [`rfftfreq`](@ref)
 freq(p::TFR) = p.freq
 freq(p::Periodogram2) = (p.freq1, p.freq2)
 FFTW.fftshift(p::Periodogram{T,F}) where {T,F<:Frequencies} =
-    Periodogram(p.freq.nreal == p.freq.n ? p.power : fftshift(p.power), fftshift(p.freq))
+    Periodogram(p.freq.n_nonnegative == p.freq.n ? p.power : fftshift(p.power), fftshift(p.freq))
 FFTW.fftshift(p::Periodogram{T,F}) where {T,F<:AbstractRange} = p
 # 2-d
 FFTW.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:Frequencies,F2<:Frequencies} =
-    Periodogram2(p.freq1.nreal == p.freq1.n ? fftshift(p.power,2) : fftshift(p.power), fftshift(p.freq1), fftshift(p.freq2))
+    Periodogram2(p.freq1.n_nonnegative == p.freq1.n ? fftshift(p.power,2) : fftshift(p.power), fftshift(p.freq1), fftshift(p.freq2))
 FFTW.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:AbstractRange,F2<:Frequencies} =
     Periodogram2(fftshift(p.power,2), p.freq1, fftshift(p.freq2))
 FFTW.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:AbstractRange,F2<:AbstractRange} = p
@@ -442,7 +442,7 @@ struct Spectrogram{T,F<:Union{Frequencies,AbstractRange}} <: TFR{T}
     time::FloatRange{Float64}
 end
 FFTW.fftshift(p::Spectrogram{T,F}) where {T,F<:Frequencies} =
-    Spectrogram(p.freq.nreal == p.freq.n ? p.power : fftshift(p.power, 1), fftshift(p.freq), p.time)
+    Spectrogram(p.freq.n_nonnegative == p.freq.n ? p.power : fftshift(p.power, 1), fftshift(p.freq), p.time)
 FFTW.fftshift(p::Spectrogram{T,F}) where {T,F<:AbstractRange} = p
 
 """

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -6,6 +6,7 @@ using ..Util, ..Windows
 export arraysplit, nextfastfft, periodogram, welch_pgram, mt_pgram,
        spectrogram, power, freq, stft
 using FFTW
+import FFTW: Frequencies, fftfreq, rfftfreq
 
 ## ARRAY SPLITTER
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -108,6 +108,9 @@ fftabs2type(::Type{Complex{T}}) where {T<:FFTW.fftwReal} = T
 fftabs2type(::Type{T}) where {T<:FFTW.fftwReal} = T
 fftabs2type(::Type{T}) where {T<:Union{Real,Complex}} = Float64
 
+@deprecate Frequencies(nreal::Int, n::Int, multiplier::Float64) FFTW.Frequencies(nreal, n, multiplier)
+@deprecate fftfreq(n::Int, fs::Real=1) FFTW.fftfreq(n, fs)
+@deprecate rfftfreq(n::Int, fs::Real=1) FFTW.rfftfreq(n, fs)
 
 # Get next fast FFT size for a given signal length
 const FAST_FFT_SIZES = [2, 3, 5, 7]

--- a/src/util.jl
+++ b/src/util.jl
@@ -108,52 +108,6 @@ fftabs2type(::Type{Complex{T}}) where {T<:FFTW.fftwReal} = T
 fftabs2type(::Type{T}) where {T<:FFTW.fftwReal} = T
 fftabs2type(::Type{T}) where {T<:Union{Real,Complex}} = Float64
 
-## FREQUENCY VECTOR
-
-struct Frequencies <: AbstractVector{Float64}
-    nreal::Int
-    n::Int
-    multiplier::Float64
-end
-
-unsafe_getindex(x::Frequencies, i::Int) =
-    (i-1+ifelse(i <= x.nreal, 0, -x.n))*x.multiplier
-function Base.getindex(x::Frequencies, i::Int)
-    (i >= 1 && i <= x.n) || throw(BoundsError())
-    unsafe_getindex(x, i)
-end
-if isdefined(Base, :iterate)
-    function Base.iterate(x::Frequencies, i::Int=1)
-        i > x.n ? nothing : (unsafe_getindex(x,i), i + 1)
-    end
-else
-    Base.start(x::Frequencies) = 1
-    Base.next(x::Frequencies, i::Int) = (unsafe_getindex(x, i), i+1)
-    Base.done(x::Frequencies, i::Int) = i > x.n
-end
-Base.size(x::Frequencies) = (x.n,)
-Base.step(x::Frequencies) = x.multiplier
-
-"""
-    fftfreq(n, fs=1)
-
-Return discrete fourier transform sample frequencies. The returned
-Frequencies object is an AbstractVector containing the frequency
-bin centers at every sample point. `fs` is the sample rate of the
-input signal.
-"""
-fftfreq(n::Int, fs::Real=1) = Frequencies(((n-1) >> 1)+1, n, fs/n)
-
-"""
-    rfftfreq(n, fs=1)
-
-Return discrete fourier transform sample frequencies for use with
-`rfft`. The returned Frequencies object is an AbstractVector
-containing the frequency bin centers at every sample point. `fs`
-is the sample rate of the input signal.
-"""
-rfftfreq(n::Int, fs::Real=1) = Frequencies((n >> 1)+1, (n >> 1)+1, fs/n)
-FFTW.fftshift(x::Frequencies) = (x.nreal-x.n:x.nreal-1)*x.multiplier
 
 # Get next fast FFT size for a given signal length
 const FAST_FFT_SIZES = [2, 3, 5, 7]

--- a/src/util.jl
+++ b/src/util.jl
@@ -108,10 +108,6 @@ fftabs2type(::Type{Complex{T}}) where {T<:FFTW.fftwReal} = T
 fftabs2type(::Type{T}) where {T<:FFTW.fftwReal} = T
 fftabs2type(::Type{T}) where {T<:Union{Real,Complex}} = Float64
 
-@deprecate Frequencies(nreal::Int, n::Int, multiplier::Float64) FFTW.Frequencies(nreal, n, multiplier)
-@deprecate fftfreq(n::Int, fs::Real=1) FFTW.fftfreq(n, fs)
-@deprecate rfftfreq(n::Int, fs::Real=1) FFTW.rfftfreq(n, fs)
-
 # Get next fast FFT size for a given signal length
 const FAST_FFT_SIZES = [2, 3, 5, 7]
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using  DSP, FFTW, Test
+import DSP: Frequencies, fftfreq, rfftfreq
 
 using Random: seed!
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -50,27 +50,6 @@ using Statistics: mean
 end
 
 @testset "fft helpers" begin
-    ## FFTFREQ
-    @test fftfreq(1) ≈ [0.]
-    @test fftfreq(2) ≈ [0., -1/2]
-    @test fftfreq(2, 1/2) ≈ [0., -1/4]
-    @test fftfreq(3) ≈ [0., 1/3, -1/3]
-    @test fftfreq(3, 1/2) ≈ [0., 1/6, -1/6]
-    @test fftfreq(6) ≈ [0., 1/6, 1/3, -1/2, -1/3, -1/6]
-    @test fftfreq(7) ≈ [0., 1/7, 2/7, 3/7, -3/7, -2/7, -1/7]
-
-    @test rfftfreq(1) ≈ [0.]
-    @test rfftfreq(2) ≈ [0., 1/2]
-    @test rfftfreq(2, 1/2) ≈ [0., 1/4]
-    @test rfftfreq(3) ≈ [0., 1/3]
-    @test rfftfreq(3, 1/2) ≈ [0., 1/6]
-    @test rfftfreq(6) ≈ [0., 1/6, 1/3, 1/2]
-    @test rfftfreq(7) ≈ [0., 1/7, 2/7, 3/7]
-
-    for n = 1:7
-        @test fftshift(fftfreq(n)) ≈ fftshift([fftfreq(n);])
-    end
-
     @test meanfreq(sin.(2*π*10*(0:1e-3:10*π)),1e3) ≈ 10.0 rtol=1e-3
 
     # nextfastfft


### PR DESCRIPTION
This PR accommodates https://github.com/JuliaMath/AbstractFFTs.jl/pull/26.

The definitions for `fftfreq`, `rfftfreq`, as well as the `Frequencies` type has been moved to AbstractFFTs.jl. Hence these definitions aren't necessary in DSP.jl anymore.

All tests pass locally. They will fail here, since https://github.com/JuliaMath/AbstractFFTs.jl/pull/26 hasn't been merged yet.

Do not merge before https://github.com/JuliaMath/AbstractFFTs.jl/pull/26 has been merged!