### PR TITLE
Make conv return floats when given integer arrays

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -702,9 +702,6 @@ function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
     conv(fu, fv)
 end
 
-conv(u::AbstractArray{<:Integer, N}, v::AbstractArray{<:Integer, N}) where {N} =
-    round.(Int, conv(float(u), float(v)))
-
 conv(u::AbstractArray{<:Number, N}, v::AbstractArray{<:Number, N}) where {N} =
     conv(float(u), float(v))
 


### PR DESCRIPTION
Ref #410, suggestion from the comments.

This removes an unnecessary round. Dispatch for this case is now handled the same as for arrays of generic Number type, so the return type of conv([1, 2, 3], [4, 5, 6]) is now Float64 instead of Int, correctly reflecting the internal precision. Users can get the old behavior by calling round themselves, i.e. `round.(Int, conv(a, b))` or perhaps even `round.(promote_type(eltype(a), eltype(b)), conv(a, b))` for other integer types.

If DSP learns a method of integer convolution in the future, the return type for that method should be an integer.