### PR TITLE
support for matrices in resample

### DIFF
--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -733,6 +733,17 @@ function resample(x::AbstractVector, rate::Real)
     resample(x, rate, h)
 end
 
+"""
+    resample(x::AbstractMatrix, rate::Real, h::Vector = resample_filter(rate); dims)
+
+Resample a matrix `x` along dimension `dims`.
+"""
+function resample(x::AbstractMatrix, rate::Real, h::Vector = resample_filter(rate); dims)
+    mapslices(x; dims=dims) do x
+        resample(x, rate, h)
+    end
+end
+
 #
 # References
 #

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -46,6 +46,21 @@ using Test
     @test y4_jl ≈ y4_ml
 end
 
+@testset "matrix signal" begin
+    rate   = 1//2
+    x_ml   = vec(readdlm(joinpath(dirname(@__FILE__), "data", "resample_x.txt"),'\t'))
+    h1_ml  = vec(readdlm(joinpath(dirname(@__FILE__), "data", "resample_taps_1_2.txt"),'\t'))
+    y1_ml  = vec(readdlm(joinpath(dirname(@__FILE__), "data", "resample_y_1_2.txt"),'\t'))
+
+    X = [x_ml 2x_ml]
+    y1_jl  = resample(X, rate, h1_ml, dims=1)
+    @test y1_jl ≈ [y1_ml 2y1_ml]
+
+    X = [x_ml'; 2x_ml']
+    y1_jl  = resample(X, rate, h1_ml, dims=2)
+    @test y1_jl ≈ [y1_ml'; 2y1_ml']
+end
+
 @testset "irrational ratio" begin
     ratio    = 3.141592653589793
     cycles   = 2


### PR DESCRIPTION
The PR simply adds the support of providing a matrix of signals to `resample` and a keyword argument `dims` to specify which dimension to resample along.