### PR TITLE
Butterworth Filter Order Estimation (#429)

### DIFF
--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -29,8 +29,9 @@ export  DF2TFilter,
         fftfilt!
 
 include("buttord.jl")
-export buttord
-
+export buttord,
+       bsfcost
+       
 include("design.jl")
 export  FilterType,
         Butterworth,

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -2,6 +2,7 @@ module Filters
 using ..Unwrap
 using ..Util
 using Polynomials: LaurentPolynomial, Polynomial, coeffs, derivative, fromroots, roots, indeterminate
+using Optim: optimize, minimizer
 
 import Base: *
 using LinearAlgebra: I, mul!, rmul!
@@ -26,6 +27,9 @@ export  DF2TFilter,
         tdfilt!,
         fftfilt,
         fftfilt!
+
+include("buttord.jl")
+export buttord
 
 include("design.jl")
 export  FilterType,

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -27,9 +27,6 @@ export  DF2TFilter,
         tdfilt!,
         fftfilt,
         fftfilt!
-
-include("buttord.jl")
-export buttord
        
 include("design.jl")
 export  FilterType,
@@ -47,6 +44,9 @@ export  FilterType,
         kaiserord,
         FIRWindow,
         resample_filter
+
+include("buttord.jl")
+export  buttord
 
 include("response.jl")
 export  freqresp,

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -29,8 +29,7 @@ export  DF2TFilter,
         fftfilt!
 
 include("buttord.jl")
-export buttord,
-       bsfcost
+export buttord
        
 include("design.jl")
 export  FilterType,

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -65,7 +65,7 @@ end
 
 function fromprototype(Wp::AbstractArray{<:Real}, Wscale::Real, ftype::Type{Bandpass})
     Wsc = [-Wscale, Wscale]
-    Wa = -Wsc .* (Wp[2]-Wp[1])./2 .+ sqrt.( Wsc.^2/4*(Wp[2]-Wp[1]).^2 + Wp[1]*Wp[2])
+    Wa = -Wsc .* (Wp[2]-Wp[1])./2 .+ sqrt.( Wsc.^2/4*(Wp[2]-Wp[1]).^2 .+ Wp[1]*Wp[2])
     sort!(abs.(Wa))
 end
 

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -1,12 +1,12 @@
 
 #
-# Prototype filter transformations
+# Butterworth prototype filter transformations
 #
 
-_toprototype(Wp::Real, Ws::Real, ftype::Lowpass) = Ws/Wp
-_toprototype(Wp::Real, Ws::Real, ftype::Highpass) = Wp/Ws
+_toprototype(Wp::Real, Ws::Real, ftype::Type{Lowpass}) = Ws/Wp
+_toprototype(Wp::Real, Ws::Real, ftype::Type{Highpass}) = Wp/Ws
 
-function _toprototype(Wp::Vector{Real}, Ws::Vector{Real}, ftype::Bandpass) 
+function _toprototype(Wp::Vector{Real}, Ws::Vector{Real}, ftype::Type{Bandpass}) 
     # bandpass filter must have two corner frequencies we're computing with
     @assert length(Ws) == 2
     @assert length(Wp) == 2
@@ -14,17 +14,17 @@ function _toprototype(Wp::Vector{Real}, Ws::Vector{Real}, ftype::Bandpass)
     Wn
 end
 
-_fromprototype(Wp::Real, Wscale::Real, ftype::Lowpass) = Wp*Wscale
-_fromprototype(Wp::Real, Wscale::Real, ftype::Highpass) = Wp/Wscale
+_fromprototype(Wp::Real, Wscale::Real, ftype::Type{Lowpass}) = Wp*Wscale
+_fromprototype(Wp::Real, Wscale::Real, ftype::Type{Highpass}) = Wp/Wscale
 
-function _fromprototype(Wp::Vector{Real}, Wscale::Real, ftype::Bandpass)
+function _fromprototype(Wp::Vector{Real}, Wscale::Real, ftype::Type{Bandpass})
     @assert length(Wp) == 2
     Wsc = [-Wscale, Wscale]
     Wn = -Wsc .* (Wp[2]-Wp[1])./2 .+ sqrt.( Wsc.^2/4*(Wp[2]-Wp[1]).^2 + Wp[1]*Wp[2])
     sort!(Wn)
 end
 
-function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real, ftype::Union{Lowpass{:z}, Highpass{:z}})
+function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real, ftype::Union{Type{Lowpass}, Type{Highpass}})
     """
         buttord(Wp, Ws, Rp, Rs, filtertype)
 
@@ -36,7 +36,7 @@ function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real, ftype::Union{Lowpass{:z
     # need to pre-warp since we want to use formulae for analog case.
     wp = tan(π/2 * Wp)
     ws = tan(π/2 * Ws)
-    wa = _toprototype(ws, wp, ftype)
+    wa = _toprototype(wp, ws, ftype)
 
     # rounding up fractional order. Using differences of logs instead of division. 
     N = ceil((log10(^(10, 0.1*Rs) - 1) - log10(^(10, 0.1*Rp) - 1)) / (2*log10(wa)))
@@ -46,5 +46,5 @@ function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real, ftype::Union{Lowpass{:z
     
     # convert back to the original analog filter and bilinear xform.
     Wn = (2/π)*atan(_fromprototype(wp, wscale, ftype))
-    order, Wn
+    N, Wn
 end

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -149,7 +149,7 @@ function buttord(Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real,
     end
 
     # get the integer order estimate.
-    N = ceil(order_estimate(Rp, Rs, wa))
+    N = ceil(Int, order_estimate(Rp, Rs, wa))
 
     wscale = natfreq_estimate(wa, Rs, Integer(N))
     ωn = (2/π).*atan.(fromprototype(wp, wscale, ftype))

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -50,15 +50,15 @@ computing in Python. Nature methods, 17(3), 261-272.
 
 ====================================================================#
 
-function bsfcost(Wx::Real, uselowband::Bool, Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real, Rs::Real)
-    """
-        bsfcost(Wx, uselowband, Wp, Ws, Rs, Rp)
+"""
+    N = bsfcost(Wx, uselowband, Wp, Ws, Rs, Rp)
 
-    Bandstop filter order estimation. The primary variables are `Wx` and `uselowband`,
-    which indicate the test passband edge and if to use the lower edge. If false, the
-    test frequency is used in high-band, ([low, high] ordering in Wp.) This function
-    returns a non-integer BSF order estimate.
-    """
+Bandstop filter order estimation. The primary variables are `Wx` and `uselowband`,
+which indicate the test passband edge and if to use the lower edge. If false, the
+test frequency is used in high-band, ([low, high] ordering in Wp.) This function
+returns a non-integer BSF order estimate.
+"""
+function bsfcost(Wx::Real, uselowband::Bool, Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real, Rs::Real)
 
     # override one of the passband edges with the test frequency.
     Wpc = uselowband ? [Wx, Wp[2]] : [Wp[1], Wx]
@@ -119,15 +119,19 @@ end
 order_estimate(Rp::Real, Rs::Real, warp::Real) = (log10(^(10, 0.1*Rs) - 1) - log10(^(10, 0.1*Rp) - 1)) / (2*log10(warp))
 natfreq_estimate(warp::Real, Rs::Real, order::Integer) = warp / (^(10, 0.1*Rs) - 1)^(1/(2*order))
 
+
+"""
+    (N, ωn) = buttord(Wp, Ws, Rp, Rs)
+
+Butterworth order estimate for bandpass and bandstop filter types. 
+`Wp` and `Ws` are 2-element pass and stopband frequency edges, with 
+no more than `Rp` dB passband ripple and at least `Rs` dB stopband 
+attenuation. Based on the ordering of passband and bandstop edges, 
+the Bandstop or Bandpass filter type is inferred. `N` is an integer 
+indicating the lowest estimated filter order, with `ωn` specifying
+the cutoff or "-3 dB" frequencies.
+"""
 function buttord(Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real, Rs::Real)
-    """
-        buttord(Wp, Ws, Rp, Rs)
-
-    Butterworth order estimate for bandpass and bandstop filter types. 
-    `Wp` and `Ws` are 2-element pass/stopband frequency edges, with filttype specifying
-    the `Bandpass` or `Bandstop` filter types.
-    """
-
     length(Wp) == 2 || error("2 passband frequencies were expected.")
     length(Ws) == 2 || error("2 stopband frequencies were expected.")
     
@@ -156,17 +160,17 @@ function buttord(Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real,
     N, ωn
 end
 
+"""
+    (N, ωn) = buttord(Wp, Ws, Rp, Rs)
+
+LPF/HPF Butterworth filter order and -3 dB frequency approximation. `Wp`
+and `Ws` are the passband and stopband frequencies, whereas Rp and Rs 
+are the passband and stopband ripple attenuations in dB. 
+If the passband is greater than stopband, the filter type is inferred to 
+be for estimating the order of a highpass filter. `N` specifies the lowest
+possible integer filter order, whereas `ωn` is the cutoff or "-3 dB" frequency.
+"""
 function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real)
-    """
-        buttord(Wp, Ws, Rp, Rs)
-
-    LPF/HPF Butterworth filter order and -3 dB frequency approximation. `Wp`
-    and `Ws` are the passband and stopband frequencies, whereas Rp and Rs 
-    are the passband and stopband ripple attenuations in dB. 
-    If the passband is greater than stopband, the filter type is inferred to 
-    be for estimating the order of a highpass filter.
-    """
-
     # infer which filter type based on the frequency ordering.
     ftype = (Wp < Ws) ? Lowpass : Highpass
 

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -115,7 +115,7 @@ function fromprototype(Wp::Tuple{Real,Real}, Wscale::Real, ftype::Type{Bandpass}
 end
 
 order_estimate(Rp::Real, Rs::Real, warp::Real) = (log10(db2pow(Rs) - 1) - log10(db2pow(Rp) - 1)) / (2*log10(warp))
-natfreq_estimate(warp::Real, Rs::Real, order::Integer) = warp / (^(10, 0.1*Rs) - 1)^(1/(2*order))
+natfreq_estimate(warp::Real, Rs::Real, order::Integer) = warp / (db2pow(Rs) - 1)^(1/(2*order))
 
 
 """

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -1,0 +1,50 @@
+
+#
+# Prototype filter transformations
+#
+
+_toprototype(Wp::Real, Ws::Real, ftype::Lowpass) = Ws/Wp
+_toprototype(Wp::Real, Ws::Real, ftype::Highpass) = Wp/Ws
+
+function _toprototype(Wp::Vector{Real}, Ws::Vector{Real}, ftype::Bandpass) 
+    # bandpass filter must have two corner frequencies we're computing with
+    @assert length(Ws) == 2
+    @assert length(Wp) == 2
+    Wn = (Ws.^2 .- Wp[1]*Wp[2]) ./ (Ws .* (Wp[1]-Wp[2]))
+    Wn
+end
+
+_fromprototype(Wp::Real, Wscale::Real, ftype::Lowpass) = Wp*Wscale
+_fromprototype(Wp::Real, Wscale::Real, ftype::Highpass) = Wp/Wscale
+
+function _fromprototype(Wp::Vector{Real}, Wscale::Real, ftype::Bandpass)
+    @assert length(Wp) == 2
+    Wsc = [-Wscale, Wscale]
+    Wn = -Wsc .* (Wp[2]-Wp[1])./2 .+ sqrt.( Wsc.^2/4*(Wp[2]-Wp[1]).^2 + Wp[1]*Wp[2])
+    sort!(Wn)
+end
+
+function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real, ftype::Union{Lowpass{:z}, Highpass{:z}})
+    """
+        buttord(Wp, Ws, Rp, Rs, filtertype)
+
+    Butterworth filter order and -3 dB frequency approximation. The lowpass and highpass filters
+    are supported, currently working on the bandpass and bandstop prototype transformations. `Wp`
+    and `Ws` are the passband and stopband frequencies, whereas Rp and Rs are the passband and
+    stopband ripple attenuations in dB.
+    """
+    # need to pre-warp since we want to use formulae for analog case.
+    wp = tan(π/2 * Wp)
+    ws = tan(π/2 * Ws)
+    wa = _toprototype(ws, wp, ftype)
+
+    # rounding up fractional order. Using differences of logs instead of division. 
+    N = ceil((log10(^(10, 0.1*Rs) - 1) - log10(^(10, 0.1*Rp) - 1)) / (2*log10(wa)))
+    
+    # specifications for the stopband ripple are met precisely.
+    wscale = wa / (^(10, 0.1*Rs) - 1)^(1/(2*N))
+    
+    # convert back to the original analog filter and bilinear xform.
+    Wn = (2/π)*atan(_fromprototype(wp, wscale, ftype))
+    order, Wn
+end

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -182,7 +182,7 @@ function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real)
     N = ceil(Int, order_estimate(Rp, Rs, wa))
     
     # specifications for the stopband ripple are met precisely.
-    wscale = natfreq_estimate(wa, Rs, Integer(N))
+    wscale = natfreq_estimate(wa, Rs, N)
     
     # convert back to the original analog filter and bilinear xform.
     ωn = (2/π)*atan(fromprototype(wp, wscale, ftype))

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -154,7 +154,7 @@ function buttord(Wp::Tuple{Real,Real}, Ws::Tuple{Real,Real}, Rp::Real, Rs::Real)
     # get the integer order estimate.
     N = ceil(Int, order_estimate(Rp, Rs, wa))
 
-    wscale = natfreq_estimate(wa, Rs, Integer(N))
+    wscale = natfreq_estimate(wa, Rs, N)
     ωn = (2/π).*atan.(fromprototype(wpadj, wscale, ftype))
     N, ωn
 end

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -38,15 +38,16 @@ function toprototype!(Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::
     # NOTE: the optimization function will adjust the corner frequencies in Wp, modifying the original input.
     length(Wp) == 2 || error("2 passband frequencies were expected.")
     length(Ws) == 2 || error("2 stopband frequencies were expected.")
-
-    C₁(w, px) = bsfcost(w, true, Wp, Ws, Rp, Rs)
-    C₂(w, px) = bsfcost(w, false, Wp, Ws, Rp, Rs)
     tol = eps(typeof(Wp[1]))^(2/3)
 
     # optimize order on bound [passband low < w < stopband-tolerance].
+    C₁(w) = bsfcost(w, true, Wp, Ws, Rp, Rs)
     p1 = minimizer(optimize(C₁, Wp[1], Ws[1]-tol))
     Wp[1] = p1 # modifying band edge for next optimization run.
     
+    # declaring the 2nd cost function here to make sure the overwritten 
+    # passband edge vector Wp is used.
+    C₂(w) = bsfcost(w, false, Wp, Ws, Rp, Rs)
     p2 = minimizer(optimize(C₂, Ws[2]+tol, Wp[2]))
     Wp[2] = p2
 

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -114,7 +114,7 @@ function fromprototype(Wp::Tuple{Real,Real}, Wscale::Real, ftype::Type{Bandpass}
     sort!(abs.(Wa))
 end
 
-order_estimate(Rp::Real, Rs::Real, warp::Real) = (log10(db2pow(Rs) - 1) - log10(db2pow(Rp) - 1)) / (2*log10(warp))
+order_estimate(Rp::Real, Rs::Real, warp::Real) = (log(db2pow(Rs) - 1) - log(db2pow(Rp) - 1)) / (2*log(warp))
 natfreq_estimate(warp::Real, Rs::Real, order::Integer) = warp / (db2pow(Rs) - 1)^(1/(2*order))
 
 

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -176,7 +176,7 @@ function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real)
     wa = toprototype(wp, ws, ftype)
 
     # rounding up fractional order. Using differences of logs instead of division. 
-    N = ceil(order_estimate(Rp, Rs, wa))
+    N = ceil(Int, order_estimate(Rp, Rs, wa))
     
     # specifications for the stopband ripple are met precisely.
     wscale = natfreq_estimate(wa, Rs, Integer(N))

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -114,7 +114,7 @@ function fromprototype(Wp::Tuple{Real,Real}, Wscale::Real, ftype::Type{Bandpass}
     sort!(abs.(Wa))
 end
 
-order_estimate(Rp::Real, Rs::Real, warp::Real) = (log10(^(10, 0.1*Rs) - 1) - log10(^(10, 0.1*Rp) - 1)) / (2*log10(warp))
+order_estimate(Rp::Real, Rs::Real, warp::Real) = (log10(db2pow(Rs) - 1) - log10(db2pow(Rp) - 1)) / (2*log10(warp))
 natfreq_estimate(warp::Real, Rs::Real, order::Integer) = warp / (^(10, 0.1*Rs) - 1)^(1/(2*order))
 
 

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -104,7 +104,7 @@ function buttord(Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real,
     # get the integer order estimate.
     N = ceil(order_estimate(Rp, Rs, wa))
 
-    wscale = natfreq_estimate(wa, Rs, N)
+    wscale = natfreq_estimate(wa, Rs, Integer(N))
     ωn = (2/π).*atan.(fromprototype(wp, wscale, ftype))
     N, ωn
 end

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -3,25 +3,42 @@
 # Butterworth prototype filter transformations
 #
 
-_toprototype(Wp::Real, Ws::Real, ftype::Type{Lowpass}) = Ws/Wp
-_toprototype(Wp::Real, Ws::Real, ftype::Type{Highpass}) = Wp/Ws
+_toprototype(Wp::Real, Ws::Real, ftype::Type{Lowpass}) = Ws / Wp
+_toprototype(Wp::Real, Ws::Real, ftype::Type{Highpass}) = Wp / Ws
 
 function _toprototype(Wp::Vector{Real}, Ws::Vector{Real}, ftype::Type{Bandpass}) 
     # bandpass filter must have two corner frequencies we're computing with
-    @assert length(Ws) == 2
-    @assert length(Wp) == 2
+    length(Wp) == 2 || error("2 passband frequencies were expected.")
+    length(Ws) == 2 || error("2 stopband frequencies were expected.")
     Wn = (Ws.^2 .- Wp[1]*Wp[2]) ./ (Ws .* (Wp[1]-Wp[2]))
     Wn
 end
 
-_fromprototype(Wp::Real, Wscale::Real, ftype::Type{Lowpass}) = Wp*Wscale
-_fromprototype(Wp::Real, Wscale::Real, ftype::Type{Highpass}) = Wp/Wscale
+_fromprototype(Wp::Real, Wscale::Real, ftype::Type{Lowpass}) = Wp * Wscale
+_fromprototype(Wp::Real, Wscale::Real, ftype::Type{Highpass}) = Wp / Wscale
 
 function _fromprototype(Wp::Vector{Real}, Wscale::Real, ftype::Type{Bandpass})
-    @assert length(Wp) == 2
+    length(Wp) == 2 || error("2 passband frequencies were expected.")
     Wsc = [-Wscale, Wscale]
     Wn = -Wsc .* (Wp[2]-Wp[1])./2 .+ sqrt.( Wsc.^2/4*(Wp[2]-Wp[1]).^2 + Wp[1]*Wp[2])
     sort!(Wn)
+end
+
+_order_estimate(Rp::Real, Rs::Real, warp::Real) = ceil((log10(^(10, 0.1*Rs) - 1) - log10(^(10, 0.1*Rp) - 1)) / (2*log10(warp)))
+_natfreq_estimate(warp::Real, Rs::Real, order::Integer) = warp / (^(10, 0.1*Rs) - 1)^(1/(2*order))
+
+function buttord(Wp::Array{Real}, Ws::Array{Real}, Rs::Real, Rp::Real, ftype::Union{Type{Bandpass}, Type{Bandstop}})
+    
+    # pre-warp both components
+    wp = tan.(π/2 .* Wp)
+    ws = tan.(π/2 .* Ws)
+    wa = _toprototype(wp, ws, ftype)
+
+    N = _order_estimate(Rp, Rs, wa)
+
+    wscale = _natfreq_estimate(wa, Rs, N)
+    ωn = (2/π).*atan.(_fromprototype(wp, wscale, ftype))
+    N, ωn
 end
 
 function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real, ftype::Union{Type{Lowpass}, Type{Highpass}})
@@ -33,18 +50,25 @@ function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real, ftype::Union{Type{Lowpa
     and `Ws` are the passband and stopband frequencies, whereas Rp and Rs are the passband and
     stopband ripple attenuations in dB.
     """
+
+    if ((ftype == Lowpass) && (Wp > Ws))
+        error("Passband frequency must be less than stopband frequency for Lowpass filters.")
+    elseif ((ftype == Highpass) && (Ws > Wp))
+        error("Passband frequency must be greater than stopband frequency for Highpass filters.")
+    end
+
     # need to pre-warp since we want to use formulae for analog case.
     wp = tan(π/2 * Wp)
     ws = tan(π/2 * Ws)
     wa = _toprototype(wp, ws, ftype)
 
     # rounding up fractional order. Using differences of logs instead of division. 
-    N = ceil((log10(^(10, 0.1*Rs) - 1) - log10(^(10, 0.1*Rp) - 1)) / (2*log10(wa)))
+    N = _order_estimate(Rp, Rs, wa)
     
     # specifications for the stopband ripple are met precisely.
-    wscale = wa / (^(10, 0.1*Rs) - 1)^(1/(2*N))
+    wscale = _natfreq_estimate(wa, Rs, Integer(N))
     
     # convert back to the original analog filter and bilinear xform.
-    Wn = (2/π)*atan(_fromprototype(wp, wscale, ftype))
-    N, Wn
+    ωn = (2/π)*atan(_fromprototype(wp, wscale, ftype))
+    N, ωn
 end

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -1,7 +1,54 @@
 
-#
-# Butterworth prototype filter transformations
-#
+#====================================================================
+
+Butterworth filter order estimation.
+Jordan R. Smith, 2021.
+
+Filter transformations translated from Scipy to Julia.
+
+SCIPY license:
+Copyright (c) 2001, 2002 Enthought, Inc.
+All rights reserved.
+
+Copyright (c) 2003-2017 SciPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  a. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  b. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  c. Neither the name of Enthought nor the names of the SciPy Developers
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+--- end of scipy license
+
+Design equations based on [1], Chapter 10.
+
+[1] Proakis, J. G., & Manolakis, D. G. (1996). Digital Signal Processing, Fourth Edition. 
+Prentice Hall, New Jersey.
+[2] Virtanen, P., Gommers, R., Oliphant, T. E., Haberland, M., Reddy, T., 
+Cournapeau, D., ... & Van Mulbregt, P. (2020). SciPy 1.0: fundamental algorithms for scientific 
+computing in Python. Nature methods, 17(3), 261-272.
+
+====================================================================#
 
 function bsfcost(Wx::Real, uselowband::Bool, Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real, Rs::Real)
     """

--- a/src/Filters/buttord.jl
+++ b/src/Filters/buttord.jl
@@ -3,41 +3,107 @@
 # Butterworth prototype filter transformations
 #
 
-_toprototype(Wp::Real, Ws::Real, ftype::Type{Lowpass}) = Ws / Wp
-_toprototype(Wp::Real, Ws::Real, ftype::Type{Highpass}) = Wp / Ws
 
-function _toprototype(Wp::Vector{Real}, Ws::Vector{Real}, ftype::Type{Bandpass}) 
+function bsfcost(Wx::Real, uselowband::Bool, Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real, Rs::Real)
+    """
+        bsfcost(Wx, uselowband, Wp, Ws, Rs, Rp)
+
+    Bandstop filter order estimation. The primary variables are `Wx` and `uselowband`,
+    which indicate the test passband edge and if to use the lower edge. If false, the
+    test frequency is used in high-band, ([low, high] ordering in Wp.) This function
+    returns a non-integer BSF order estimate.
+    """
+
+    # override one of the passband edges with the test frequency.
+    Wpc = uselowband ? [Wx, Wp[2]] : [Wp[1], Wx]
+    
+    # get the new warp frequency.
+    warp = minimum(abs.((Ws .* (Wpc[1]-Wpc[2])) ./ (Ws.^2 .- (Wpc[1]*Wpc[2]))))
+
+    # use the new frequency to determine the new filter order.
+    order_estimate(Rp, Rs, warp)
+end
+
+toprototype(Wp::Real, Ws::Real, ftype::Type{Lowpass}) = Ws / Wp
+toprototype(Wp::Real, Ws::Real, ftype::Type{Highpass}) = Wp / Ws
+
+function toprototype(Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, ftype::Type{Bandpass}) 
     # bandpass filter must have two corner frequencies we're computing with
     length(Wp) == 2 || error("2 passband frequencies were expected.")
     length(Ws) == 2 || error("2 stopband frequencies were expected.")
-    Wn = (Ws.^2 .- Wp[1]*Wp[2]) ./ (Ws .* (Wp[1]-Wp[2]))
-    Wn
+    Wa = (Ws.^2 .- Wp[1]*Wp[2]) ./ (Ws .* (Wp[1]-Wp[2]))
+    minimum(abs.(Wa))
 end
 
-_fromprototype(Wp::Real, Wscale::Real, ftype::Type{Lowpass}) = Wp * Wscale
-_fromprototype(Wp::Real, Wscale::Real, ftype::Type{Highpass}) = Wp / Wscale
+function toprototype!(Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real, Rs::Real, ftype::Type{Bandstop})
+    # NOTE: the optimization function will adjust the corner frequencies in Wp, modifying the original input.
+    length(Wp) == 2 || error("2 passband frequencies were expected.")
+    length(Ws) == 2 || error("2 stopband frequencies were expected.")
 
-function _fromprototype(Wp::Vector{Real}, Wscale::Real, ftype::Type{Bandpass})
+    C₁(w, px) = bsfcost(w, true, Wp, Ws, Rp, Rs)
+    C₂(w, px) = bsfcost(w, false, Wp, Ws, Rp, Rs)
+    tol = eps(typeof(Wp[1]))^(2/3)
+
+    # optimize order on bound [passband low < w < stopband-tolerance].
+    p1 = minimizer(optimize(C₁, Wp[1], Ws[1]-tol))
+    Wp[1] = p1 # modifying band edge for next optimization run.
+    
+    p2 = minimizer(optimize(C₂, Ws[2]+tol, Wp[2]))
+    Wp[2] = p2
+
+    Wa = (Ws .* (Wp[1]-Wp[2])) ./ (Ws.^2 .- (Wp[1]-Wp[2]))
+    minimum(abs.(Wa))
+end
+
+fromprototype(Wp::Real, Wscale::Real, ftype::Type{Lowpass}) = Wp * Wscale
+fromprototype(Wp::Real, Wscale::Real, ftype::Type{Highpass}) = Wp / Wscale
+
+function fromprototype(Wp::AbstractArray{<:Real}, Wscale::Real, ftype::Type{Bandstop})
+    length(Wp) == 2 || error("2 passband frequencies were  expected.")
+    Wa = zeros(2)
+    diff = Wp[2]-Wp[1]
+    prod = Wp[2]*Wp[1]
+    Wa[1] = (diff + sqrt(diff^2 + 4*(Wscale^2)*prod)) / (2*Wscale)
+    Wa[2] = (diff - sqrt(diff^2 + 4*(Wscale^2)*prod)) / (2*Wscale)
+    sort!(abs.(Wa))
+    Wa
+end
+
+function fromprototype(Wp::AbstractArray{<:Real}, Wscale::Real, ftype::Type{Bandpass})
     length(Wp) == 2 || error("2 passband frequencies were expected.")
     Wsc = [-Wscale, Wscale]
-    Wn = -Wsc .* (Wp[2]-Wp[1])./2 .+ sqrt.( Wsc.^2/4*(Wp[2]-Wp[1]).^2 + Wp[1]*Wp[2])
-    sort!(Wn)
+    Wa = -Wsc .* (Wp[2]-Wp[1])./2 .+ sqrt.( Wsc.^2/4*(Wp[2]-Wp[1]).^2 + Wp[1]*Wp[2])
+    sort!(abs.(Wa))
+    Wa
 end
 
-_order_estimate(Rp::Real, Rs::Real, warp::Real) = ceil((log10(^(10, 0.1*Rs) - 1) - log10(^(10, 0.1*Rp) - 1)) / (2*log10(warp)))
-_natfreq_estimate(warp::Real, Rs::Real, order::Integer) = warp / (^(10, 0.1*Rs) - 1)^(1/(2*order))
+order_estimate(Rp::Real, Rs::Real, warp::Real) = (log10(^(10, 0.1*Rs) - 1) - log10(^(10, 0.1*Rp) - 1)) / (2*log10(warp))
+natfreq_estimate(warp::Real, Rs::Real, order::Integer) = warp / (^(10, 0.1*Rs) - 1)^(1/(2*order))
 
-function buttord(Wp::Array{Real}, Ws::Array{Real}, Rs::Real, Rp::Real, ftype::Union{Type{Bandpass}, Type{Bandstop}})
+function buttord(Wp::AbstractArray{<:Real}, Ws::AbstractArray{<:Real}, Rp::Real, Rs::Real, ftype::Union{Type{Bandpass}, Type{Bandstop}})
+    """
+        buttord(Wp, Ws, Rp, Rs, filttype)
+
+    Butterworth order estimate for bandpass and bandstop filter types. 
+    `Wp` and `Ws` are 2-element pass/stopband frequency edges, with filttype specifying
+    the `Bandpass` or `Bandstop` filter types.
+    """
     
     # pre-warp both components
     wp = tan.(π/2 .* Wp)
     ws = tan.(π/2 .* Ws)
-    wa = _toprototype(wp, ws, ftype)
+    if (type == Bandstop)
+        # optimizer modifies passband frequencies. this is intended behavior.
+        wa = toprototype!(wp, ws, Rp, Rs, ftype)
+    else
+        wa = toprototype(wp, ws, ftype)
+    end
 
-    N = _order_estimate(Rp, Rs, wa)
+    # get the integer order estimate.
+    N = ceil(order_estimate(Rp, Rs, wa))
 
-    wscale = _natfreq_estimate(wa, Rs, N)
-    ωn = (2/π).*atan.(_fromprototype(wp, wscale, ftype))
+    wscale = natfreq_estimate(wa, Rs, N)
+    ωn = (2/π).*atan.(fromprototype(wp, wscale, ftype))
     N, ωn
 end
 
@@ -60,15 +126,15 @@ function buttord(Wp::Real, Ws::Real, Rp::Real, Rs::Real, ftype::Union{Type{Lowpa
     # need to pre-warp since we want to use formulae for analog case.
     wp = tan(π/2 * Wp)
     ws = tan(π/2 * Ws)
-    wa = _toprototype(wp, ws, ftype)
+    wa = toprototype(wp, ws, ftype)
 
     # rounding up fractional order. Using differences of logs instead of division. 
-    N = _order_estimate(Rp, Rs, wa)
+    N = ceil(order_estimate(Rp, Rs, wa))
     
     # specifications for the stopband ripple are met precisely.
-    wscale = _natfreq_estimate(wa, Rs, Integer(N))
+    wscale = natfreq_estimate(wa, Rs, Integer(N))
     
     # convert back to the original analog filter and bilinear xform.
-    ωn = (2/π)*atan(_fromprototype(wp, wscale, ftype))
+    ωn = (2/π)*atan(fromprototype(wp, wscale, ftype))
     N, ωn
 end

--- a/test/buttord.jl
+++ b/test/buttord.jl
@@ -11,9 +11,19 @@ using DSP, Test
     # [n, Wn] = buttord(Wp, Ws, 3, 60)
     #
 
-    (n, Wn) = buttord(40/500, 150/500, 3, 60, Lowpass)
+    (n, Wn) = buttord(40/500, 150/500, 3, 60)
     @test n == 5
-    @test isapprox(Wn, 0.0810, rtol=1e-3)
+    @test isapprox(Wn, 0.081038494957764, rtol=1e-12)
+
+    #
+    # Highpass filter example
+    # Wp = 600/2000; Ws = 1200/2000;
+    # Rs = 3; Rp = 60;
+
+    (nhpf, Wnhpf) = buttord(600/2000, 1200/2000, 3, 60)
+    @test nhpf == 7
+    @test isapprox(Wnhpf, 0.301783479785, rtol=1e-12)
+
 
     #
     # https://www.mathworks.com/help/signal/ref/buttord.html#d123e9937
@@ -26,8 +36,23 @@ using DSP, Test
     # [n, Wn] = buttord(Wp, Ws, Rp, Rs)
     #
 
-    (nbp, Wnbp) = buttord([100/500, 200/500], [50/500, 250/500], 3, 40, Bandpass)
+    (nbp, Wnbp) = buttord([100/500, 200/500], [50/500, 250/500], 3, 40)
     @test nbp == 8
-    @test isapprox(Wnbp[1], 0.1951, rtol=1e-3)
-    @test isapprox(Wnbp[2], 0.4080, rtol=1e-3)
+    @test isapprox(Wnbp[1], 0.195101359239, rtol=1e-12)
+    @test isapprox(Wnbp[2], 0.408043633382, rtol=1e-12)
+
+    #
+    # Bandstop Example, (44.1 kHz Nyquist)
+    # Wp = [3200 7800]/22050
+    # Ws = [4800 5600]/22050
+    # Rp = 2
+    # Rs = 60
+
+    # this test may be more sensitive...MATLAB's implementation of bounded minimization
+    # will yield different results in comparison to Optim.jl.
+    (nbs, Wnbs) = buttord([3200/22050, 7800/22050], [4800/22050, 5600/22050], 2, 60)
+    @test nbs == 5
+    @test isapprox(Wnbs[1], 0.172660908966, rtol=1e-12)
+    @test isapprox(Wnbs[2], 0.314956388749, rtol=1e-12)
+
 end

--- a/test/buttord.jl
+++ b/test/buttord.jl
@@ -35,7 +35,7 @@ using DSP, Test
     # [n, Wn] = buttord(Wp, Ws, Rp, Rs)
     #
 
-    (nbp, Wnbp) = buttord([100/500, 200/500], [50/500, 250/500], 3, 40)
+    (nbp, Wnbp) = buttord(tuple(100/500, 200/500), tuple(50/500, 250/500), 3, 40)
     @test nbp == 8
     @test Wnbp[1] ≈ 0.195101359239
     @test Wnbp[2] ≈ 0.408043633382
@@ -49,7 +49,7 @@ using DSP, Test
 
     # this test may be more sensitive...MATLAB's implementation of bounded minimization
     # will yield different results in comparison to Optim.jl.
-    (nbs, Wnbs) = buttord([3200/22050, 7800/22050], [4800/22050, 5600/22050], 2, 60)
+    (nbs, Wnbs) = buttord(tuple(3200/22050, 7800/22050), tuple(4800/22050, 5600/22050), 2, 60)
     @test nbs == 5
     @test ≈(Wnbs[1], 0.172660908966, rtol=1e-3)
     @test ≈(Wnbs[2], 0.314956388749, rtol=1e-3)

--- a/test/buttord.jl
+++ b/test/buttord.jl
@@ -1,0 +1,33 @@
+using DSP, Test
+
+@testset "buttord" begin
+    
+    #
+    # https://www.mathworks.com/help/signal/ref/buttord.html#d123e9937
+    # Example 1: Lowpass Butterworth Example
+    #
+    # Wp = 40/500;
+    # Ws = 150/500;
+    # [n, Wn] = buttord(Wp, Ws, 3, 60)
+    #
+
+    (n, Wn) = buttord(40/500, 150/500, 3, 60, Lowpass)
+    @test n == 5
+    @test isapprox(Wn, 0.0810, rtol=1e-3)
+
+    #
+    # https://www.mathworks.com/help/signal/ref/buttord.html#d123e9937
+    # Example 2: Bandpass Butterworth Example
+    #
+    # Wp = [100 200]/500;
+    # Ws = [50 250]/500;
+    # Rp = 3;
+    # Rs = 40;
+    # [n, Wn] = buttord(Wp, Ws, Rp, Rs)
+    #
+
+    (nbp, Wnbp) = buttord([100/500, 200/500], [50/500, 250/500], 3, 40, Bandpass)
+    @test nbp == 8
+    @test isapprox(Wnbp[1], 0.1951, rtol=1e-3)
+    @test isapprox(Wnbp[2], 0.4080, rtol=1e-3)
+end

--- a/test/buttord.jl
+++ b/test/buttord.jl
@@ -11,18 +11,30 @@ using DSP, Test
     # [n, Wn] = buttord(Wp, Ws, 3, 60)
     #
 
-    (n, Wn) = buttord(40/500, 150/500, 3, 60)
+    # z-domain test
+    (n, Wn) = buttord(40/500, 150/500, 3, 60, domain=:z)
     @test n == 5
     @test Wn ≈ 0.081038494957764
+
+    # s-domain test
+    (ns, Wns) = buttord(40/500, 150/500, 3, 60, domain=:s)
+    @test ns == 6
+    @test Wns ≈ 0.0948683377107
 
     #
     # Highpass filter example
     # Wp = 600/2000; Ws = 1200/2000;
     # Rs = 3; Rp = 60;
 
-    (nhpf, Wnhpf) = buttord(600/2000, 1200/2000, 3, 60)
+    # z-domain (default)
+    (nhpf, Wnhpf) = buttord(600/2000, 1200/2000, 3, 60, domain=:z)
     @test nhpf == 7
     @test Wnhpf ≈ 0.301783479785
+
+    # s-domain test
+    (nhpfs, Wnhpfs) = buttord(60/2000, 1200/2000, 3, 60, domain=:s)
+    @test nhpfs == 3
+    @test Wnhpf ≈ 0.06000001
 
     #
     # https://www.mathworks.com/help/signal/ref/buttord.html#d123e9937
@@ -35,10 +47,16 @@ using DSP, Test
     # [n, Wn] = buttord(Wp, Ws, Rp, Rs)
     #
 
-    (nbp, Wnbp) = buttord(tuple(100/500, 200/500), tuple(50/500, 250/500), 3, 40)
+    (nbp, Wnbp) = buttord(tuple(100/500, 200/500), tuple(50/500, 250/500), 3, 40, domain=:z)
     @test nbp == 8
     @test Wnbp[1] ≈ 0.195101359239
     @test Wnbp[2] ≈ 0.408043633382
+
+    # s-domain
+    (nbps, Wnbps) = buttord(tuple(100/500, 200/500), tuple(50/500, 250/500), 3, 40, domain=:s)
+    @test nbps == 9
+    @test Wnbps[1] ≈ 0.198730150231
+    @test Wnbps[2] ≈ 0.402555927759
 
     #
     # Bandstop Example, (44.1 kHz Nyquist)
@@ -49,9 +67,14 @@ using DSP, Test
 
     # this test may be more sensitive...MATLAB's implementation of bounded minimization
     # will yield different results in comparison to Optim.jl.
-    (nbs, Wnbs) = buttord(tuple(3200/22050, 7800/22050), tuple(4800/22050, 5600/22050), 2, 60)
+    (nbs, Wnbs) = buttord(tuple(3200/22050, 7800/22050), tuple(4800/22050, 5600/22050), 2, 60, domain=:z)
     @test nbs == 5
     @test ≈(Wnbs[1], 0.172660908966, rtol=1e-3)
     @test ≈(Wnbs[2], 0.314956388749, rtol=1e-3)
+
+    # s-domain
+    (nbss, Wnbss) = buttord(tuple(3200/22050, 7800/22050), tuple(4800/22050, 5600/22050), 2, 60, domain=:s)
+    @test ≈(Wnbss[1], 0.173677826752, rtol=1e-3)
+    @test ≈(Wnbss[2], 0.318267164272, rtol=1e-3)
 
 end

--- a/test/buttord.jl
+++ b/test/buttord.jl
@@ -13,7 +13,7 @@ using DSP, Test
 
     (n, Wn) = buttord(40/500, 150/500, 3, 60)
     @test n == 5
-    @test isapprox(Wn, 0.081038494957764, rtol=1e-12)
+    @test Wn ≈ 0.081038494957764
 
     #
     # Highpass filter example
@@ -22,8 +22,7 @@ using DSP, Test
 
     (nhpf, Wnhpf) = buttord(600/2000, 1200/2000, 3, 60)
     @test nhpf == 7
-    @test isapprox(Wnhpf, 0.301783479785, rtol=1e-12)
-
+    @test Wnhpf ≈ 0.301783479785
 
     #
     # https://www.mathworks.com/help/signal/ref/buttord.html#d123e9937
@@ -38,8 +37,8 @@ using DSP, Test
 
     (nbp, Wnbp) = buttord([100/500, 200/500], [50/500, 250/500], 3, 40)
     @test nbp == 8
-    @test isapprox(Wnbp[1], 0.195101359239, rtol=1e-12)
-    @test isapprox(Wnbp[2], 0.408043633382, rtol=1e-12)
+    @test Wnbp[1] ≈ 0.195101359239
+    @test Wnbp[2] ≈ 0.408043633382
 
     #
     # Bandstop Example, (44.1 kHz Nyquist)
@@ -52,7 +51,7 @@ using DSP, Test
     # will yield different results in comparison to Optim.jl.
     (nbs, Wnbs) = buttord([3200/22050, 7800/22050], [4800/22050, 5600/22050], 2, 60)
     @test nbs == 5
-    @test isapprox(Wnbs[1], 0.172660908966, rtol=1e-12)
-    @test isapprox(Wnbs[2], 0.314956388749, rtol=1e-12)
+    @test ≈(Wnbs[1], 0.172660908966, rtol=1e-3)
+    @test ≈(Wnbs[2], 0.314956388749, rtol=1e-3)
 
 end

--- a/test/buttord.jl
+++ b/test/buttord.jl
@@ -23,18 +23,19 @@ using DSP, Test
 
     #
     # Highpass filter example
-    # Wp = 600/2000; Ws = 1200/2000;
+    # Wp = 1200/2000; Ws=600/2000;
     # Rs = 3; Rp = 60;
 
     # z-domain (default)
-    (nhpf, Wnhpf) = buttord(600/2000, 1200/2000, 3, 60, domain=:z)
+    (nhpf, Wnhpf) = buttord(1200/2000, 600/2000, 3, 60, domain=:z)
     @test nhpf == 7
-    @test Wnhpf ≈ 0.301783479785
+    @test Wnhpf ≈ 0.597905417809
+    
 
     # s-domain test
-    (nhpfs, Wnhpfs) = buttord(60/2000, 1200/2000, 3, 60, domain=:s)
-    @test nhpfs == 3
-    @test Wnhpf ≈ 0.06000001
+    (nhpfs, Wnhpfs) = buttord(1200/2000, 600/2000, 3, 60, domain=:s)
+    @test nhpfs == 10
+    @test Wnhpfs ≈ 0.598578664562
 
     #
     # https://www.mathworks.com/help/signal/ref/buttord.html#d123e9937


### PR DESCRIPTION
This is a realization of #429 . I had utilized the Optim.jl package for bounded minimization when calculating the Bandstop filter case. I'm still very much a Julia newbie, so I apologize if the dependency on Optim isn't encoded in the Project.toml file, (still learning the developer ecosystem.) 

My open questions would be (1) is the Optim.jl dependency ok or would the reviewers suggest a more up-to-date package, and (2) should I investigate further on the minimization solution difference for the Bandstop filter case? The results are _slightly_ different than the solution provided by MATLAB, I had given some leniency in the buttord.jl test. I hope this is a worthy addition to DSP.jl!