### PR TITLE
Reject non-numerical arrays as arguments to conv

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -718,10 +718,14 @@ function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
     conv(u, float(v))
 end
 
-function conv(A::AbstractArray{<:Number, N},
-              B::AbstractArray{<:Number, P}) where {N, P}
-    maxnd = max(ndims(A), ndims(B))
-    return conv(cat(A, dims=maxnd), cat(B, dims=maxnd))
+function conv(A::AbstractArray{<:Number, M},
+              B::AbstractArray{<:Number, N}) where {M, N}
+    if (M < N)
+        conv(cat(A, dims=N), B)
+    else
+        @assert M > N
+        conv(A, cat(B, dims=M))
+    end
 end
 
 """

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -721,10 +721,10 @@ end
 function conv(A::AbstractArray{<:Number, M},
               B::AbstractArray{<:Number, N}) where {M, N}
     if (M < N)
-        conv(cat(A, dims=N), B)
+        conv(cat(A, dims=N)::AbstractArray{eltype(A), N}, B)
     else
         @assert M > N
-        conv(A, cat(B, dims=M))
+        conv(A, cat(B, dims=M)::AbstractArray{eltype(B), M})
     end
 end
 

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -718,7 +718,8 @@ function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
     conv(u, float(v))
 end
 
-function conv(A::AbstractArray, B::AbstractArray)
+function conv(A::AbstractArray{<:Number, N},
+              B::AbstractArray{<:Number, P}) where {N, P}
     maxnd = max(ndims(A), ndims(B))
     return conv(cat(A, dims=maxnd), cat(B, dims=maxnd))
 end

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -64,6 +64,8 @@ end
         @test conv(offset_arr, 1:3) == OffsetVector(expectation, 0:5)
         # Issue #352
         @test conv([1//2, 1//3, 1//4], [1, 2]) ≈ [1//2, 4//3, 11//12, 1//2]
+        # Non-numerical arrays should not be convolved
+        @test_throws MethodError conv([sin], [cos])
     end
 
 


### PR DESCRIPTION
Related to #352 (#353)

Currently `conv` has a method `conv(::AbstractArray, ::AbstractArray)`
that is intended to cast arrays of different ndims into
dimension-compatible ones before delegating to more detailed methods.
Unfortunately, this method ends up catching arrays with non-`Number`
eltypes, and since no detailed methods accept such arrays as arguments,
this method ends up calling itself and results in stack overflow.  This
commit fixes that by restricting the signature of the abovementioned
method to `conv(::AbstractArray{<:Number, N}, ::AbstractArray{<:Number,
P}) where {N, P}` so that calling `conv` with non-numerical arrays
is now a type error.