### PR TITLE
Add "using DSP" to all doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,7 @@
 using Documenter, DSP
 
+DocMeta.setdocmeta!(DSP, :DocTestSetup, :(using DSP); recursive=true)
+
 makedocs(
     modules = [DSP],
     format = Documenter.HTML(),


### PR DESCRIPTION
Some doctests were failing because `using DSP` was not specifically included in
the example. I have added a setup step in doc/make.jl that includes the DSP
module in all doctests, so that examples that do not explicitly include `using
DSP` will still be able to use DSP functions.