### PR TITLE
[DOCS] Add Small Note about Method Validations

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # Welcome to DSP.jl's documentation!
 
-DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia. So far, the following submodules are implemented:
+DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia that are validated against popular tools such as [MATLAB's Signal Processing suite](https://www.mathworks.com/help/overview/signal-processing.html?s_tid=hc_product_group_bc) and [Python's MNE-Python package](https://mne.tools/stable/index.html). So far, the following submodules are implemented:
 
 ## Table of contents
 ```@contents

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,8 @@
 # Welcome to DSP.jl's documentation!
 
-DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia that are validated against popular tools such as [MATLAB's Signal Processing suite](https://www.mathworks.com/help/overview/signal-processing.html?s_tid=hc_product_group_bc) and [Python's MNE-Python package](https://mne.tools/stable/index.html). So far, the following submodules are implemented:
+DSP.jl provides a number of common [digital signal processing](https://en.wikipedia.org/wiki/Digital_signal_processing) routines in Julia.  
+Many methods provided in this package are validated against popular tools such as [MATLAB's Signal Processing suite](https://www.mathworks.com/help/overview/signal-processing.html?s_tid=hc_product_group_bc) and [Python's MNE-Python package](https://mne.tools/stable/index.html). 
+So far, the following submodules are implemented:
 
 ## Table of contents
 ```@contents


### PR DESCRIPTION
Hey there!

After a discussion with @ericphanson , I learned that DSP.jl is actually validated against MATLAB and MNE-Python! In my eyes, that made using DSP.jl much more salient to me in knowing that, although its methods are made in Julia from scratch, they are compared with suites that are considered state of the art in many domains. I know it is a small edit, but I thought it was worthwhile enough to update the docs here because if I think that way, it may appeal to other folks thinking similarly.