### PR TITLE
Add compat entries for dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,11 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Polynomials = ">= 0.1.0"
+Polynomials = "0.6.0"
+FFTW = "1.0"
+Reexport = "0.2"
+SpecialFunctions = "0.8"
+OffsetArrays = "0.11"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This PR adds compat entries for all dependencies in line with the general guidelines of Julia auto-merge system for the General registry.

**Do only merge after #300 has been merged. Afterwards tag a new release (patch version number increment).** The auto-merge should work then.

## Background / Why this is important:
See https://discourse.julialang.org/t/please-be-mindful-of-version-bounds-and-semantic-versioning-when-tagging-your-packages/30708/135.

Due to the changes in AbstractFFTs.jl (https://github.com/JuliaMath/AbstractFFTs.jl/pull/26) we are in a broken state until #300 gets merged. See for example the complaints [here](https://github.com/JuliaDSP/DSP.jl/issues/306).

This could and should have been avoided by `[compat]` entries which would have set effective upper bounds on FFTW.jl. This way, we would have had the time to merge #300 whenever we want and then bump the FFTW version in `[compat]`. However, those compat entries didn't exist. This PR changes that for the after-#300 time.