### PR TITLE
Improve accuracy of `blackman`

### DIFF
--- a/src/windows.jl
+++ b/src/windows.jl
@@ -459,7 +459,7 @@ $zerophase_docs
 function blackman(n::Integer; padding::Integer=0, zerophase::Bool=false)
     a0, a1, a2 = 0.42, 0.5, 0.08
     makewindow(n, padding, zerophase) do x
-        a0 + a1*cos(2pi*x) + a2*cos(4pi*x)
+        a0 + a2*cospi(4*x) + a1*cospi(2*x)
     end
 end
 

--- a/test/windows.jl
+++ b/test/windows.jl
@@ -75,6 +75,7 @@ end
     blackman_jl = blackman(128)
     blackman_ml = readdlm(joinpath(dirname(@__FILE__), "data", "blackman128.txt"), '\t')
     @test blackman_jl ≈ blackman_ml
+    @test minimum(blackman_jl) == 0.0
 
     kaiser_jl = kaiser(128, 0.4/π)
     kaiser_ml = readdlm(joinpath(dirname(@__FILE__), "data", "kaiser128,0.4.txt"), '\t')


### PR DESCRIPTION
Fixes #347 by simply reordering the terms since, when inserting `-1` and `1`for the cosines:
```julia
julia> 0.42 - 0.5 + 0.08 # old order
-1.3877787807814457e-17 # resulting value at the edges

julia> 0.42 + 0.08 - 0.5 # new order
0.0
```
This should not matter much for the accuracy overall, but avoids this pathological case.

While at it, utilize `cospi` for potentially better accuracy by avoiding rounding of pi, but I'm not sure that has any practical impact. OTOH, it definitely should not hurt.