### PR TITLE
extend `lpc` to complex inputs, other fixes

### DIFF
--- a/docs/src/lpc.md
+++ b/docs/src/lpc.md
@@ -1,6 +1,6 @@
 # `LPC` - Linear Predictive Coding
 ```@docs
 lpc
-lpc(::AbstractVector{Number}, ::Int, ::LPCBurg)
-lpc(::AbstractVector{Number}, ::Int, ::LPCLevinson)
+arburg
+levinson
 ```

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -795,8 +795,8 @@ julia> xcorr([1,2,3],[1,2,3])
 ```
 """
 function xcorr(
-    u::AbstractVector{U}, v::AbstractVector{V}; padmode::Symbol=:none, scaling::Symbol=:none
-) where {U,V}
+    u::AbstractVector, v::AbstractVector; padmode::Symbol=:none, scaling::Symbol=:none
+)
     su = size(u, 1); sv = size(v, 1)
 
     if scaling == :biased && su != sv
@@ -815,13 +815,14 @@ function xcorr(
 
     res = conv(u, dsp_reverse(conj(v), axes(v)))
     if scaling == :biased
-        res = _normalize(res, su)
+        res = _normalize!(res, su)
     end
 
     return res
 end
 
-_normalize(x::AbstractArray{<:Integer}, sz::Int) = (x ./ sz)
-_normalize(x::AbstractArray, sz::Int) = (x ./= sz)
+_normalize!(x::AbstractArray{<:Integer}, sz::Int) = (x ./ sz)   # does not mutate x
+_normalize!(x::AbstractArray, sz::Int) = (x ./= sz)
 
+# TODO: write specialized (r/)fft-ed autocorrelation functions
 xcorr(u::AbstractVector; kwargs...) = xcorr(u, u; kwargs...)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -764,17 +764,23 @@ end
 
 
 """
-    xcorr(u,v; padmode = :none)
+    xcorr(u; padmode::Symbol=:none, scaling::Symbol=:none)
+    xcorr(u, v; padmode::Symbol=:none, scaling::Symbol=:none)
 
-Compute the cross-correlation of two vectors, by calculating the similarity
-between `u` and `v` with various offsets of `v`. Delaying `u` relative to `v`
-will shift the result to the right.
+With two arguments, compute the cross-correlation of two vectors, by calculating
+the similarity between `u` and `v` with various offsets of `v`. Delaying `u`
+relative to `v` will shift the result to the right. If one argument is provided,
+calculate `xcorr(u, u; kwargs...)`.
 
-The size of the output depends on the padmode keyword argument: with padmode =
-:none the length of the result will be length(u) + length(v) - 1, as with conv.
-With padmode = :longest the shorter of the arguments will be padded so they are
-equal length. This gives a result with length 2*max(length(u), length(v))-1,
+The size of the output depends on the `padmode` keyword argument: with `padmode =
+:none` the length of the result will be `length(u) + length(v) - 1`, as with `conv`.
+With `padmode = :longest`, the shorter of the arguments will be padded so they
+are of equal length. This gives a result with length `2*max(length(u), length(v))-1`,
 with the zero-lag condition at the center.
+
+The keyword argument `scaling` can be provided. Possible arguments are the default
+`:none` and `:biased`. `:biased` is valid only if the vectors have the same length,
+or only one vector is provided, dividing the result by `length(u)`.
 
 # Examples
 
@@ -789,10 +795,10 @@ julia> xcorr([1,2,3],[1,2,3])
 ```
 """
 function xcorr(
-    u::AbstractVector, v::AbstractVector; padmode::Symbol = :none
+    u::AbstractVector, v::AbstractVector; padmode::Symbol=:none, scaling::Symbol=:none
 )
-    su = size(u,1); sv = size(v,1)
-    if padmode == :longest
+    su = size(u, 1); sv = size(v, 1)
+    res = if padmode == :longest
         if su < sv
             u = _zeropad_keep_offset(u, sv)
         elseif sv < su
@@ -804,4 +810,16 @@ function xcorr(
     else
         throw(ArgumentError("padmode keyword argument must be either :none or :longest"))
     end
+
+    if scaling == :biased
+        if su == sv
+            res ./= su
+        else
+            throw(DimensionMismatch("scaling only valid for vectors of same length"))
+        end
+    end
+
+    res
 end
+
+xcorr(u::AbstractVector; kwargs...) = xcorr(u, u; kwargs...)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -798,26 +798,23 @@ function xcorr(
     u::AbstractVector, v::AbstractVector; padmode::Symbol=:none, scaling::Symbol=:none
 )
     su = size(u, 1); sv = size(v, 1)
-    res = if padmode == :longest
+
+    if scaling == :biased && su != sv
+        throw(DimensionMismatch("scaling only valid for vectors of same length"))
+    end
+
+    if padmode == :longest
         if su < sv
             u = _zeropad_keep_offset(u, sv)
         elseif sv < su
             v = _zeropad_keep_offset(v, su)
         end
-        conv(u, dsp_reverse(conj(v), axes(v)))
-    elseif padmode == :none
-        conv(u, dsp_reverse(conj(v), axes(v)))
-    else
+    elseif padmode != :none
         throw(ArgumentError("padmode keyword argument must be either :none or :longest"))
     end
 
-    if scaling == :biased
-        if su == sv
-            res ./= su
-        else
-            throw(DimensionMismatch("scaling only valid for vectors of same length"))
-        end
-    end
+    res = conv(u, dsp_reverse(conj(v), axes(v)))
+    scaling == :biased && res ./= su
 
     res
 end

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -795,8 +795,8 @@ julia> xcorr([1,2,3],[1,2,3])
 ```
 """
 function xcorr(
-    u::AbstractVector, v::AbstractVector; padmode::Symbol=:none, scaling::Symbol=:none
-)
+    u::AbstractVector{U}, v::AbstractVector{V}; padmode::Symbol=:none, scaling::Symbol=:none
+) where {U,V}
     su = size(u, 1); sv = size(v, 1)
 
     if scaling == :biased && su != sv
@@ -814,9 +814,14 @@ function xcorr(
     end
 
     res = conv(u, dsp_reverse(conj(v), axes(v)))
-    scaling == :biased && res ./= su
+    if scaling == :biased
+        res = _normalize(res, su)
+    end
 
     res
 end
+
+_normalize(x::AbstractArray{<:Integer}, sz::Int) = (x ./ sz)
+_normalize(x::AbstractArray, sz::Int) = (x ./= sz)
 
 xcorr(u::AbstractVector; kwargs...) = xcorr(u, u; kwargs...)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -818,7 +818,7 @@ function xcorr(
         res = _normalize(res, su)
     end
 
-    res
+    return res
 end
 
 _normalize(x::AbstractArray{<:Integer}, sz::Int) = (x ./ sz)

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -72,7 +72,7 @@ function arburg(x::AbstractVector{T}, p::Integer) where T<:Number
 end
 
 function lpc(x::AbstractVector{<:Number}, p::Integer, ::LPCLevinson)
-    R_xx = xcorr(x,x)[length(x):end]
+    R_xx = xcorr(x; scaling=:biased)[length(x):end]
     a, prediction_err = levinson(R_xx, p)
     a, prediction_err
 end

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -73,7 +73,7 @@ function arburg(x::AbstractVector{T}, p::Integer) where T<:Number
         k = -2 * dot(eb, ef) / den
         reflection_coeffs[m] = k
 
-        copyto!(rev_buf, CartesianIndices((1:m,)), a, CartesianIndices((m:-1:1,)))
+        rev_buf[1:m] .= a[m:-1:1]
         @. a[2:m+1] += k * conj(rev_buf[1:m])
 
         # update prediction errors
@@ -132,7 +132,7 @@ function levinson(R_xx::AbstractVector{U}, p::Integer) where U<:Number
     rev_a = similar(a, p - 1)     # buffer to store a in reverse
 
     @views for m = 2:p
-        copyto!(rev_a, CartesianIndices((1:m-1,)), a, CartesianIndices((m-1:-1:1,)))
+        rev_a[1:m-1] .= a[m-1:-1:1]
         k = -(R_xx[m+1] + dotu(R_xx[2:m], rev_a[1:m-1])) / prediction_err
         @. a[1:m-1] += k * conj(rev_a[1:m-1])
         a[m] = reflection_coeffs[m] = k

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -55,7 +55,7 @@ function arburg(x::AbstractVector{T}, p::Integer) where T<:Number
     # Initialize prediction error with the variance of the signal
     prediction_err = sum(abs2, x) / length(x)
     R = typeof(prediction_err)
-    F = promote_type(R, T)
+    F = promote_type(R, Base.promote_union(T))
 
     ef = collect(F, x)                  # forward error
     eb = copy(ef)                       # backwards error
@@ -99,7 +99,7 @@ function lpc(x::AbstractVector{<:Number}, p::Integer, ::LPCLevinson)
 end
 
 """
-    levinson(x::AbstractVector, p::Integer, LPCLevinson())
+    levinson(x::AbstractVector, p::Integer)
 
 LPC (Linear-Predictive-Code) estimation, using the Levinson method. This
 function implements the mathematics described in [1].
@@ -108,10 +108,10 @@ function implements the mathematics described in [1].
 (N. Levinson, Studies in Applied Mathematics 25(1946), 261-278,
 https://doi.org/10.1002/sapm1946251261)
 """
-function levinson(R_xx::AbstractVector{<:Number}, p::Integer)
+function levinson(R_xx::AbstractVector{U}, p::Integer) where U<:Number
     # for m = 1
     a_1 = -R_xx[2] / R_xx[1]
-    F = typeof(a_1)
+    F = promote_type(Base.promote_union(U), typeof(a_1))
     prediction_err = abs(R_xx[1] * (one(F) - abs2(a_1)))
     R = typeof(prediction_err)
     T = promote_type(F, R)

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -5,14 +5,14 @@ using ..DSP: xcorr
 
 using LinearAlgebra: dot
 
-export lpc, LPCBurg, LPCLevinson
+export lpc, arburg, levinson, LPCBurg, LPCLevinson
 
 # Dispatch types for lpc()
 struct LPCBurg end
 struct LPCLevinson end
 
 """
-    lpc(x::AbstractVector, p::Int, [LPCBurg()])
+    lpc(x::AbstractVector, p::Integer, [LPCBurg()])
 
 Given input signal `x` and prediction order `p`, returns IIR coefficients `a`
 and average reconstruction error `prediction_err`. Note that this method does
@@ -25,8 +25,14 @@ either `LPCBurg` or `LPCLevinson`.
 """
 function lpc end
 
+function lpc(x::AbstractVector{<:Number}, p::Integer, ::LPCBurg)
+    a, prediction_err = arburg(x, p)
+    popfirst!(a)
+    a, prediction_err
+end
+
 """
-    lpc(x::AbstractVector, p::Int, LPCBurg())
+    arburg(x::AbstractVector, p::Integer)
 
 LPC (Linear-Predictive-Code) estimation, using the Burg method. This function
 implements the mathematics published in [1].
@@ -35,7 +41,7 @@ implements the mathematics published in [1].
 (DAFX 2003 article, Lagrange et al)
 http://www.sylvain-marchand.info/Publications/dafx03.pdf
 """
-function lpc(x::AbstractVector{<:Number}, p::Int, ::LPCBurg)
+function arburg(x::AbstractVector{<:Number}, p::Integer)
     # Initialize prediction error with the variance of the signal
     prediction_err = sum(abs2, x) / length(x)
     T = typeof(prediction_err)
@@ -44,6 +50,7 @@ function lpc(x::AbstractVector{<:Number}, p::Int, ::LPCBurg)
     eb = copy(ef)                       # backwards error
     a = zeros(T, p + 1); a[1] = 1       # prediction coefficients
     rev_buf = similar(a, p)             # buffer to store a in reverse
+    reflection_coeffs = zeros(T, p)     # reflection coefficients
 
     @views for m in 1:p
         pop!(ef)
@@ -57,14 +64,20 @@ function lpc(x::AbstractVector{<:Number}, p::Int, ::LPCBurg)
         rev_buf[1:m] = a[m:-1:1]
         @. a[2:m+1] += k * rev_buf[1:m]
         prediction_err *= (1 - k^2)
+        reflection_coeffs[m] = k
     end
 
-    popfirst!(a)
-    return a, prediction_err
+    return a, prediction_err, reflection_coeffs
+end
+
+function lpc(x::AbstractVector{<:Number}, p::Integer, ::LPCLevinson)
+    R_xx = xcorr(x,x)[length(x):end]
+    a, prediction_err = levinson(R_xx, p)
+    a, prediction_err
 end
 
 """
-    lpc(x::AbstractVector, p::Int, LPCLevinson())
+    levinson(x::AbstractVector, p::Integer, LPCLevinson())
 
 LPC (Linear-Predictive-Code) estimation, using the Levinson method. This
 function implements the mathematics described in [1].
@@ -73,25 +86,27 @@ function implements the mathematics described in [1].
 (N. Levinson, Studies in Applied Mathematics 25(1946), 261-278,
 https://doi.org/10.1002/sapm1946251261)
 """
-function lpc(x::AbstractVector{<:Number}, p::Int, ::LPCLevinson)
-    R_xx = xcorr(x,x)[length(x):end]
-    a = zeros(p)
+function levinson(R_xx::AbstractVector{<:Number}, p::Integer)
+    # for m = 1
+    a_1 = -R_xx[2] / R_xx[1]
+    prediction_err = R_xx[1] * (one(a_1) - a_1^2)
+    T = typeof(prediction_err)
+
+    a = zeros(T, p)
+    reflection_coeffs = zeros(T, p)
+    a[1] = reflection_coeffs[1] = a_1
     rev_buf = similar(a, p - 1)     # buffer to store a in reverse
 
-    # for m = 1
-    a[1] = -R_xx[2] / R_xx[1]
-    prediction_err = R_xx[1] * (1 - a[1]^2)
-
-    # for m = 2,3,4,..p
     @views for m = 2:p
-        a[m] = (-(R_xx[m+1] + dot(a[1:m-1], R_xx[m:-1:2])) / prediction_err)
+        k = (-(R_xx[m+1] + dot(a[1:m-1], R_xx[m:-1:2])) / prediction_err)
         rev_buf[1:m-1] = a[m-1:-1:1]
-        @. a[1:m-1] += a[m] * rev_buf[1:m-1]
-        prediction_err *= (1 - a[m]^2)
+        @. a[1:m-1] += k * rev_buf[1:m-1]
+        a[m] = reflection_coeffs[m] = k
+        prediction_err *= (1 - k^2)
     end
 
-    # Return autocorrelation coefficients and error estimate
-    a, prediction_err
+    # Return autocorrelation coefficients, error estimate, and reflection coefficients
+    a, prediction_err, reflection_coeffs
 end
 
 

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -44,7 +44,7 @@ http://www.sylvain-marchand.info/Publications/dafx03.pdf
 function arburg(x::AbstractVector{<:Number}, p::Integer)
     # Initialize prediction error with the variance of the signal
     prediction_err = sum(abs2, x) / length(x)
-    T = typeof(prediction_err)
+    T = promote_type(typeof(prediction_err), eltype(x))
 
     ef = collect(T, x)                  # forward error
     eb = copy(ef)                       # backwards error

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -16,12 +16,12 @@ struct LPCLevinson end
 
 Given input signal `x` and prediction order `p`, returns IIR coefficients `a`
 and average reconstruction error `prediction_err`. Note that this method does
-NOT return the leading `1` present in the true autocorrelative estimate; it
+NOT return the leading ``1`` present in the true autocorrelative estimate; it
 omits it as it is implicit in every LPC estimate, and must be manually
 reintroduced if the returned vector should be treated as a polynomial.
 
 The algorithm used is determined by the last optional parameter, and can be
-either `LPCBurg` or `LPCLevinson`.
+either `LPCBurg` ([`arburg`](@ref)) or `LPCLevinson` ([`levinson`](@ref)).
 """
 function lpc end
 
@@ -34,22 +34,21 @@ end
 """
     arburg(x::AbstractVector, p::Integer)
 
-LPC (Linear-Predictive-Code) estimation, using the Burg method.
-This function implements the mathematics published in [1], and
-the recursion relation as noted in [2], in turn referenced from [3].
+LPC (Linear Predictive Coding) estimation, using the Burg method.
+This function implements the mathematics published in [^Lagrange], and
+the recursion relation as noted in [^Vos], in turn referenced from [^Andersen].
 
-[1] - Enhanced Partial Tracking Using Linear Prediction
-(DAFX 2003 article, Lagrange et al)
-http://www.sylvain-marchand.info/Publications/dafx03.pdf
+[^Lagrange]: Enhanced Partial Tracking Using Linear Prediction.
+    [DAFX 2003 article, Lagrange et al]
+    (http://www.sylvain-marchand.info/Publications/dafx03.pdf)
 
-[2] - A Fast Implementation of Burg’s Method © 2013, Koen Vos.\\
-https://www.opus-codec.org/docs/vos_fastburg.pdf
+[^Vos]: [A Fast Implementation of Burg’s Method]
+    (https://www.opus-codec.org/docs/vos_fastburg.pdf).
+    © 2013 Koen Vos, licensed under [CC BY 3.0]
+    (https://creativecommons.org/licenses/by/3.0/)
 
-This work is licensed under a Creative Commons Attribution 3.0 Unported License.\\
-https://creativecommons.org/licenses/by/3.0/
-
-[3] - N. Andersen. Comments on the performance of maximum entropy algorithms.\\
-Proceedings of the IEEE 66.11: 1581-1582, 1978.
+[^Andersen]: N. Andersen. Comments on the performance of maximum entropy algorithms.
+    Proceedings of the IEEE 66.11: 1581-1582, 1978.
 """
 function arburg(x::AbstractVector{T}, p::Integer) where T<:Number
     # Initialize prediction error with the variance of the signal
@@ -101,12 +100,12 @@ end
 """
     levinson(x::AbstractVector, p::Integer)
 
-LPC (Linear-Predictive-Code) estimation, using the Levinson method. This
-function implements the mathematics described in [1].
+Implements Levinson recursion, as described in [^Levinson].
+This function can be used for LPC (Linear Predictive Coding) estimation.
 
-[1] - The Wiener (RMS) Error Criterion in Filter Design and Prediction
-(N. Levinson, Studies in Applied Mathematics 25(1946), 261-278,
-https://doi.org/10.1002/sapm1946251261)
+[^Levinson]: The Wiener (RMS) Error Criterion in Filter Design and Prediction.
+    N. Levinson, Studies in Applied Mathematics 25(1946), 261-278.\\
+    <https://doi.org/10.1002/sapm1946251261>
 """
 function levinson(R_xx::AbstractVector{U}, p::Integer) where U<:Number
     # for m = 1
@@ -133,7 +132,7 @@ function levinson(R_xx::AbstractVector{U}, p::Integer) where U<:Number
     a, prediction_err, reflection_coeffs
 end
 
-"workaround for 1.6 BLAS incompatibility with negative stride views"
+# workaround for 1.6 BLAS incompatibility with negative stride views
 reverse_dot(x, y) = mapreduce(*, +, x, Iterators.reverse(y))
 
 # Default users to using Burg estimation as it is in general more stable

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -62,11 +62,14 @@ function arburg(x::AbstractVector{T}, p::Integer) where T<:Number
     rev_buf = similar(a, p)             # buffer to store a in reverse
     reflection_coeffs = similar(a, p)   # reflection coefficients
 
-    cf = pop!(ef)
-    cb = popfirst!(eb)
-    den = sum(abs2, eb) + sum(abs2, ef)
+    den = 2sum(abs2, ef)
+    ratio = one(R)
 
     @views for m in 1:p
+        cf = pop!(ef)
+        cb = popfirst!(eb)
+        den = ratio * den - abs2(cf) - abs2(cb)
+
         k = -2 * dot(eb, ef) / den
         reflection_coeffs[m] = k
 
@@ -82,10 +85,6 @@ function arburg(x::AbstractVector{T}, p::Integer) where T<:Number
 
         ratio = one(R) - abs2(k)
         prediction_err *= ratio
-        den = ratio * den - abs2(cf) - abs2(cb)
-
-        cf = pop!(ef)
-        cb = popfirst!(eb)
     end
 
     return conj!(a), prediction_err, reflection_coeffs

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -100,8 +100,20 @@ end
 """
     levinson(x::AbstractVector, p::Integer)
 
-Implements Levinson recursion, as described in [^Levinson].
-This function can be used for LPC (Linear Predictive Coding) estimation.
+Implements Levinson recursion, as described in [^Levinson], to find
+the solution `a` of the linear equation
+```math
+\\mathbf{T} \\vec{a}
+=
+\\begin{bmatrix}
+    x_2 \\\\
+    \\vdots \\\\
+    x_{p+1}
+\\end{bmatrix}
+```
+in the case where ``\\mathbf{T}`` is Hermitian and Toeplitz, with first column `x[1:p]`.
+This function can be used for LPC (Linear Predictive Coding) estimation,
+by providing `LPCLevinson()` as an argument to `lpc`.
 
 [^Levinson]: The Wiener (RMS) Error Criterion in Filter Design and Prediction.
     N. Levinson, Studies in Applied Mathematics 25(1946), 261-278.\\
@@ -109,15 +121,15 @@ This function can be used for LPC (Linear Predictive Coding) estimation.
 """
 function levinson(R_xx::AbstractVector{U}, p::Integer) where U<:Number
     # for m = 1
-    a_1 = -R_xx[2] / R_xx[1]
-    F = promote_type(Base.promote_union(U), typeof(a_1))
-    prediction_err = abs(R_xx[1] * (one(F) - abs2(a_1)))
+    k = -R_xx[2] / R_xx[1]
+    F = promote_type(Base.promote_union(U), typeof(k))
+    prediction_err = real(R_xx[1] * (one(F) - abs2(k)))
     R = typeof(prediction_err)
     T = promote_type(F, R)
 
     a = zeros(T, p)
     reflection_coeffs = zeros(T, p)
-    a[1] = reflection_coeffs[1] = a_1
+    a[1] = reflection_coeffs[1] = k
     rev_buf = similar(a, p - 1)     # buffer to store a in reverse
 
     @views for m = 2:p

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -76,6 +76,7 @@ https://doi.org/10.1002/sapm1946251261)
 function lpc(x::AbstractVector{<:Number}, p::Int, ::LPCLevinson)
     R_xx = xcorr(x,x)[length(x):end]
     a = zeros(p)
+    rev_buf = similar(a, p - 1)     # buffer to store a in reverse
 
     # for m = 1
     a[1] = -R_xx[2] / R_xx[1]
@@ -84,7 +85,8 @@ function lpc(x::AbstractVector{<:Number}, p::Int, ::LPCLevinson)
     # for m = 2,3,4,..p
     @views for m = 2:p
         a[m] = (-(R_xx[m+1] + dot(a[1:m-1], R_xx[m:-1:2])) / prediction_err)
-        @. a[1:m-1] += a[m] * a[m-1:-1:1]
+        rev_buf[1:m-1] = a[m-1:-1:1]
+        @. a[1:m-1] += a[m] * rev_buf[1:m-1]
         prediction_err *= (1 - a[m]^2)
     end
 

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -52,7 +52,7 @@ the recursion relation as noted in [^Vos], in turn referenced from [^Andersen].
 """
 function arburg(x::AbstractVector{T}, p::Integer) where T<:Number
     # Initialize prediction error with the variance of the signal
-    unnormed_err = dot(x, x)
+    unnormed_err = abs(dot(x, x))
     prediction_err = unnormed_err / length(x)
     R = typeof(prediction_err)
     F = promote_type(R, Base.promote_union(T))

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -103,7 +103,7 @@ end
 Implements Levinson recursion, as described in [^Levinson], to find
 the solution `a` of the linear equation
 ```math
-\\mathbf{T} \\vec{a}
+\\mathbf{T} (-\\vec{a})
 =
 \\begin{bmatrix}
     x_2 \\\\

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -28,7 +28,7 @@ function lpc end
 function lpc(x::AbstractVector{<:Number}, p::Integer, ::LPCBurg)
     a, prediction_err = arburg(x, p)
     popfirst!(a)
-    a, prediction_err
+    return a, prediction_err
 end
 
 """
@@ -94,7 +94,7 @@ end
 function lpc(x::AbstractVector{<:Number}, p::Integer, ::LPCLevinson)
     R_xx = xcorr(x; scaling=:biased)[length(x):end]
     a, prediction_err = levinson(R_xx, p)
-    a, prediction_err
+    return a, prediction_err
 end
 
 """
@@ -141,7 +141,7 @@ function levinson(R_xx::AbstractVector{U}, p::Integer) where U<:Number
     end
 
     # Return autocorrelation coefficients, error estimate, and reflection coefficients
-    a, prediction_err, reflection_coeffs
+    return a, prediction_err, reflection_coeffs
 end
 
 # for convenience, define dotu as dot for real vectors

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -264,6 +264,10 @@ end
     @test xcorr(off_a, off_b, padmode = :longest) == OffsetVector(vcat(0, exp), -3:1)
 
     @test_throws ArgumentError xcorr([1], [2]; padmode=:bug)
+    @test_throws DimensionMismatch xcorr([1], [2,3]; scaling=:biased)
+
+    # check that :biased doesn't throw InexactError
+    @test xcorr([1, 2], [3, 4]; scaling=:biased) == [2.0, 5.5, 3.0]
 end
 
 @testset "deconv" begin

--- a/test/lpc.jl
+++ b/test/lpc.jl
@@ -1,20 +1,12 @@
 # Filter some noise, try to learn the coefficients
-@testset "$method, Float64" for method in (LPCBurg(), LPCLevinson())
-    coeffs = [1, .5, .3, .2]
-    x = filt(1, coeffs, randn(50000))
+@testset "$method" for method in (LPCBurg(), LPCLevinson())
+    @testset "$T" for T in (Float64, ComplexF64)
+        coeffs = T <: Complex ? [1, 0.5 + 0.2im, 0.3 - 0.5im, 0.2] : [1, .5, .3, .2]
+        x = filt(1, coeffs, randn(T, 50000))
 
         # Analyze the filtered noise, attempt to reconstruct the coefficients above
-    ar, e = lpc(x[1000:end], length(coeffs)-1, method)
+        ar, e = lpc(x[1000:end], length(coeffs)-1, method)
 
-    @test isapprox(ar, coeffs[2:end]; atol=0.01)
-end
-
-@testset "$method, ComplexF64" for method in (LPCBurg(), LPCLevinson())
-    coeffs = [1, 0.5 + 0.2im, 0.3 - 0.5im, 0.2]
-    x = filt(1, coeffs, randn(ComplexF64, 50000))
-
-    # Analyze the filtered noise, attempt to reconstruct the coefficients above
-    ar, e = lpc(x[1000:end], length(coeffs) - 1, method)
-
-    @test isapprox(ar, coeffs[2:end]; atol=0.01)
+        @test all(<(0.01), abs.(ar - coeffs[2:end]))
+    end
 end

--- a/test/lpc.jl
+++ b/test/lpc.jl
@@ -1,10 +1,20 @@
 # Filter some noise, try to learn the coefficients
-@testset "$method" for method in (LPCBurg(), LPCLevinson())
+@testset "$method, Float64" for method in (LPCBurg(), LPCLevinson())
     coeffs = [1, .5, .3, .2]
-    x = filt([1], coeffs, randn(50000))
+    x = filt(1, coeffs, randn(50000))
 
-    # Analyze the filtered noise, attempt to reconstruct the coefficients above
+        # Analyze the filtered noise, attempt to reconstruct the coefficients above
     ar, e = lpc(x[1000:end], length(coeffs)-1, method)
 
-    @test all(abs.([1; ar] .- coeffs) .<= 1e-2)
+    @test isapprox(ar, coeffs[2:end]; atol=0.01)
+end
+
+@testset "$method, ComplexF64" for method in (LPCBurg(), LPCLevinson())
+    coeffs = [1, 0.5 + 0.2im, 0.3 - 0.5im, 0.2]
+    x = filt(1, coeffs, randn(ComplexF64, 50000))
+
+    # Analyze the filtered noise, attempt to reconstruct the coefficients above
+    ar, e = lpc(x[1000:end], length(coeffs) - 1, method)
+
+    @test isapprox(ar, coeffs[2:end]; atol=0.01)
 end

--- a/test/lpc.jl
+++ b/test/lpc.jl
@@ -7,6 +7,6 @@
         # Analyze the filtered noise, attempt to reconstruct the coefficients above
         ar, e = lpc(x[1000:end], length(coeffs)-1, method)
 
-        @test all(<(0.01), abs.(ar - coeffs[2:end]))
+        @test all(<(0.01), abs.(ar .- coeffs[2:end]))
     end
 end

--- a/test/lpc.jl
+++ b/test/lpc.jl
@@ -8,5 +8,14 @@
         ar, e = lpc(x[1000:end], length(coeffs)-1, method)
 
         @test all(<(0.01), abs.(ar .- coeffs[2:end]))
+        @test isapprox(e, 1; rtol=0.01)
     end
+end
+
+# test dotu, levinson with Int coefficients
+@test isapprox(levinson(1:10, 3)[1], -[1.25, 0, 0.25])
+
+# test that lpc defaults to Burg
+@test let v = rand(1000)
+    lpc(v, 20) == lpc(v, 20, LPCBurg())
 end

--- a/test/lpc.jl
+++ b/test/lpc.jl
@@ -12,8 +12,8 @@
     end
 end
 
-# test dotu, levinson with Int coefficients
-@test isapprox(levinson(1:10, 3)[1], -[1.25, 0, 0.25])
+# test dotu, levinson with complex Int coefficients
+@test isapprox(levinson(complex(1:10), 3)[1] |> real, -[1.25, 0, 0.25])
 
 # test that lpc defaults to Burg
 @test let v = rand(1000)


### PR DESCRIPTION
- fixed wrong error estimate for `levinson` by scaling
- `levinson` now has original O(n) space complexity
- both `arburg` and `levinson` can now handle complex inputs
- split off from #512, references #171