### PR TITLE
Update version for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DSP"
 uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-version = "0.7.0-dev"
+version = "0.7.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
According to https://github.com/JuliaDSP/DSP.jl/pull/408#issuecomment-827532999 the next version of DSP.jl needs to be breaking, which is why it was bumped to `0.7-dev`. Here, I remove the `dev` so that we can tag a release. I would really like a release to get #401 into a release of DSP.jl.