### PR TITLE
Use Polynomials 1.0 API

### DIFF
--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -1,6 +1,6 @@
 module Filters
 using ..Unwrap
-using Polynomials, ..Util
+using ..Util
 using Polynomials: Polynomial, coeffs, roots, fromroots
 
 import Base: *

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -1,7 +1,7 @@
 module Filters
 using ..Unwrap
 using Polynomials, ..Util
-using Polynomials.PolyCompat
+using Polynomials: Polynomial, coeffs, roots, fromroots
 
 import Base: *
 using LinearAlgebra: I, mul!, rmul!

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -160,8 +160,8 @@ function filt!(out::AbstractVector, f::DF2TFilter{PolynomialRatio{T},Vector{S}},
     si = f.state
     # Note: these are in the Polynomials.jl convention, which is
     # reversed WRT the usual DSP convention
-    b = f.coef.b.a
-    a = f.coef.a.a
+    b = coeffs(f.coef.b)
+    a = coeffs(f.coef.a)
     n = length(b)
     if n == 1
         mul!(out, x, b[1])

--- a/src/Filters/response.jl
+++ b/src/Filters/response.jl
@@ -7,7 +7,7 @@
 function freqz(filter::FilterCoefficients, w::Number)
     filter = convert(PolynomialRatio, filter)
     ejw = exp(-im * w)
-    polyval(filter.b, ejw) ./ polyval(filter.a, ejw)
+    filter.b(ejw) ./ filter.a(ejw)
 end
 
 function freqz(filter::ZeroPoleGain, w::Number)
@@ -88,7 +88,7 @@ or frequencies `w` in radians/sample.
 function freqs(filter::FilterCoefficients, w::Number)
     filter = convert(PolynomialRatio, filter)
     s = im * w
-    polyval(filter.b, s) ./ polyval(filter.a, s)
+    filter.b(s) ./ filter.a(s)
 end
 
 function freqs(filter::ZeroPoleGain, w::Number)

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -234,9 +234,13 @@ end
     @test Biquad(2.0, 0.0, 0.0, 0.0, 0.0)*2 == Biquad(4.0, 0.0, 0.0, 0.0, 0.0)
     @test convert(Biquad{Float64}, f1) == convert(Biquad, f1)
     f = PolynomialRatio(Float64[1.0], Float64[1.0])
-    empty!(f.b.a)
-    empty!(f.a.a)
+
+    # I don't understand why this tests is necessary, it's impossible to make a
+    # PolynomialRatio with empty coefficients in the first place.
+    empty!(f.b.coeffs)
+    empty!(f.a.coeffs)
     @test_throws ArgumentError convert(Biquad, f)
+
     @test_throws ArgumentError convert(SecondOrderSections, ZeroPoleGain([0.5 + 0.5im, 0.5 + 0.5im], [0.5 + 0.5im, 0.5 - 0.5im], 1))
     @test_throws ArgumentError convert(SecondOrderSections, ZeroPoleGain([0.5 + 0.5im, 0.5 - 0.5im], [0.5 + 0.5im, 0.5 + 0.5im], 1))
 


### PR DESCRIPTION
Instead of using the compatibility interface provided by Polynomials.jl for
backwards compatibility, I have changed calls to Polynomials.jl from DSP.jl so
that they use the Polynomials.jl v1 API.

Related to #359.