### PR TITLE
Add Julia 1.3 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ os:
   - linux
 julia:
   - 1.0
-  - 1.2
-  - 1.3
+  - 1
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ os:
   - linux
 julia:
   - 1.0
+  - 1.1
+  - 1.2
+  - 1.3
   - 1
   - nightly
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - linux
 julia:
   - 1.0
-  - 1.1
   - 1.2
+  - 1.3
   - nightly
 matrix:
   allow_failures:


### PR DESCRIPTION
Also remove Julia 1.1.

I don't know how many versions we should be testing? 1.0 is the LTS so it makes sense to keep it. 1.3 is the most recent version, and 1.2 is the version most people are probably running. I figured that it doesn't make that much sense to keep testing on 1.1, but happy to change that if people disagree.