### PR TITLE
fail ci with codecov error + workflow_dispatch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
     branches: [master]
     tags: ['*']
   pull_request:
+  workflow_dispatch:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} ${{ matrix.arch }}
@@ -41,6 +42,7 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
- `fail_ci_if_error: true` => if the codecov upload errors, CI fails (probably due to secrets / codecov token)
- manually triggering CI is enabled with `workflow_dispatch`

Following up on #525.
On a side note, Windows on v1.6 is taking up a lot of time on `julia-buildpkg`.