### PR TITLE
Update macOS CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macOS-13
         arch:
           - x64
         include:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         arch:
           - x64
         include:
-          - os: macOS-14
+          - os: macOS-latest
             arch: aarch64
             version: '1'
           - os: ubuntu-latest


### PR DESCRIPTION
Since macOS-latest now points to macos-14.
Also, the macOS-latest x64 job currently emulates x64 on aarch64 (actions/runner-images#9741). Should this be macos-13 x64 instead?