### PR TITLE
Add functionnality to create eye diagrams.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ DSP.jl provides a number of common [digital signal processing](https://en.wikipe
 - [Linear Predictive Coding](https://juliadsp.github.io/DSP.jl/stable/lpc)
 - [Window functions](https://juliadsp.github.io/DSP.jl/stable/windows)
 - [Utility functions](https://juliadsp.github.io/DSP.jl/stable/util)
+- [Eye diagrams](https://juliadsp.github.io/DSP.jl/stable/eyediag)
 
 More details can be found in the [Online Documentation](https://juliadsp.github.io/DSP.jl/stable/contents/).
 

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -17,6 +17,7 @@ include("periodograms.jl")
 include("Filters/Filters.jl")
 include("lpc.jl")
 include("estimation.jl")
+include("eyediag.jl")
 
 using Reexport
 @reexport using .Util, .Windows, .Periodograms, .Filters, .LPC, .Unwrap, .Estimation

--- a/src/eyediag.jl
+++ b/src/eyediag.jl
@@ -35,7 +35,7 @@ Trace data is stored in a `DataEye` object as vectors of `(x,y)` sub-vectors.
 
 Inputs:
   - tbit: Bit period (s).  Defines "trigger point" of each bit start.
-  - teye: Eye period (s).  Defines how much of eye data (along x-axis) algorithm is to collect after "trigger point".  Typical values are `1.5*tbit` or `2.0*tbit`.
+  - teye: Eye period (s).  Defines how much of eye data (along x-axis) algorithm is to collect after "trigger point".  Typically, this is set to `2.0*tbit`.
   - tstart: Time of first "trigger point" (s).
 
 Example plotting with Plots.jl:
@@ -44,7 +44,7 @@ Example plotting with Plots.jl:
     tbit = 1e-9 #Assume data bit period is 1ns.
 
     #Build eye & use tstart to center data.
-    eye = buildeye(x, y, tbit, 1.5*tbit, tstart=0.2*tbit)
+    eye = buildeye(x, y, tbit, 2.0*tbit, tstart=0.2*tbit)
 
     plot(eye.vx, eye.vy)
 """
@@ -56,28 +56,33 @@ function buildeye(x::Vector, y::Vector, tbit::Number, teye::Number; tstart::Numb
 	while i <= length(x) && x[i] < tstart
 		i+=1
 	end
+
 	wndnum = 0
 	inext = i
-	done = i > length(x)
-	while !done
-		istart = inext
+	while true
+		if inext > length(x); break; end #Nothing else to add
 		wndstart = tstart+wndnum*tbit
 		nexteye = wndstart+tbit
 		wndend = wndstart+teye
+		istart = inext
+		i = istart
 		while i <= length(x) && x[i] < nexteye
 			i+=1
 		end
 		inext = i
-		while i <= length(x) && x[i] < wndend
+		while i <= length(x) && x[i] <= wndend
 			i+=1
 		end
 		if i > length(x)
 			i = length(x)
 		end
-		if i == istart; break; end #Nothing to add
-		push!(eye.vx, x[istart:i].-wndstart)
-		push!(eye.vy, y[istart:i])
-		if inext > length(x); break; end #Nothing else
+		if x[i] > wndend
+			i -= 1
+		end
+		if i > istart
+			push!(eye.vx, x[istart:i].-wndstart)
+			push!(eye.vy, y[istart:i])
+		end
 		wndnum += 1
 	end
 	return eye

--- a/src/eyediag.jl
+++ b/src/eyediag.jl
@@ -1,0 +1,86 @@
+#Eye diagram generation
+#-------------------------------------------------------------------------------
+
+export buildeye
+
+#==Types
+===============================================================================#
+#=TODO: Restructure DataEye to be a vector of (x,y) vector pairs.
+        - Less likely to be in an invalid state)
+        - But less compatible with most plotting tool API (which tend to accept
+          vectors of x & y vectors).
+=#     
+mutable struct DataEye
+	vx::Vector{Vector{Float64}}
+	vy::Vector{Vector{Float64}}
+end
+DataEye() = DataEye([], [])
+
+
+#==
+===============================================================================#
+#=TODO: - kwargs tbit, teye?:
+          Preferable to use named arguments, but can it be done cleanly without
+          being confusing to user?
+        - Define algorithm to detect first crossing and center eye
+          (select `tstart`) accordingly.
+=#
+
+"""
+    buildeye(x::Vector, y::Vector, tbit::Number, teye::Number; tstart::Number=0)
+
+Segments the `(x,y)` vector into multiple traces of the eye diagram.
+
+Trace data is stored in a `DataEye` object as vectors of `(x,y)` sub-vectors.
+
+Inputs:
+  - tbit: Bit period (s).  Defines "trigger point" of each bit start.
+  - teye: Eye period (s).  Defines how much of eye data (along x-axis) algorithm is to collect after "trigger point".  Typical values are `1.5*tbit` or `2.0*tbit`.
+  - tstart: Time of first "trigger point" (s).
+
+Example plotting with Plots.jl:
+
+    #Assumption: (x, y) data generated here.
+    tbit = 1e-9 #Assume data bit period is 1ns.
+
+    #Build eye & use tstart to center data.
+    eye = buildeye(x, y, tbit, 1.5*tbit, tstart=0.2*tbit)
+
+    plot(eye.vx, eye.vy)
+"""
+function buildeye(x::Vector, y::Vector, tbit::Number, teye::Number; tstart::Number=0)
+	eye = DataEye()
+
+	i = 1
+	#skip initial data:
+	while i <= length(x) && x[i] < tstart
+		i+=1
+	end
+	wndnum = 0
+	inext = i
+	done = i > length(x)
+	while !done
+		istart = inext
+		wndstart = tstart+wndnum*tbit
+		nexteye = wndstart+tbit
+		wndend = wndstart+teye
+		while i <= length(x) && x[i] < nexteye
+			i+=1
+		end
+		inext = i
+		while i <= length(x) && x[i] < wndend
+			i+=1
+		end
+		if i > length(x)
+			i = length(x)
+		end
+		if i == istart; break; end #Nothing to add
+		push!(eye.vx, x[istart:i].-wndstart)
+		push!(eye.vy, y[istart:i])
+		if inext > length(x); break; end #Nothing else
+		wndnum += 1
+	end
+	return eye
+end
+
+#Last line

--- a/test/eyediag.jl
+++ b/test/eyediag.jl
@@ -1,0 +1,73 @@
+using Test, DSP
+
+@testset "Eye Diagram Tests" begin #Scope for test data
+
+testbits = [0,1,0,1,0,1,1,0,1,0,0,1,1,1,0,0,0,1,0]
+#@show length(testbits)
+
+#Simple function to build a triangular bit pattern from a bit sequence
+function BuildTriangPat(bitseq; tbit::Float64=1.0)
+	y = 1.0 .* bitseq #Get floating point values
+	x = collect((0:1:(length(bitseq)-1)) .* tbit)
+	return (x, y)
+end
+
+#For debug purposes:
+function dbg_showeyedata(eyedata)
+	for i in 1:length(eyedata.vx)
+		println("$i:")
+		@show eyedata.vx[i]
+		@show eyedata.vy[i]
+	end
+end
+
+tbit = 1.0
+(x,y) = BuildTriangPat(testbits, tbit = tbit)
+
+@testset "Eye Diagram: Centered" begin
+	eyedata = buildeye(x, y, tbit, 2.0*tbit, tstart=0.0*tbit)
+
+	@test length(eyedata.vx) == length(eyedata.vy)
+	@test length(eyedata.vx) == length(testbits) - 1
+
+#	dbg_showeyedata(eyedata)
+
+	for i in 1:(length(eyedata.vx)-1)
+		@test eyedata.vx[i] == [0.0, 1.0, 2.0]
+		@test eyedata.vy[i] == Float64[testbits[i], testbits[i+1], testbits[i+2]]
+	end
+
+	i = length(eyedata.vx)
+	@test eyedata.vx[end] == [0.0, 1.0] #Cannot extrapolate past last data point
+	@test eyedata.vy[i] == Float64[testbits[i], testbits[i+1]]
+end
+
+@testset "Eye Diagram: Early" begin
+	eyedata = buildeye(x, y, tbit, 2.0*tbit, tstart=0.8*tbit)
+
+	@test length(eyedata.vx) == length(eyedata.vy)
+	@test length(eyedata.vx) == length(testbits) - 2 #Skipped 1st data point
+
+#	dbg_showeyedata(eyedata)
+
+	for i in 1:length(eyedata.vx)
+		@test eyedata.vx[i] ≈ [0.2, 1.2]
+		@test eyedata.vy[i] == Float64[testbits[i+1], testbits[i+2]]
+	end
+end
+
+@testset "Eye Diagram: Late" begin
+	eyedata = buildeye(x, y, tbit, 2.0*tbit, tstart=0.2*tbit)
+
+	@test length(eyedata.vx) == length(eyedata.vy)
+	@test length(eyedata.vx) == length(testbits) - 2 #Skipped 1st data point
+
+#	dbg_showeyedata(eyedata)
+
+	for i in 1:length(eyedata.vx)
+		#Last data point in sweep should be >= 2.0*tbit:
+		@test eyedata.vx[i] ≈ [0.8, 1.8]
+		@test eyedata.vy[i] == Float64[testbits[i+1], testbits[i+2]]
+	end
+end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Random: seed!
 testfiles = [ "dsp.jl", "util.jl", "windows.jl", "filter_conversion.jl",
     "filter_design.jl", "filter_response.jl", "filt.jl", "filt_stream.jl",
     "periodograms.jl", "resample.jl", "lpc.jl", "estimation.jl", "unwrap.jl",
-    "remez_fir.jl" ]
+    "remez_fir.jl", "eyediag.jl" ]
 
 seed!(1776)
 


### PR DESCRIPTION
Hi,

I was wondering if it would be appropriate to add functionality to create eye diagrams in DSP.jl.

For those who are less familiar with this "analog" visualization of digital signals, there is information here:

https://en.wikipedia.org/wiki/Eye_pattern

Note that I personally consider this part of DIGITAL signal processing, because we are typically observing digital signals, and often correcting with digital filters (ex: FIR pre-emphasis on the TX output).

If this is ok, I will create a test set to validate the functionality.

Thanks.