### PR TITLE
Accommodate AbstractFFTs PR 26

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DSP"
 uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -12,7 +12,11 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Polynomials = ">= 0.1.0"
+FFTW = "1.1"
+OffsetArrays = "0.11"
+Polynomials = "0.6"
+Reexport = "0.2"
+SpecialFunctions = "0.8"
 julia = "1"
 
 [extras]

--- a/docs/src/util.md
+++ b/docs/src/util.md
@@ -9,8 +9,6 @@ end
 unwrap
 unwrap!
 hilbert
-fftfreq
-rfftfreq
 nextfastfft
 pow2db
 amp2db

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -4,4 +4,8 @@ Base.@deprecate_binding TFFilter PolynomialRatio
 Base.@deprecate_binding BiquadFilter Biquad
 Base.@deprecate_binding SOSFilter SecondOrderSections
 
+Base.@deprecate Frequencies(nreal::Int, n::Int, multiplier::Float64) FFTW.Frequencies(nreal, n, multiplier)
+Base.@deprecate fftfreq(n::Int, fs::Real=1) FFTW.fftfreq(n, fs)
+Base.@deprecate rfftfreq(n::Int, fs::Real=1) FFTW.rfftfreq(n, fs)
+
 @deprecate conv2 conv

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -6,6 +6,7 @@ using ..Util, ..Windows
 export arraysplit, nextfastfft, periodogram, welch_pgram, mt_pgram,
        spectrogram, power, freq, stft
 using FFTW
+import FFTW: Frequencies, fftfreq, rfftfreq
 
 ## ARRAY SPLITTER
 
@@ -218,11 +219,11 @@ See also: [`fftfreq`](@ref), [`rfftfreq`](@ref)
 freq(p::TFR) = p.freq
 freq(p::Periodogram2) = (p.freq1, p.freq2)
 FFTW.fftshift(p::Periodogram{T,F}) where {T,F<:Frequencies} =
-    Periodogram(p.freq.nreal == p.freq.n ? p.power : fftshift(p.power), fftshift(p.freq))
+    Periodogram(p.freq.n_nonnegative == p.freq.n ? p.power : fftshift(p.power), fftshift(p.freq))
 FFTW.fftshift(p::Periodogram{T,F}) where {T,F<:AbstractRange} = p
 # 2-d
 FFTW.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:Frequencies,F2<:Frequencies} =
-    Periodogram2(p.freq1.nreal == p.freq1.n ? fftshift(p.power,2) : fftshift(p.power), fftshift(p.freq1), fftshift(p.freq2))
+    Periodogram2(p.freq1.n_nonnegative == p.freq1.n ? fftshift(p.power,2) : fftshift(p.power), fftshift(p.freq1), fftshift(p.freq2))
 FFTW.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:AbstractRange,F2<:Frequencies} =
     Periodogram2(fftshift(p.power,2), p.freq1, fftshift(p.freq2))
 FFTW.fftshift(p::Periodogram2{T,F1,F2}) where {T,F1<:AbstractRange,F2<:AbstractRange} = p
@@ -442,7 +443,7 @@ struct Spectrogram{T,F<:Union{Frequencies,AbstractRange}} <: TFR{T}
     time::FloatRange{Float64}
 end
 FFTW.fftshift(p::Spectrogram{T,F}) where {T,F<:Frequencies} =
-    Spectrogram(p.freq.nreal == p.freq.n ? p.power : fftshift(p.power, 1), fftshift(p.freq), p.time)
+    Spectrogram(p.freq.n_nonnegative == p.freq.n ? p.power : fftshift(p.power, 1), fftshift(p.freq), p.time)
 FFTW.fftshift(p::Spectrogram{T,F}) where {T,F<:AbstractRange} = p
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using  DSP, FFTW, Test
+import DSP: Frequencies, fftfreq, rfftfreq
 
 using Random: seed!
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -50,27 +50,6 @@ using Statistics: mean
 end
 
 @testset "fft helpers" begin
-    ## FFTFREQ
-    @test fftfreq(1) ≈ [0.]
-    @test fftfreq(2) ≈ [0., -1/2]
-    @test fftfreq(2, 1/2) ≈ [0., -1/4]
-    @test fftfreq(3) ≈ [0., 1/3, -1/3]
-    @test fftfreq(3, 1/2) ≈ [0., 1/6, -1/6]
-    @test fftfreq(6) ≈ [0., 1/6, 1/3, -1/2, -1/3, -1/6]
-    @test fftfreq(7) ≈ [0., 1/7, 2/7, 3/7, -3/7, -2/7, -1/7]
-
-    @test rfftfreq(1) ≈ [0.]
-    @test rfftfreq(2) ≈ [0., 1/2]
-    @test rfftfreq(2, 1/2) ≈ [0., 1/4]
-    @test rfftfreq(3) ≈ [0., 1/3]
-    @test rfftfreq(3, 1/2) ≈ [0., 1/6]
-    @test rfftfreq(6) ≈ [0., 1/6, 1/3, 1/2]
-    @test rfftfreq(7) ≈ [0., 1/7, 2/7, 3/7]
-
-    for n = 1:7
-        @test fftshift(fftfreq(n)) ≈ fftshift([fftfreq(n);])
-    end
-
     @test meanfreq(sin.(2*π*10*(0:1e-3:10*π)),1e3) ≈ 10.0 rtol=1e-3
 
     # nextfastfft


### PR DESCRIPTION
Bound FFTW to 1.1 to avoid conflicting export of `Frequencies` et al., set verion to 0.6.1. Carsten's authorship has been preserved.

Fixes #320 
Closes #300 
Closes #321 