### PR TITLE
Create WelchConfig object

### DIFF
--- a/docs/src/periodograms.md
+++ b/docs/src/periodograms.md
@@ -8,6 +8,7 @@ Common procedures like computing the [short-time Fourier transform](@ref stft),
 arraysplit
 periodogram(s::AbstractVector{T}) where T <: Number
 welch_pgram
+welch_pgram!
 spectrogram
 stft
 periodogram(s::AbstractMatrix{T}) where T <: Real
@@ -35,6 +36,7 @@ mt_coherence!
 ## Configuration objects
 
 ```@docs
+WelchConfig
 MTConfig
 MTSpectrogramConfig
 MTCrossSpectraConfig

--- a/src/multitaper.jl
+++ b/src/multitaper.jl
@@ -2,7 +2,7 @@
 ##### Multitapered periodogram
 #####
 
-struct MTConfig{T,R1,F,P,T1,T2,W,R2} <: AbstractPGramConfig
+struct MTConfig{T,R1,F,P,T1,T2,W,R2}
     n_samples::Int
     fs::R1
     nfft::Int

--- a/src/multitaper.jl
+++ b/src/multitaper.jl
@@ -2,7 +2,7 @@
 ##### Multitapered periodogram
 #####
 
-struct MTConfig{T,R1,F,P,T1,T2,W,R2}
+struct MTConfig{T,R1,F,P,T1,T2,W,R2} <: AbstractPGramConfig
     n_samples::Int
     fs::R1
     nfft::Int

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -385,7 +385,7 @@ end
              onesided=eltype<:Real, nfft=nextfastfft(n),
              fs=1, window=nothing)
 
-Captures all configuraiton options for the [welch_pgram](@ref) in a single struct. (Akin to
+Captures all configuration options for the [welch_pgram](@ref) in a single struct. (Akin to
 [MTConfig](@ref)). When passed on the second argument of [`welch_pgram`](@ref), computes the
 periodogram based on segments with `n` samples with overlap of `noverlap` samples, and
 returns a Periodogram object. For a Bartlett periodogram, set `noverlap=0`. See

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -376,8 +376,6 @@ struct WelchConfig{F,W} <: AbstractPGramConfig
     window::W
 end
 
-nout(config::WelchConfig) = config.onesided ? (config.nfft >> 1)+1 : config.nfft
-
 """
     WelchConfig(data; n=length(signal)>>3, noverlap=n>>1,
              onesided=eltype(signal)<:Real, nfft=nextfastfft(n),
@@ -410,8 +408,9 @@ Computes the Welch periodogram of the given signal using the predefined config o
 [WelchConfig](@ref).
 """
 function welch_pgram(data::AbstractVector, config::WelchConfig)
-    return welch_pgram(data, config.nsamples, config.noverlap; config.onesided,
-                           config.nfft, config.fs, config.window)
+    return welch_pgram(data, config.nsamples, config.noverlap; 
+                       onesided=config.onesided, nfft=config.nfft, 
+                       fs=config.fs, window=config.window)
 end
 
 # Compute an estimate of the power spectral density of a signal s via Welch's

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -387,8 +387,8 @@ end
              onesided=eltype<:Real, nfft=nextfastfft(n),
              fs=1, window=nothing)
 
-Captures all configuration options for the [welch_pgram](@ref) in a single struct. (Akin to
-[MTConfig](@ref)). When passed on the second argument of [`welch_pgram`](@ref), computes the
+Captures all configuration options for [`welch_pgram`](@ref) in a single struct (akin to
+[`MTConfig`](@ref)). When passed on the second argument of [`welch_pgram`](@ref), computes the
 periodogram based on segments with `n` samples with overlap of `noverlap` samples, and
 returns a Periodogram object. For a Bartlett periodogram, set `noverlap=0`. See
 [`periodogram`](@ref) for description of optional keyword arguments.
@@ -459,8 +459,7 @@ end
 """
     welch_pgram(signal::AbstractVector, config::WelchConfig)
 
-Computes the Welch periodogram of the given signal using the predefined config object
-[WelchConfig](@ref).
+Computes the Welch periodogram of the given signal using a predefined [`WelchConfig`](@ref) object.
 """
 function welch_pgram(s::AbstractVector{T}, config::WelchConfig) where T<:Number
     out = Vector{fftabs2type(T)}(undef, config.onesided ? (config.nfft >> 1)+1 : config.nfft)
@@ -470,8 +469,8 @@ end
 """
     welch_pgram!(out::AbstractVector, in::AbstractVector, config::WelchConfig)
 
-Computes the Welch periodogram of the given signal, storing the result in `out`, using the
-predefined config object [WelchConfig](@ref).
+Computes the Welch periodogram of the given signal, storing the result in `out`,
+using a predefined [`WelchConfig`](@ref) object.
 """
 function welch_pgram!(out::AbstractVector, s::AbstractVector{T}, config::WelchConfig{T}) where T<:Number
     if length(out) != length(config.freq)

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -24,15 +24,23 @@ struct ArraySplit{T<:AbstractVector,S,W} <: AbstractVector{Vector{S}}
     window::W
     k::Int
 
-    function ArraySplit{Ti,Si,Wi}(s, n, noverlap, nfft, window) where {Ti<:AbstractVector,Si,Wi}
+    function ArraySplit{Ti,Si,Wi}(s, n, noverlap, nfft, window;
+        buffer::Union{Nothing,Vector{Si}}=nothing) where {Ti<:AbstractVector,Si,Wi}
+        
         # n = noverlap is a problem - the algorithm will not terminate.
         (0 ≤ noverlap < n) || error("noverlap must be between zero and n")
         nfft >= n || error("nfft must be >= n")
-        new{Ti,Si,Wi}(s, zeros(Si, nfft), n, noverlap, window, length(s) >= n ? div((length(s) - n), n - noverlap)+1 : 0)
+        buf_ = isnothing(buffer) ? zeros(Si, nfft) : buffer
+        length(buf_) == nfft ||
+            error("buffer length ($(length(buffer)) must be length of `nfft` ($nfft)")
+
+        new{Ti,Si,Wi}(s, buf_, n, noverlap, window, length(s) >= n ? div((length(s) - n),
+            n - noverlap) + 1 : 0)
     end
+
 end
-ArraySplit(s::AbstractVector, n, noverlap, nfft, window) =
-    ArraySplit{typeof(s),fftintype(eltype(s)),typeof(window)}(s, n, noverlap, nfft, window)
+ArraySplit(s::AbstractVector, n, noverlap, nfft, window; buffer) =
+    ArraySplit{typeof(s),fftintype(eltype(s)),typeof(window)}(s, n, noverlap, nfft, window; buffer)
 
 function Base.getindex(x::ArraySplit{T,S,Nothing}, i::Int) where {T,S}
     (i >= 1 && i <= x.k) || throw(BoundsError())
@@ -54,13 +62,14 @@ end
 Base.size(x::ArraySplit) = (x.k,)
 
 """
-    arraysplit(s, n, m)
+    arraysplit(s, n, m, nfft=n, window=nothing; buffer)
 
 Split an array into arrays of length `n` with overlapping regions
 of length `m`. Iterating or indexing the returned AbstractVector
 always yields the same Vector with different contents.
+Optionally provide a buffer of length `nfft`
 """
-arraysplit(s, n, noverlap, nfft=n, window=nothing) = ArraySplit(s, n, noverlap, nfft, window)
+arraysplit(s, n, noverlap, nfft=n, window=nothing; buffer) = ArraySplit(s, n, noverlap, nfft, window; buffer)
 
 ## Make collect() return the correct split arrays rather than repeats of the last computed copy
 Base.collect(x::ArraySplit) = collect(copy(a) for a in x)
@@ -367,17 +376,22 @@ Abstract type representing a configuration object used for computing a periodogr
 """
 abstract type AbstractPGramConfig end
 
-struct WelchConfig{F,W} <: AbstractPGramConfig
+struct WelchConfig{F,Fr,W,P,T1,T2,R} <: AbstractPGramConfig
     nsamples::Int
     noverlap::Int
     onesided::Bool
     nfft::Int
     fs::F
+    freq::Fr
     window::W
+    plan::P
+    inbuf::T1
+    outbuf::T2
+    r::R # inverse normalization 
 end
 
 """
-    WelchConfig(data; n=length(signal)>>3, noverlap=n>>1,
+    WelchConfig(data; n=size(signal, ndims(signal))>>3, noverlap=n>>1,
              onesided=eltype(signal)<:Real, nfft=nextfastfft(n),
              fs=1, window=nothing)
 
@@ -391,26 +405,26 @@ periodogram based on segments with `n` samples with overlap of `noverlap` sample
 returns a Periodogram object. For a Bartlett periodogram, set `noverlap=0`. See
 [`periodogram`](@ref) for description of optional keyword arguments.
 """
-function WelchConfig(nsamples, eltype; n=nsamples >> 3, noverlap=n >> 1,
-                                onesided::Bool=eltype <: Real, nfft=nextfastfft(n),
-                                fs=1, window=nothing)
-    return WelchConfig(n, noverlap, onesided, nfft, fs, window)
+function WelchConfig(nsamples, ::Type{T}; n::Int=nsamples >> 3, noverlap::Int=n >> 1,
+    onesided::Bool=eltype <: Real, nfft::Int=nextfastfft(n),
+    fs::Real=1, window::Union{Function,AbstractVector,Nothing}=nothing) where T
+
+    onesided && T <: Complex && error("cannot compute one-sided FFT of a complex signal")
+    nfft >= n || error("nfft must be >= n")
+
+    win, norm2 = compute_window(window, n)
+    r = fs*norm2*nfft
+    inbuf = zeros(float(T), nfft)
+    outbuf = Vector{fftouttype(T)}(undef, T<:Real ? (nfft >> 1)+1 : nfft)
+    plan = forward_plan(inbuf, outbuf)
+
+    freq = onesided ? rfftfreq(nfft, fs) : fftfreq(nfft, fs)
+
+    return WelchConfig(n, noverlap, onesided, nfft, fs, freq, win, plan, inbuf, outbuf, r)
 end
 
 function WelchConfig(data::AbstractArray; kwargs...)
     return WelchConfig(size(data, ndims(data)), eltype(data); kwargs...)
-end
-
-"""
-    welch_pgram(signal::AbstractVector, config::WelchConfig)
-
-Computes the Welch periodogram of the given signal using the predefined config object
-[WelchConfig](@ref).
-"""
-function welch_pgram(data::AbstractVector, config::WelchConfig)
-    return welch_pgram(data, config.nsamples, config.noverlap; 
-                       onesided=config.onesided, nfft=config.nfft, 
-                       fs=config.fs, window=config.window)
 end
 
 # Compute an estimate of the power spectral density of a signal s via Welch's
@@ -420,33 +434,74 @@ end
 # Modified Periodograms."  P. Welch, IEEE Transactions on Audio and Electroacoustics,
 # vol AU-15, pp 70-73, 1967.
 """
-    welch_pgram(s, n=div(length(s), 8), noverlap=div(n, 2); onesided=eltype(s)<:Real, nfft=nextfastfft(n), fs=1, window=nothing)
+    welch_pgram(s, n=div(length(s), 8), noverlap=div(n, 2); onesided=eltype(s)<:Real, 
+                nfft=nextfastfft(n), fs=1, window=nothing)
 
 Computes the Welch periodogram of a signal `s` based on segments with `n` samples
 with overlap of `noverlap` samples, and returns a Periodogram
 object. For a Bartlett periodogram, set `noverlap=0`. See
 [`periodogram`](@ref) for description of optional keyword arguments.
 """
-function welch_pgram(s::AbstractVector{T}, n::Int=length(s)>>3, noverlap::Int=n>>1;
-                     onesided::Bool=eltype(s)<:Real,
-                     nfft::Int=nextfastfft(n), fs::Real=1,
-                     window::Union{Function,AbstractVector,Nothing}=nothing) where T<:Number
-    onesided && T <: Complex && error("cannot compute one-sided FFT of a complex signal")
-    nfft >= n || error("nfft must be >= n")
+function welch_pgram(s::AbstractVector, n::Int=length(s)>>3, noverlap::Int=n>>1; kwargs...)
+    welch_pgram(s, WelchConfig(s; n, noverlap, kwargs...))
+end
 
-    win, norm2 = compute_window(window, n)
-    sig_split = arraysplit(s, n, noverlap, nfft, win)
-    out = zeros(fftabs2type(T), onesided ? (nfft >> 1)+1 : nfft)
-    r = fs*norm2*length(sig_split)
+"""
+    welch_pgram!(out::AbstractVector, in::AbstractVector, n=div(length(s), 8), 
+                 noverlap=div(n, 2); onesided=eltype(s)<:Real, nfft=nextfastfft(n), 
+                 fs=1, window=nothing)
 
-    tmp = Vector{fftouttype(T)}(undef, T<:Real ? (nfft >> 1)+1 : nfft)
-    plan = forward_plan(sig_split.buf, tmp)
+Computes the Welch periodogram of a signal `s`, storing the result in `out`, based on
+segments with `n` samples with overlap of `noverlap` samples, and returns a Periodogram
+object. For a Bartlett periodogram, set `noverlap=0`. See [`periodogram`](@ref) for
+description of optional keyword arguments.
+"""
+function welch_pgram!(output::AbstractVector, s::AbstractVector, n::Int=length(s)>>3, noverlap::Int=n>>1;
+                      kwargs...)
+    welch_pgram!(output, s, WelchConfig(s; n, overlap, kwargs...))
+end
+
+"""
+    welch_pgram(signal::AbstractVector, config::WelchConfig)
+
+Computes the Welch periodogram of the given signal using the predefined config object
+[WelchConfig](@ref).
+"""
+function welch_pgram(s::AbstractVector{T}, config::WelchConfig{T}) where T<:Number
+    out = zeros(fftabs2type(T), config.onesided ? (config.nfft >> 1)+1 : config.nfft)
+    return welch_pgram_helper!(out, s, config)
+end
+
+"""
+    welch_pgram!(out::AbstractVector, in::AbstractVector, n=div(length(s), 8), 
+                 noverlap=div(n, 2); onesided=eltype(s)<:Real, nfft=nextfastfft(n), 
+                 fs=1, window=nothing)
+
+Computes the Welch periodogram of the given signal, storing the result in `out`, using the
+predefined config object [WelchConfig](@ref).
+"""
+function welch_pgram!(out::AbstractVector, in::AbstractVector{T}, config::WelchConfig{T}) where T<:Number
+    if length(output) != length(config.freq)
+        throw(DimensionMismatch("""Expected `output` to be of length `length(config.freq)`;
+            got `length(output) = $(length(output)) and `length(config.freq)` = $(length(config.freq))"""))
+    end
+    if eltype(out) == fftabs2type(T)
+        throw(ArgumentError("Eltype of output ($eltype(out)) doesn't matched the expected "*
+                            "type: $(fftabs2type(T))."))
+    end
+    welch_pgram_helper!(out, in, config)
+end
+
+function welch_pgram_helper!(out, in, config)
+    sig_split = arraysplit(in, config.nsamples, config.noverlap, config.nfft, config.window;
+                           buffer=config.inbuf)
+
     for sig in sig_split
-        mul!(tmp, plan, sig)
-        fft2pow!(out, tmp, nfft, r, onesided)
+        mul!(config.outbuf, config.plan, sig)
+        fft2pow!(out, config.outbuf, config.nfft, config.r, config.onesided)
     end
 
-    Periodogram(out, onesided ? rfftfreq(nfft, fs) : fftfreq(nfft, fs))
+    Periodogram(out, config.freq)
 end
 
 ## SPECTROGRAM

--- a/test/periodograms.jl
+++ b/test/periodograms.jl
@@ -217,6 +217,11 @@ end
     @test power(welch_pgram(data, length(data), 0; window=hamming, nfft=32)) ≈ expected
     @test power(spectrogram(data, length(data), 0; window=hamming, nfft=32)) ≈ expected
 
+    # test welch_pgram configuration object
+    expected = power(welch_pgram(data, length(data), 0; window=hamming, nfft=32))
+    config = WelchConfig(data; n=length(data), noverlap=0, window=hamming, nfft=32)
+    @test power(welch_pgram(data, config)) == expected
+
     # Test fftshift
     p = periodogram(data)
     @test power(p) == power(fftshift(p))

--- a/test/periodograms.jl
+++ b/test/periodograms.jl
@@ -222,6 +222,13 @@ end
     config = WelchConfig(data; n=length(data), noverlap=0, window=hamming, nfft=32)
     @test power(welch_pgram(data, config)) == expected
 
+    # test welch_pgram!
+    out = similar(expected)
+    @test power(welch_pgram!(out, data, config)) == expected
+    @test power(welch_pgram!(out, data, length(data), 0; window=hamming, nfft=32)) == expected
+    @test_throws ArgumentError welch_pgram!(convert(Vector{Float32}, out), data, config)
+    @test_throws DimensionMismatch welch_pgram!(empty!(out), data, config)
+
     # Test fftshift
     p = periodogram(data)
     @test power(p) == power(fftshift(p))


### PR DESCRIPTION
This allows `welch_pgram` to use a predefined set of configuration parameters in an object named `WelchConfig`, rather than passing these configuration values by keyword argument. FFT plans and intermediate buffers are preconfigured in `WelchConfig` making repeated calls that use the same config object faster.

This also sets `MTConfig` and `WelchConfig` to be children of the abstract type `AbstractPGramConfig`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204607356620460