### PR TITLE
Update CI.yml to use pre-release builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
             version: '1'
           - os: ubuntu-latest
             arch: x64
-            version: 'lts'
+            version: '1.6'
           - os: ubuntu-latest
             arch: x64
             version: 'pre'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,10 +34,10 @@ jobs:
             version: '1'
           - os: ubuntu-latest
             arch: x64
-            version: '1.6'
+            version: 'lts'
           - os: ubuntu-latest
             arch: x64
-            version: 'nightly'
+            version: 'pre'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Using `pre` instead of `nightly`. Thoughts?