### PR TITLE
remove restriction on `fs::Int` in multitaper methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DSP"
 uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/multitaper.jl
+++ b/src/multitaper.jl
@@ -294,7 +294,7 @@ end
 
 """
     mt_spectrogram!(output, signal::AbstractVector{T}, n::Int=length(signal) >> 3,
-        n_overlap::Int=n >> 1; fs::Int=1, onesided::Bool=T <: Real, kwargs...) where {T}
+        n_overlap::Int=n >> 1; fs=1, onesided::Bool=T <: Real, kwargs...) where {T}
     mt_spectrogram!(destination::AbstractMatrix, signal::AbstractVector, config::MTSpectrogramConfig)
 
 Computes a multitaper spectrogram using the parameters specified in `config`. Arguments:
@@ -310,7 +310,7 @@ See also [`mt_spectrogram`](@ref).
 mt_spectrogram!
 
 function mt_spectrogram!(output, signal::AbstractVector{T}, n::Int=length(signal) >> 3,
-    n_overlap::Int=n >> 1; fs::Int=1, onesided::Bool=T <: Real,
+    n_overlap::Int=n >> 1; fs=1, onesided::Bool=T <: Real,
     kwargs...) where {T}
     config = MTSpectrogramConfig{T}(length(signal), n, n_overlap; fs=fs, onesided=onesided,
         fft_flags=FFTW.ESTIMATE, kwargs...)
@@ -348,7 +348,7 @@ end
 
 """
     mt_spectrogram(signal::AbstractVector{T}, n::Int=length(s) >> 3,
-                                  n_overlap::Int=n >> 1; fs::Int=1,
+                                  n_overlap::Int=n >> 1; fs=1,
                                   onesided::Bool=T <: Real, kwargs...) where {T}
     mt_spectrogram(signal::AbstractVector, config::MTSpectrogramConfig)
 

--- a/src/multitaper.jl
+++ b/src/multitaper.jl
@@ -363,7 +363,7 @@ See also [`mt_spectrogram!`](@ref).
 mt_spectrogram
 
 function mt_spectrogram(signal::AbstractVector{T}, n::Int=length(signal) >> 3,
-                        n_overlap::Int=n >> 1; fs::Int=1, onesided::Bool=T <: Real,
+                        n_overlap::Int=n >> 1; fs=1, onesided::Bool=T <: Real,
                         kwargs...) where {T}
     config = MTSpectrogramConfig{T}(length(signal), n, n_overlap; fs=fs, onesided=onesided,
                                     fft_flags=FFTW.ESTIMATE, kwargs...)


### PR DESCRIPTION
Fixes #490 

I went ahead and bumped the patch version; I didn't see any commits that introduced breaking changes between the last release and current master.