### PR TITLE
Explicitly test Julia 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ julia:
   - 1.0
   - 1.1
   - 1.2
+  - 1.3
   - 1
   - nightly
 matrix:


### PR DESCRIPTION
Julia 1.4 has been released, so `1` will now test `1.4`. And `1.3` needs to be explicitly added.