### PR TITLE
Enable previews of docs builds

### DIFF
--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -1,0 +1,18 @@
+name: Delete preview deployment
+
+on:
+  pull_request:
+    types: [ closed ]
+jobs:
+  delete-preview:
+    name: Delete preview deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - run: rm -rf previews/PR${{ github.event.number }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'Delete preview of PR#${{ github.event.number }}'
+          branch: gh-pages

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,4 +24,5 @@ deploydocs(
     target = "build",
     deps   = nothing,
     make   = nothing,
+    push_preview = true,
 )


### PR DESCRIPTION
As suggested by @rob-luke in https://github.com/JuliaDSP/DSP.jl/pull/421#issuecomment-827146995. Also included is another action that deletes the preview for closed/merged PRs.