### PR TITLE
Fix #352: Relax type bounds of conv conversion method

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -701,14 +701,18 @@ function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
     fu, fv = promote(u, v)
     conv(fu, fv)
 end
-conv(u::AbstractArray{T, N}, v::AbstractArray{T, N}) where {T<:Number, N} =
-    conv(float(u), float(v))
+
 conv(u::AbstractArray{<:Integer, N}, v::AbstractArray{<:Integer, N}) where {N} =
     round.(Int, conv(float(u), float(v)))
+
+conv(u::AbstractArray{<:Number, N}, v::AbstractArray{<:Number, N}) where {N} =
+    conv(float(u), float(v))
+
 function conv(u::AbstractArray{<:Number, N},
               v::AbstractArray{<:BLAS.BlasFloat, N}) where N
     conv(float(u), v)
 end
+
 function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
               v::AbstractArray{<:Number, N}) where N
     conv(u, float(v))

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -62,6 +62,8 @@ end
         offset_arr = OffsetArray{Int}(undef, -1:2)
         offset_arr[:] = a
         @test conv(offset_arr, 1:3) == OffsetVector(expectation, 0:5)
+        # Issue #352
+        @test conv([1//2, 1//3, 1//4], [1, 2]) ≈ [1//2, 4//3, 11//12, 1//2]
     end
 
 


### PR DESCRIPTION
`Conv` currently only works with floating point numbers, and converts arrays to
have the same dimensions and floating point element type prior to convolution.
There are a number of conversion methods for `conv` that perform this
conversion. However, if the two input arrays do not have the same element type,
and further if one of the inputs has a non-floating point real element type, for
example a fixed point number, then there is currently no conversion method that
will match this case. This results in a stack overflow. To fix this, I have
relaxed the type bounds of the method `conv(::AbstractArray{T, N},
::AbstractArray{T, N}) where {T<:Number, N}` so that it no longer requires the
two input arrays to have the same element type.

Fixes #352.