### PR TITLE
Remove deprecations

### DIFF
--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -4,7 +4,7 @@ using FFTW
 using LinearAlgebra: mul!, rmul!
 using IterTools: subsets
 
-export conv, conv2, deconv, filt, filt!, xcorr
+export conv, deconv, filt, filt!, xcorr
 
 include("dspbase.jl")
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,5 +1,0 @@
-# deprecations after 0.5
-Base.@deprecate_binding ZPKFilter ZeroPoleGain
-Base.@deprecate_binding TFFilter PolynomialRatio
-Base.@deprecate_binding BiquadFilter Biquad
-Base.@deprecate_binding SOSFilter SecondOrderSections

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -4,8 +4,4 @@ Base.@deprecate_binding TFFilter PolynomialRatio
 Base.@deprecate_binding BiquadFilter Biquad
 Base.@deprecate_binding SOSFilter SecondOrderSections
 
-Base.@deprecate Frequencies(nreal::Int, n::Int, multiplier::Float64) FFTW.Frequencies(nreal, n, multiplier)
-Base.@deprecate fftfreq(n::Int, fs::Real=1) FFTW.fftfreq(n, fs)
-Base.@deprecate rfftfreq(n::Int, fs::Real=1) FFTW.rfftfreq(n, fs)
-
 @deprecate conv2 conv

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -3,5 +3,3 @@ Base.@deprecate_binding ZPKFilter ZeroPoleGain
 Base.@deprecate_binding TFFilter PolynomialRatio
 Base.@deprecate_binding BiquadFilter Biquad
 Base.@deprecate_binding SOSFilter SecondOrderSections
-
-@deprecate conv2 conv

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -752,27 +752,6 @@ function conv(u::AbstractVector{T}, v::AbstractVector{T}, A::AbstractMatrix{T}) 
 end
 
 
-function check_padmode_kwarg(padmode::Symbol, su::Integer, sv::Integer)
-    if padmode == :default_longest
-        if su != sv
-            Base.depwarn(
-            """
-            The default value of `padmode` will be changing from `:longest` to
-            `:none` in a future release of DSP. In preparation for this change,
-            leaving `padmode` unspecified is currently deprecated. To keep
-            current behavior specify `padmode=:longest`. To avoid this warning,
-            specify padmode = :none or padmode = :longest where appropriate.
-            """
-                ,
-                :xcorr
-            )
-        end
-        :longest
-    else
-        padmode
-    end
-end
-
 dsp_reverse(v, ::NTuple{<:Any, Base.OneTo{Int}}) = reverse(v, dims = 1)
 function dsp_reverse(v, vaxes)
     vsize = length(v)
@@ -795,17 +774,11 @@ The size of the output depends on the padmode keyword argument: with padmode =
 With padmode = :longest the shorter of the arguments will be padded so they are
 equal length. This gives a result with length 2*max(length(u), length(v))-1,
 with the zero-lag condition at the center.
-
-!!! warning
-    The default value of `padmode` will be changing from `:longest` to `:none`
-    in a future release of DSP. In preparation for this change, leaving
-    `padmode` unspecified is currently deprecated.
 """
 function xcorr(
-    u::AbstractVector, v::AbstractVector; padmode::Symbol = :default_longest
+    u::AbstractVector, v::AbstractVector; padmode::Symbol = :none
 )
     su = size(u,1); sv = size(v,1)
-    padmode = check_padmode_kwarg(padmode, su, sv)
     if padmode == :longest
         if su < sv
             u = _zeropad_keep_offset(u, sv)

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -7,13 +7,7 @@ export unwrap, unwrap!
 
 In-place version of [`unwrap`](@ref).
 """
-function unwrap!(m::AbstractArray{T,N}; dims=nothing, kwargs...) where {T, N}
-    if dims === nothing && N != 1
-        Base.depwarn("`unwrap!(m::AbstractArray)` is deprecated, use `unwrap!(m, dims=ndims(m))` instead", :unwrap!)
-        dims = N
-    end
-    unwrap!(m, m; dims=dims, kwargs...)
-end
+unwrap!(m::AbstractArray; kwargs...) = unwrap!(m, m; kwargs...)
 
 """
     unwrap!(y, m; kwargs...)
@@ -71,16 +65,7 @@ of an image, as each pixel is wrapped to stay within (-pi, pi].
 - `rng=GLOBAL_RNG`: Unwrapping of arrays with dimension > 1 uses a random
     initialization. A user can pass their own RNG through this argument.
 """
-function unwrap(m::AbstractArray{T,N}; dims=nothing, kwargs...) where {T, N}
-    if dims === nothing && N != 1
-        Base.depwarn("`unwrap(m::AbstractArray)` is deprecated, use `unwrap(m, dims=ndims(m))` instead", :unwrap)
-        dims = ndims(m)
-    end
-    unwrap!(similar(m), m; dims=dims, kwargs...)
-end
-
-@deprecate(unwrap(m::AbstractArray, dim::Integer; range::Number=2pi),
-    unwrap(m, dims=dim, range=range))
+unwrap(m::AbstractArray; kwargs...) = unwrap!(similar(m), m; kwargs...)
 
 #= Algorithm based off of
  M. A. Herráez, D. R. Burton, M. J. Lalor, and M. A. Gdeisat,

--- a/src/util.jl
+++ b/src/util.jl
@@ -6,12 +6,9 @@ using LinearAlgebra: mul!
 using FFTW
 
 export  hilbert,
-        Frequencies,
         fftintype,
         fftouttype,
         fftabs2type,
-        fftfreq,
-        rfftfreq,
         nextfastfft,
         dB,
         dBa,

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -234,19 +234,19 @@ end
     b = [4, 5]
     exp = [5, 14, 23, 12]
     @test xcorr([1, 2], [3, 4]) == [4, 11, 6]
-    @test xcorr(a, b) == [0, 5, 14, 23, 12]
+    @test xcorr(a, b) == exp
     @test xcorr(a, b, padmode = :longest) == [0, 5, 14, 23, 12]
     @test xcorr(a, b, padmode = :none) == exp
-    @test xcorr([1, 2], [3, 4, 5]) == [5, 14, 11, 6, 0]
+    @test xcorr([1, 2], [3, 4, 5]) == [5, 14, 11, 6]
     @test xcorr([1, 2], [3, 4, 5], padmode = :longest) == [5, 14, 11, 6, 0]
     @test xcorr([1, 2], [3, 4, 5], padmode = :none) == [5, 14, 11, 6]
     @test xcorr([1.0im], [1.0im]) == [1]
-    @test xcorr([1, 2, 3]*1.0im, ComplexF64[4, 5]) ≈ [0, 5, 14, 23, 12]*im
-    @test xcorr([1, 2]*1.0im, ComplexF64[3, 4, 5]) ≈ [5, 14, 11, 6, 0]*im
-    @test xcorr(ComplexF64[1, 2, 3], [4, 5]*1.0im) ≈ -[0, 5, 14, 23, 12]*im
-    @test xcorr(ComplexF64[1, 2], [3, 4, 5]*1.0im) ≈ -[5, 14, 11, 6, 0]*im
-    @test xcorr([1, 2, 3]*1.0im, [4, 5]*1.0im) ≈ [0, 5, 14, 23, 12]
-    @test xcorr([1, 2]*1.0im, [3, 4, 5]*1.0im) ≈ [5, 14, 11, 6, 0]
+    @test xcorr([1, 2, 3]*1.0im, ComplexF64[4, 5]) ≈ [5, 14, 23, 12]*im
+    @test xcorr([1, 2]*1.0im, ComplexF64[3, 4, 5]) ≈ [5, 14, 11, 6]*im
+    @test xcorr(ComplexF64[1, 2, 3], [4, 5]*1.0im) ≈ -[5, 14, 23, 12]*im
+    @test xcorr(ComplexF64[1, 2], [3, 4, 5]*1.0im) ≈ -[5, 14, 11, 6]*im
+    @test xcorr([1, 2, 3]*1.0im, [4, 5]*1.0im) ≈ [5, 14, 23, 12]
+    @test xcorr([1, 2]*1.0im, [3, 4, 5]*1.0im) ≈ [5, 14, 11, 6]
 
     # Base Julia issue #17351
     let

--- a/test/periodograms.jl
+++ b/test/periodograms.jl
@@ -16,6 +16,7 @@
 
 using DSP, Test
 using Statistics: mean
+using FFTW: fftfreq
 
 @testset "matlab ref" begin
     x0 = vec(readdlm(joinpath(dirname(@__FILE__), "data", "spectrogram_x.txt"),'\t'))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using  DSP, FFTW, Test
-import DSP: Frequencies, fftfreq, rfftfreq
 
 using Random: seed!
 


### PR DESCRIPTION
With the next release bumping the minor version, this might be a good time to remove the deprecations currently in place. Of course, the cost of keeping them around is also relatively little, hence RFC. Could also decide to remove only some them, of course. Maybe depending on how long they have been around?