### PR TITLE
replace 10^(x) with exp10(x) for db2pow and db2amp

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -135,7 +135,7 @@ const dBa = dBaconvert()
 Convert dB to a power ratio. This function call also be called
 using `a*dB`, i.e. `3dB == db2pow(3)`. The inverse of `pow2db`.
 """
-db2pow(a::Real) = 10^(a/10)
+db2pow(a::Real) = exp10(a/10)
 
 """
     db2amp(a)
@@ -143,7 +143,7 @@ db2pow(a::Real) = 10^(a/10)
 Convert dB to an amplitude ratio. This function call also be called
 using `a*dBa`, i.e. `3dBa == db2amp(3)`. The inverse of `amp2db`.
 """
-db2amp(a::Real) = 10^(a/20)
+db2amp(a::Real) = exp10(a/20)
 
 """
     pow2db(a)


### PR DESCRIPTION
replace 10^(x) with exp10(x) in db2pow and db2amp (about 4 times faster on my PC)