### PR TITLE
Drop Julia 0.7 and Compat dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 /usr
 
 /docs/build
+
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 version = "0.5.2"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
@@ -13,9 +12,8 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Compat = ">= 1.3.0"
 Polynomials = ">= 0.1.0"
-julia = "0.7,1"
+julia = "1"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia 0.7
-Polynomials 0.1.0
-Reexport
-SpecialFunctions
-FFTW
-Compat 1.3

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -1,10 +1,7 @@
-__precompile__()
-
 module DSP
 
 using FFTW
 using LinearAlgebra: mul!, rmul!
-using Compat: range
 
 export conv, conv2, deconv, filt, filt!, xcorr
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-OffsetArrays


### PR DESCRIPTION
Might as well, since 0.7 is officially unmaintained (and has been for a long time). We can also delete the REQUIRE files since they aren't used.