### PR TITLE
Remove redundant Julia 1.3 test from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ julia:
   - 1.0
   - 1.1
   - 1.2
-  - 1.3
   - 1
   - nightly
 matrix:


### PR DESCRIPTION
At the moment, the latest version of Julia is v1.3, and because the Travis
script includes both the latest Julia and an entry explicitly for Julia v1.3,
tests are run on 1.3 twice. Until a new version of Julia is released, the
explicit entry for 1.3 is redundant and should be removed.