### PR TITLE
Fix CI for building docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "0.24"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, DSP
 
 makedocs(
     modules = [DSP],
-    format = :html,
+    format = Documenter.HTML(),
     sitename = "DSP.jl",
     pages = Any[
         "Contents" => "contents.md",


### PR DESCRIPTION
Docs were failing because the Documenter.jl version used was uncontrolled, and
the interface for specifying HTML output has changed in recent version of
Documenter.jl. I have specified which version of Documenter.jl to use as the
current version, and updated our usage of `makedocs` accordingly.