### PR TITLE
Fix the footnote in `iirnotch`

### DIFF
--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -472,9 +472,7 @@ Second-order digital IIR notch filter [^Orfandis] at frequency `Wn` with
 bandwidth `bandwidth`. If `fs` is not specified, `Wn` is
 interpreted as a normalized frequency in half-cycles/sample.
 
-[^Orfandis]:
-Orfanidis, S. J. (1996). Introduction to signal processing.
-Englewood Cliffs, N.J: Prentice Hall, p. 370.
+[^Orfandis]: Orfanidis, S. J. (1996). Introduction to signal processing. Englewood Cliffs, N.J: Prentice Hall, p. 370.
 """
 function iirnotch(w::Real, bandwidth::Real; fs=2)
     w = normalize_freq(w, fs)


### PR DESCRIPTION
There can be no newlines in the footnote definition, unfortunately...