### PR TITLE
Make `resample` more generic

### DIFF
--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -734,11 +734,11 @@ function resample(x::AbstractVector, rate::Real)
 end
 
 """
-    resample(x::AbstractMatrix, rate::Real, h::Vector = resample_filter(rate); dims)
+    resample(x::AbstractArray, rate::Real, h::Vector = resample_filter(rate); dims)
 
-Resample a matrix `x` along dimension `dims`.
+Resample an array `x` along dimension `dims`.
 """
-function resample(x::AbstractMatrix, rate::Real, h::Vector = resample_filter(rate); dims)
+function resample(x::AbstractArray, rate::Real, h::Vector = resample_filter(rate); dims)
     mapslices(x; dims=dims) do x
         resample(x, rate, h)
     end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -1,5 +1,6 @@
 using DSP
 using Test
+using DelimitedFiles: readdlm
 
 @testset "rational ratio" begin
     # AM Modulator
@@ -46,19 +47,29 @@ using Test
     @test y4_jl ≈ y4_ml
 end
 
-@testset "matrix signal" begin
+@testset "array signal" begin
     rate   = 1//2
     x_ml   = vec(readdlm(joinpath(dirname(@__FILE__), "data", "resample_x.txt"),'\t'))
     h1_ml  = vec(readdlm(joinpath(dirname(@__FILE__), "data", "resample_taps_1_2.txt"),'\t'))
     y1_ml  = vec(readdlm(joinpath(dirname(@__FILE__), "data", "resample_y_1_2.txt"),'\t'))
 
+    expected_result = [y1_ml 2y1_ml]
     X = [x_ml 2x_ml]
     y1_jl  = resample(X, rate, h1_ml, dims=1)
-    @test y1_jl ≈ [y1_ml 2y1_ml]
+    @test y1_jl ≈ expected_result
 
-    X = [x_ml'; 2x_ml']
-    y1_jl  = resample(X, rate, h1_ml, dims=2)
-    @test y1_jl ≈ [y1_ml'; 2y1_ml']
+    y1_jl  = resample(X', rate, h1_ml, dims=2)
+    @test y1_jl ≈ expected_result'
+
+    expected_result_3d = permutedims(reshape(expected_result, (size(expected_result, 1), size(expected_result, 2), 1)), (3, 1, 2))
+    X_3d = permutedims(reshape(X, (size(X, 1), size(X, 2), 1)), (3, 1, 2))
+    y1_jl  = resample(X_3d, rate, h1_ml, dims=2)
+    @test y1_jl ≈ expected_result_3d
+
+    expected_result_3d = permutedims(expected_result_3d, (1, 3, 2))
+    X_3d = permutedims(X_3d, (1, 3, 2))
+    y1_jl  = resample(X_3d, rate, h1_ml, dims=3)
+    @test y1_jl ≈ expected_result_3d
 end
 
 @testset "irrational ratio" begin


### PR DESCRIPTION
I found that `resample` is currently restricted to `AbstractMatrix`, which is an alias for `AbstractArray{T,2}`. Since `mapslices` works well with `dims > 2`, the changes from #414 can easily be extended to `AbstractArray` without restrictions on dimensionality, which I did in this PR.