### PR TITLE
exchange BLAS.BlasFloat for Union{AbstractFloat, Complex{<:AbstractFl…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DSP"
 uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -677,7 +677,7 @@ function _conv(u, v, su, sv)
 end
 
 # We use this type definition for clarity
-const AbstractFloats = Union{<:AbstractFloat,Complex{T} where T<:AbstractFloat}
+const RealOrComplexFloat = Union{AbstractFloat, Complex{T} where T<:AbstractFloat}
 
 # May switch argument order
 """
@@ -688,7 +688,7 @@ depending on the size of the input. `u` and `v` can be  N-dimensional arrays,
 with arbitrary indexing offsets, but their axes must be a `UnitRange`.
 """
 function conv(u::AbstractArray{T, N},
-              v::AbstractArray{T, N}) where {T<:AbstractFloats, N}
+              v::AbstractArray{T, N}) where {T<:RealOrComplexFloat, N}
     su = size(u)
     sv = size(v)
     if prod(su) >= prod(sv)
@@ -698,8 +698,8 @@ function conv(u::AbstractArray{T, N},
     end
 end
 
-function conv(u::AbstractArray{<:AbstractFloats, N},
-              v::AbstractArray{<:AbstractFloats, N}) where N
+function conv(u::AbstractArray{<:RealOrComplexFloat, N},
+              v::AbstractArray{<:RealOrComplexFloat, N}) where N
     fu, fv = promote(u, v)
     conv(fu, fv)
 end
@@ -711,11 +711,11 @@ conv(u::AbstractArray{<:Number, N}, v::AbstractArray{<:Number, N}) where {N} =
     conv(float(u), float(v))
 
 function conv(u::AbstractArray{<:Number, N},
-              v::AbstractArray{<:AbstractFloats, N}) where N
+              v::AbstractArray{<:RealOrComplexFloat, N}) where N
     conv(float(u), v)
 end
 
-function conv(u::AbstractArray{<:AbstractFloats, N},
+function conv(u::AbstractArray{<:RealOrComplexFloat, N},
               v::AbstractArray{<:Number, N}) where N
     conv(u, float(v))
 end

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -677,7 +677,7 @@ function _conv(u, v, su, sv)
 end
 
 # We use this type definition for clarity
-const AbstractFloats = Union{AbstractFloat,Complex{T} where T<:AbstractFloat}
+const AbstractFloats = Union{<:AbstractFloat,Complex{T} where T<:AbstractFloat}
 
 # May switch argument order
 """

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -1,7 +1,6 @@
 # This file was formerly a part of Julia. License is MIT: https://julialang.org/license
 
 import Base: trailingsize
-import LinearAlgebra.BLAS
 
 const SMALL_FILT_CUTOFF = 58
 
@@ -677,6 +676,9 @@ function _conv(u, v, su, sv)
     _conv!(out, u, v, su, sv, outsize)
 end
 
+# We use this type definition for clarity
+const AbstractFloats = Union{AbstractFloat,Complex{T} where T<:AbstractFloat}
+
 # May switch argument order
 """
     conv(u,v)
@@ -686,7 +688,7 @@ depending on the size of the input. `u` and `v` can be  N-dimensional arrays,
 with arbitrary indexing offsets, but their axes must be a `UnitRange`.
 """
 function conv(u::AbstractArray{T, N},
-              v::AbstractArray{T, N}) where {T<:BLAS.BlasFloat, N}
+              v::AbstractArray{T, N}) where {T<:AbstractFloats, N}
     su = size(u)
     sv = size(v)
     if prod(su) >= prod(sv)
@@ -696,8 +698,8 @@ function conv(u::AbstractArray{T, N},
     end
 end
 
-function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
-              v::AbstractArray{<:BLAS.BlasFloat, N}) where N
+function conv(u::AbstractArray{<:AbstractFloats, N},
+              v::AbstractArray{<:AbstractFloats, N}) where N
     fu, fv = promote(u, v)
     conv(fu, fv)
 end
@@ -709,11 +711,11 @@ conv(u::AbstractArray{<:Number, N}, v::AbstractArray{<:Number, N}) where {N} =
     conv(float(u), float(v))
 
 function conv(u::AbstractArray{<:Number, N},
-              v::AbstractArray{<:BLAS.BlasFloat, N}) where N
+              v::AbstractArray{<:AbstractFloats, N}) where N
     conv(float(u), v)
 end
 
-function conv(u::AbstractArray{<:BLAS.BlasFloat, N},
+function conv(u::AbstractArray{<:AbstractFloats, N},
               v::AbstractArray{<:Number, N}) where N
     conv(u, float(v))
 end


### PR DESCRIPTION
…oat}}

There is an upcoming package for FFTs on generic number types https://github.com/JuliaApproximation/GenericFFT.jl. This will enable, in particular, convolutions with `BigFloat` and `Complex{BigFloat}` arrays. To make this Just Work<sup>TM</sup>, we may simply remove the type restrictions referring to FFTW number types (quoted as `BLAS.BlasFloat`s). Then when both packages are loaded, `using DSP, GenericFFT`, `conv(rand(BigFloat, 10), rand(BigFloat, 20))` works analogously to finding BigFloat eigenvalues through `GenericLinearAlgebra`.