### PR TITLE
Set version to 0.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DSP"
 uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"


### PR DESCRIPTION
I bumped the minor version because we're dropping 0.7 and there have been a lot of changes since the last release (though none seem particularly disruptive).