### PR TITLE
Remove references to fftfreq in documentation

### DIFF
--- a/docs/src/util.md
+++ b/docs/src/util.md
@@ -1,9 +1,10 @@
 # `Util` - utility functions
-```@meta
-DocTestSetup = quote
-    using DSP
-end
-```
+
+!!! note
+    As of version 0.6.1 of DSP.jl, `fftfreq` and `rfftfreq` have been moved from
+    DSP.jl to [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl)
+    version 0.5 and above. You can also access these functions through
+    [FFTW.jl](https://github.com/JuliaMath/FFTW.jl) version 1.1 and above.
 
 ```@docs
 unwrap
@@ -22,8 +23,4 @@ shiftsignal
 shiftsignal!
 alignsignals
 alignsignals!
-```
-
-```@meta
-DocTestSetup = nothing
 ```

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -213,8 +213,6 @@ Spectrogram object.
 
 Returns a tuple of frequency bin centers for a given Periodogram2
 object.
-
-See also: [`fftfreq`](@ref), [`rfftfreq`](@ref)
 """
 freq(p::TFR) = p.freq
 freq(p::Periodogram2) = (p.freq1, p.freq2)


### PR DESCRIPTION
These are no longer in DSP.jl, but links to their documentation were still
present in the documentation of DSP.jl.