### PR TITLE
Rework definition of `FloatRange` (fix for Julia 1.8)

### DIFF
--- a/src/multitaper.jl
+++ b/src/multitaper.jl
@@ -255,7 +255,7 @@ end
 struct MTSpectrogramConfig{T,C<:MTConfig{T}}
     n_samples::Int
     n_overlap_samples::Int
-    time::FloatRange{Float64}
+    time::Float64Range
     mt_config::C
 end
 

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -392,14 +392,12 @@ end
 
 ## SPECTROGRAM
 
-@static if isdefined(Base, :StepRangeLen)
-    const FloatRange{T} = StepRangeLen{T,Base.TwicePrecision{T},Base.TwicePrecision{T}}
-end
+const Float64Range = typeof(range(0.0, step=1.0, length=2))
 
 struct Spectrogram{T,F<:Union{Frequencies,AbstractRange}, M<:AbstractMatrix{T}} <: TFR{T}
     power::M
     freq::F
-    time::FloatRange{Float64}
+    time::Float64Range
 end
 FFTW.fftshift(p::Spectrogram{T,F}) where {T,F<:Frequencies} =
     Spectrogram(p.freq.n_nonnegative == p.freq.n ? p.power : fftshift(p.power, 1), fftshift(p.freq), p.time)


### PR DESCRIPTION
In Julia 1.7, the definition of `StepRangeLen` acquired another type parameter, making the fields typed with `FloatRange{Float64}` abstractly typed. While that is unfortunate but not critical, https://github.com/JuliaLang/julia/pull/43059 further broke `convert`ing to this abstract type, causing failures within DSP.jl. This change reworks the definition of `FloatRange` to pick the type of an appropriate `range` call, making it adjust automatically to the changes in Julia. To simplify things, the type parameter is dropped, as it was only used with `Float64` anyway.