### PR TITLE
Fix bugs in corner cases of conversion from ZeroPoleGain to SecondOrderSections

### DIFF
--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -324,7 +324,7 @@ function split_real_complex(x::Vector{T}) where T
     r = typeof(real(zero(T)))[]
     for k in keys(d)
         if imag(k) != 0
-            if !haskey(d, conj(k))
+            if !haskey(d, conj(k)) || d[k] != d[conj(k)]
                 # No match for conjugate
                 return (c, r, false)
             elseif imag(k) > 0

--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -282,10 +282,10 @@ PolynomialRatio{D}(f::SecondOrderSections{D}) where {D} = PolynomialRatio{D}(Zer
 # Group each pole in p with its closest zero in z
 # Remove paired poles from p and z
 function groupzp(z, p)
-    unpaired = fill(true, length(z))  # whether zeros have been mapped
     n = min(length(z), length(p))
     groupedz = similar(z, n)
-    for i = 1:n
+    i = 1
+    while i <= n
         closest_zero_idx = 0
         closest_zero_val = Inf
         for j = 1:length(z)
@@ -296,6 +296,11 @@ function groupzp(z, p)
             end
         end
         groupedz[i] = splice!(z, closest_zero_idx)
+        if !isreal(groupedz[i])
+            i += 1
+            groupedz[i] = splice!(z, closest_zero_idx)
+        end
+        i += 1
     end
     ret = (groupedz, p[1:n])
     splice!(p, 1:n)
@@ -317,7 +322,7 @@ function split_real_complex(x::Vector{T}) where T
 
     c = T[]
     r = typeof(real(zero(T)))[]
-    for k in sort!(collect(keys(d)), by=x -> (real(x), imag(x)))
+    for k in keys(d)
         if imag(k) != 0
             if !haskey(d, conj(k))
                 # No match for conjugate

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -258,6 +258,8 @@ end
 
     @test_throws ArgumentError convert(SecondOrderSections, ZeroPoleGain([0.5 + 0.5im, 0.5 + 0.5im], [0.5 + 0.5im, 0.5 - 0.5im], 1))
     @test_throws ArgumentError convert(SecondOrderSections, ZeroPoleGain([0.5 + 0.5im, 0.5 - 0.5im], [0.5 + 0.5im, 0.5 + 0.5im], 1))
+    @test_throws ArgumentError convert(SecondOrderSections, ZeroPoleGain([1+im, 1+im, 1-im], [1, 0, 0], 1))
+    @test_throws ArgumentError convert(SecondOrderSections, ZeroPoleGain([1+im, 1-im, 1-im], [1, 0, 0], 1))
 
     @test promote_type(SecondOrderSections{:z,Float64,Float32}, SecondOrderSections{:z,Float32,Float64}) == SecondOrderSections{:z,Float64,Float64}
     @test convert(SecondOrderSections{:z,Float32,Float32}, convert(SecondOrderSections, b)).biquads == convert(SecondOrderSections, convert(Biquad{:z,Float32}, b)).biquads

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -143,6 +143,12 @@ using Polynomials.PolyCompat
     f = ZeroPoleGain(ones(100), 0.99*ones(100), 1)
     g = convert(SecondOrderSections, f)
     tffilter_eq(convert(PolynomialRatio, f), convert(PolynomialRatio, g))
+
+    H = ZeroPoleGain{:z}([1+im, 1-im, 0.5+im, 0.5-im], [1, 0.0, 0.0, 0.0], 1.0)
+    H′ = ZeroPoleGain(SecondOrderSections(H))
+    @test sort(H.p, by=z->(real(z), imag(z))) ≈ sort(H′.p, by=z->(real(z), imag(z)))
+    @test sort(H.z, by=z->(real(z), imag(z))) ≈ sort(H′.z, by=z->(real(z), imag(z)))
+    @test H.k ≈ H′.k
 end
 
 @testset "conversions" begin


### PR DESCRIPTION
The first two commits fix bugs in corner cases, ~the third commit rewrites the while thing. I'm not sure 100% the rewrite is actually beneficial, so in the likely event I don't get a review on it within reasonable time, I'll just take it out. Therefore, in case anyone has only a little time to spend on this one, review of the first two commits only would also be quite welcome.~