### PR TITLE
Convert arguments to FIRArbitrary to expected types

### DIFF
--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -105,7 +105,9 @@ mutable struct FIRArbitrary{T} <: FIRKernel{T}
     hLen::Int
 end
 
-function FIRArbitrary(h::Vector, rate::Real, Nϕ::Integer)
+function FIRArbitrary(h::Vector, rate_in::Real, Nϕ_in::Integer)
+    rate         = convert(Float64, rate_in)
+    Nϕ           = convert(Int, Nϕ_in)
     dh           = [diff(h); zero(eltype(h))]
     pfb          = taps2pfb(h,  Nϕ)
     dpfb         = taps2pfb(dh, Nϕ)
@@ -117,7 +119,20 @@ function FIRArbitrary(h::Vector, rate::Real, Nϕ::Integer)
     inputDeficit = 1
     xIdx         = 1
     hLen         = length(h)
-    FIRArbitrary(rate, pfb, dpfb, Nϕ, tapsPerϕ, ϕAccumulator, ϕIdx, α, Δ, inputDeficit, xIdx, hLen)
+    FIRArbitrary(
+        rate,
+        pfb,
+        dpfb,
+        Nϕ,
+        tapsPerϕ,
+        ϕAccumulator,
+        ϕIdx,
+        α,
+        Δ,
+        inputDeficit,
+        xIdx,
+        hLen
+    )
 end
 
 

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -59,6 +59,16 @@ end
     idxUpper = idxLower*2
     yDelta   = abs.(y[idxLower:idxUpper].-yy[idxLower:idxUpper])
     @test all(map(delta -> abs(delta) < 0.005, yDelta))
+
+    # Test Float32 ratio (#302)
+    f32_ratio = convert(Float32, ratio)
+    f32_y     = resample(x, f32_ratio)
+    ty        = range(0, stop =cycles, length =yLen)
+    yy        = sinpi.(2*ty)
+    idxLower  = round(Int, yLen/3)
+    idxUpper  = idxLower*2
+    yDelta    = abs.(f32_y[idxLower:idxUpper].-yy[idxLower:idxUpper])
+    @test all(map(delta -> abs(delta) < 0.005, yDelta))
 end
 
 @testset "resample_filter" begin


### PR DESCRIPTION
The parameters `Nϕ` and `rate` were not converted to the expected types prior to
constructing `FIRArbitrary` objects.

Fixes #302