### PR TITLE
Update badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DSP.jl
 ======
 
-[![Build Status](https://travis-ci.org/JuliaDSP/DSP.jl.svg?branch=master)](https://travis-ci.org/JuliaDSP/DSP.jl)
+[![CI](https://github.com/JuliaDSP/DSP.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaDSP/DSP.jl/actions/workflows/CI.yml)
 [![Coverage Status](https://coveralls.io/repos/JuliaDSP/DSP.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaDSP/DSP.jl?branch=master)
 
 DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia. These include:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ DSP.jl
 
 [![CI](https://github.com/JuliaDSP/DSP.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaDSP/DSP.jl/actions/workflows/CI.yml)
 [![Coverage Status](https://coveralls.io/repos/JuliaDSP/DSP.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaDSP/DSP.jl?branch=master)
+[![Documentation (stable)](https://img.shields.io/badge/docs-stable-blue.svg)](https://docs.juliadsp.org/stable/contents/)
+[![Documentation (latest)](https://img.shields.io/badge/docs-dev-blue.svg)](https://docs.juliadsp.org/latest/contents/)
 
 DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia. These include:
 


### PR DESCRIPTION
Replacing the Travis one with the Github actions one should be uncontroversial, given that the last Travis run was for v0.7.0 in May.
Adding the docs badges seems in line with how most (?) packages do it and I like it, too. I also don't expect anyone to be against them; speak up in case I am mistaken.