### PR TITLE
Fix filtfilt so it works for real coefficents and complex data.

### DIFF
--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -237,9 +237,9 @@ end
 # Zero phase digital filtering by processing data in forward and reverse direction
 function iir_filtfilt(b::AbstractVector, a::AbstractVector, x::AbstractArray)
     zi = filt_stepstate(b, a)
-    zitmp = copy(zi)
     pad_length = 3 * (max(length(a), length(b)) - 1)
     t = Base.promote_eltype(b, a, x)
+    zitmp = similar(zi, t)
     extrapolated = Vector{t}(undef, size(x, 1)+pad_length*2)
     out = similar(x, t)
 
@@ -312,9 +312,9 @@ end
 # Zero phase digital filtering for second order sections
 function filtfilt(f::SecondOrderSections{T,G}, x::AbstractArray{S}) where {T,G,S}
     zi = filt_stepstate(f)
-    zitmp = similar(zi)
     pad_length = 6 * length(f.biquads)
     t = Base.promote_type(T, G, S)
+    zitmp = similar(zi, t)
     extrapolated = Vector{t}(undef, size(x, 1)+pad_length*2)
     out = similar(x, t)
 

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -152,6 +152,19 @@ end
     @test x2_matlab ≈ filtfilt(b, a, x)
 end
 
+# Make sure above doesn't crash for real coeffs & complex data.
+@testset "filtfilt 1D Complex" begin
+    x2_matlab = readdlm(joinpath(dirname(@__FILE__), "data", "filtfilt_output.txt"),'\t')
+
+    b = [ 0.00327922,  0.01639608,  0.03279216,  0.03279216,  0.01639608,  0.00327922]
+    a = [ 1.        , -2.47441617,  2.81100631, -1.70377224,  0.54443269, -0.07231567]
+    x  = readdlm(joinpath(dirname(@__FILE__), "data", "spectrogram_x.txt"),'\t')
+
+    y = x .+ 1im .* randn(size(x, 1))
+
+    @test x2_matlab ≈ real.(filtfilt(b, a, y))
+end
+
 #######################################
 #
 # Test 2d filtfilt against matlab results


### PR DESCRIPTION
Trying to run `filtfilt` on complex data fails with `InexactError` due to calling `mul!(Y, A, B)` with `eltype(Y) <: Real`. I tried to correct the type logic and added a test.