### PR TITLE
Avoid `BoundsError` in `groupzp`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DSP"
 uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -322,6 +322,9 @@ function groupzp(z, p)
         groupedz[i] = splice!(z, closest_zero_idx)
         if !isreal(groupedz[i])
             i += 1
+            if closest_zero_idx > length(z)
+                closest_zero_idx = length(z)
+            end
             groupedz[i] = splice!(z, closest_zero_idx)
         end
         i += 1

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -344,3 +344,14 @@ end
         @test coefb(f) == [0.0, 0.0, 1.0]
     end
 end
+
+@testset "issue #432" begin
+    bp1 = 0.75
+    bp2 = 10.0
+    Fsamp = 180
+    responsetype = Bandpass(bp1, bp2; fs = Fsamp)
+    designmethod = Elliptic(11, 0.25, 40)
+    bpass = digitalfilter(responsetype, designmethod)
+    H = SecondOrderSections(bpass) # this shouldn't throw
+    @test H isa SecondOrderSections
+end


### PR DESCRIPTION
The whole zero/pole grouping could use some love, I guess, but this is the easiest band-aid to fix #432.

I've also bumped the version for an immediate bugfix release.