### PR TITLE
use `std` to test lpc error

### DIFF
--- a/test/lpc.jl
+++ b/test/lpc.jl
@@ -1,14 +1,16 @@
 # Filter some noise, try to learn the coefficients
+using Statistics: std
 @testset "$method" for method in (LPCBurg(), LPCLevinson())
     @testset "$T" for T in (Float64, ComplexF64)
-        coeffs = T <: Complex ? [1, 0.5 + 0.2im, 0.3 - 0.5im, 0.2] : [1, .5, .3, .2]
-        x = filt(1, coeffs, randn(T, 50000))
+        coeffs = T <: Complex ? [1, 0.5 + 0.2im, 0.3 - 0.5im, 0.2] : [1, 0.5, 0.3, 0.2]
+        s = randn(T, 50000)
+        x = filt(1, coeffs, s)
 
         # Analyze the filtered noise, attempt to reconstruct the coefficients above
-        ar, e = lpc(x[1000:end], length(coeffs)-1, method)
+        ar, e = lpc(x[1000:end], length(coeffs) - 1, method)
 
         @test all(<(0.01), abs.(ar .- coeffs[2:end]))
-        @test isapprox(e, 1; rtol=0.01)
+        @test isapprox(e, std(s); rtol=0.01)
     end
 end
 


### PR DESCRIPTION
The lpc error was previously compared to 1, but the `std` of the `randn` generated signal is a better choice.