### PR TITLE
replace splat with `Tuple`

### DIFF
--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -268,7 +268,7 @@ function calculate_reliability(pixel_image::AbstractArray{T, N}, circular_dims, 
     end
 
     pixel_shifts_border = similar(pixel_shifts)
-    new_ps = zeros(N)
+    new_ps = zeros(Int, N)
     for (idx_dim, connected) in enumerate(circular_dims)
         if connected
             # first border

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -310,10 +310,9 @@ function get_border_range(size_img::NTuple{N, T}, border_dim, border_idx) where 
 end
 
 function calculate_pixel_reliability(pixel_image::AbstractArray{Pixel{T},N}, pixel_index, pixel_shifts, range) where {T,N}
+    pix_val = pixel_image[pixel_index].val
     @inline rel_contrib(shift) =
-        let pix_val = pixel_image[pixel_index].val, rg = range, img = pixel_image, ind = pixel_index
-            @inbounds wrap_val(img[ind+shift].val - pix_val, rg)^2
-        end
+            @inbounds wrap_val(pixel_image[pixel_index+shift].val - pix_val, range)^2
     # for N=3, pixel_shifts[14] is null shift, can avoid if manually unrolling loop
     sum_val = sum(rel_contrib, pixel_shifts)
     return sum_val

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -235,18 +235,18 @@ function populate_edges!(edges, pixel_image::Array{T, N}, dim, connected, range)
     size_img[dim] -= 1
     idx_step       = fill(0, N)
     idx_step[dim] += 1
-    idx_step_cart  = CartesianIndex{N}(Tuple(idx_step))
-    idx_size       = CartesianIndex{N}(Tuple(size_img))
+    idx_step_cart  = CartesianIndex{N}(NTuple{N,Int}(idx_step))
+    idx_size       = CartesianIndex{N}(NTuple{N,Int}(size_img))
     for i in CartesianIndices(idx_size)
         push!(edges, Edge{N}(pixel_image, i, i+idx_step_cart, range))
     end
     if connected
         idx_step        = fill!(idx_step, 0)
         idx_step[dim]   = -size_img[dim]
-        idx_step_cart   = CartesianIndex{N}(Tuple(idx_step))
+        idx_step_cart   = CartesianIndex{N}(NTuple{N,Int}(idx_step))
         edge_begin      = ones(Int, N)
         edge_begin[dim] = size(pixel_image)[dim]
-        edge_begin_cart = CartesianIndex{N}(Tuple(edge_begin))
+        edge_begin_cart = CartesianIndex{N}(NTuple{N,Int}(edge_begin))
         for i in CartesianIndices(ntuple(dim_idx -> edge_begin_cart[dim_idx]:size(pixel_image, dim_idx), N))
             push!(edges, Edge{N}(pixel_image, i, i+idx_step_cart, range))
         end
@@ -272,13 +272,13 @@ function calculate_reliability(pixel_image::AbstractArray{T, N}, circular_dims, 
     for (idx_dim, connected) in enumerate(circular_dims)
         if connected
             # first border
-            pixel_shifts_border = copyto!(pixel_shifts_border, pixel_shifts)
+            copyto!(pixel_shifts_border, pixel_shifts)
             for (idx_ps, ps) in enumerate(pixel_shifts_border)
                 # if the pixel shift goes out of bounds, we make the shift wrap
                 if ps[idx_dim] == 1
-                    new_ps          = fill!(new_ps, 0)
+                    fill!(new_ps, 0)
                     new_ps[idx_dim] = -size_img[idx_dim]+1
-                    pixel_shifts_border[idx_ps] = CartesianIndex{N}(Tuple(new_ps))
+                    pixel_shifts_border[idx_ps] = CartesianIndex{N}(NTuple{N,Int}(new_ps))
                 end
             end
             border_range = get_border_range(size_img, idx_dim, size_img[idx_dim])
@@ -290,9 +290,9 @@ function calculate_reliability(pixel_image::AbstractArray{T, N}, circular_dims, 
             for (idx_ps, ps) in enumerate(pixel_shifts_border)
                 # if the pixel shift goes out of bounds, we make the shift wrap, this time to the other side
                 if ps[idx_dim] == -1
-                    new_ps          = fill!(new_ps, 0)
+                    fill!(new_ps, 0)
                     new_ps[idx_dim] = size_img[idx_dim]-1
-                    pixel_shifts_border[idx_ps] = CartesianIndex{N}(Tuple(new_ps))
+                    pixel_shifts_border[idx_ps] = CartesianIndex{N}(NTuple{N,Int}(new_ps))
                 end
             end
             border_range = get_border_range(size_img, idx_dim, 1)

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -306,7 +306,7 @@ end
 function get_border_range(size_img::NTuple{N, T}, border_dim, border_idx) where {N, T}
     border_range = [2:(size_img[dim]-1) for dim=1:N]
     border_range[border_dim] = border_idx:border_idx
-    return Tuple(border_range)
+    return NTuple{N,UnitRange{Int}}(border_range)
 end
 
 function calculate_pixel_reliability(pixel_image::AbstractArray{Pixel{T},N}, pixel_index, pixel_shifts, range) where {T,N}

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -311,8 +311,7 @@ end
 
 function calculate_pixel_reliability(pixel_image::AbstractArray{Pixel{T},N}, pixel_index, pixel_shifts, range) where {T,N}
     pix_val = pixel_image[pixel_index].val
-    @inline rel_contrib(shift) =
-            @inbounds wrap_val(pixel_image[pixel_index+shift].val - pix_val, range)^2
+    rel_contrib(shift) = @inbounds wrap_val(pixel_image[pixel_index+shift].val - pix_val, range)^2
     # for N=3, pixel_shifts[14] is null shift, can avoid if manually unrolling loop
     sum_val = sum(rel_contrib, pixel_shifts)
     return sum_val


### PR DESCRIPTION
For a random matrix `M` of size (500, 500), allocations measured for `unwrap(M; dims=1:2)` drops from 2.2M+ to 250k, with a small speedup of about 30% on Windows, Julia 1.9.

This is achieved by changing every instance of splatting a vector into `CartesianIndex{N}` to `Tuple`.