### PR TITLE
Fix bounds errors when resampling with some arbitrary ratios

### DIFF
--- a/test/resample.jl
+++ b/test/resample.jl
@@ -97,6 +97,16 @@ end
     @test all(map(delta -> abs(delta) < 0.005, yDelta))
 end
 
+@testset "arbitrary ratio" begin
+    # https://github.com/JuliaDSP/DSP.jl/issues/317
+    @testset "Buffer length calculation" begin
+        @test length(resample(sin.(1:1:35546),  1/55.55)) == 641
+        @test length(resample(randn(1822), 0.9802414928649835)) == 1787
+        @test length(resample(1:16_367_000*2, 10_000_000/16_367_000)) == 20_000_001
+        @test resample(zeros(1000), 0.012) == zeros(13)
+    end
+end
+
 @testset "resample_filter" begin
     @testset "decimation" begin
         ratio = 1//2


### PR DESCRIPTION
In some cases when `filt(::FIRFilter{FIRArbitrary}, x)` is called
with certain values of `x`, the buffer is actually one sample too
short and a `BoundsError` is thrown in
`filt!(buffer, ::FIRFilter{FIRArbitrary}, x)`.  Add one extra sample
to the calculated buffer length to catch these exceptional cases, which
mostly arise when resampling with particular resampling ratios.

(This code is really a hack and simply works around the deeper problem
of ~calculating the correct output buffer length~ writing the correct number of points in `filt!`; this should instead be
addressed properly in a future change.)

Closes #317.
