### PR TITLE
Allow cross correlations to work with arbitrary offsets and padding

### DIFF
--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -205,6 +205,9 @@ end
     off_a = OffsetVector(a, -1:1)
     off_b = OffsetVector(b, 0:1)
     @test xcorr(off_a, off_b, padmode = :none) == OffsetVector(exp, -2:1)
+
+    # Issue #288
+    @test xcorr(off_a, off_b, padmode = :longest) == OffsetVector(vcat(0, exp), -3:1)
 end
 
 @testset "deconv" begin


### PR DESCRIPTION
Cross-correlation of input arrays with arbitrary indexing did not work in
conjunction with padding, because padding did not preserve indexing.
Adding a zero-padding function that preserves indexing, `_zeropad_keep_offset`,
fixes this problem. The `_zeropad` function works the same as before, and
returns an array with base-1 indexing. I have added `_zeropad!` methods that
also work with arbitrary indexing for the padded array, which are dispatched
based on the axes of the of padded array.

Fixes #288