### PR TITLE
Fix `unwrap` 1.11 regression + performance improvements

### DIFF
--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -1,5 +1,5 @@
 module Unwrap
-using Random: GLOBAL_RNG, AbstractRNG
+using Random: AbstractRNG, default_rng
 export unwrap, unwrap!
 
 """
@@ -62,7 +62,7 @@ of an image, as each pixel is wrapped to stay within (-pi, pi].
 - `circular_dims=(false, ...)`:  When an element of this tuple is `true`, the
     unwrapping process will consider the edges along the corresponding axis
     of the array to be connected.
-- `rng=GLOBAL_RNG`: Unwrapping of arrays with dimension > 1 uses a random
+- `rng=default_rng()`: Unwrapping of arrays with dimension > 1 uses a random
     initialization. A user can pass their own RNG through this argument.
 """
 unwrap(m::AbstractArray; kwargs...) = unwrap!(similar(m), m; kwargs...)
@@ -114,7 +114,7 @@ function unwrap_nd!(dest::AbstractArray{T, N},
                     src::AbstractArray{T, N};
                     range::Number=2*convert(T, pi),
                     circular_dims::NTuple{N, Bool}=ntuple(_->false, Val(N)),
-                    rng::AbstractRNG=GLOBAL_RNG) where {T, N}
+                    rng::AbstractRNG=default_rng()) where {T, N}
 
     range_T = convert(T, range)
 

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -80,7 +80,7 @@ unwrap(m::AbstractArray; kwargs...) = unwrap!(similar(m), m; kwargs...)
 
 mutable struct Pixel{T}
     periods::Int
-    val::T
+    const val::T
     reliability::Float64
     groupsize::Int
     head::Pixel{T}
@@ -127,7 +127,8 @@ function unwrap_nd!(dest::AbstractArray{T, N},
         populate_edges!(edges, pixel_image, idx_dim, circular_dims[idx_dim], range_T)
     end
 
-    sort!(edges, alg=MergeSort)
+    perm = sortperm(map(x -> x.reliability, edges); alg=MergeSort)
+    edges = edges[perm]
     gather_pixels!(pixel_image, edges)
     unwrap_image!(dest, pixel_image, range_T)
 

--- a/src/unwrap.jl
+++ b/src/unwrap.jl
@@ -168,16 +168,16 @@ end
 
 function wrap_val(val, range)
     wrapped_val  = val
-    wrapped_val += ifelse(val >  range/2, -range, zero(val))
-    wrapped_val += ifelse(val < -range/2,  range, zero(val))
+    wrapped_val -= ifelse(val >  range/2, range, zero(val))
+    wrapped_val += ifelse(val < -range/2, range, zero(val))
     return wrapped_val
 end
 
 function find_period(val_left, val_right, range)
     difference = val_left - val_right
     period  = 0
-    period += ifelse(difference >  range/2, -1, 0)
-    period += ifelse(difference < -range/2,  1, 0)
+    period -= (difference >  range/2)
+    period += (difference < -range/2)
     return period
 end
 

--- a/test/unwrap.jl
+++ b/test/unwrap.jl
@@ -1,4 +1,5 @@
 using DSP, Test
+using Random: MersenneTwister
 
 @testset "Unwrap 1D" begin
     @test unwrap([0.1, 0.2, 0.3, 0.4]) ≈ [0.1, 0.2, 0.3, 0.4]


### PR DESCRIPTION
The regression affects 1.11 but not 1.10. I think the optimizer fails to simplify `merge_groups`. Aside, this includes a small performance enhancement  (replacing `sort!` with `sortperm`) at the cost of ~40% more memory. Maybe it's worth it.
<details>
<summary>
PR
</summary>

```julia
julia> @benchmark unwrap(A; dims=1:2) setup=A=rand(500,500)
BenchmarkTools.Trial: 42 samples with 1 evaluation.
 Range (min … max):  104.560 ms … 184.250 ms  ┊ GC (min … max):  0.00% … 38.84%
 Time  (median):     118.173 ms               ┊ GC (median):    10.01%
 Time  (mean ± σ):   120.484 ms ±  16.391 ms  ┊ GC (mean ± σ):  10.78% ±  9.32%

  ▃█▁      █   ▃ ▁
  ███▁▁▁▁▄▁█▇▄▇█▄█▇▄▄▁▄▁▁▁▄▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▄ ▁
  105 ms           Histogram: frequency by time          184 ms <

 Memory estimate: 74.29 MiB, allocs estimate: 250113.

julia> @benchmark unwrap(A; dims=1:3) setup=A=rand(50,50,50)
BenchmarkTools.Trial: 64 samples with 1 evaluation.
 Range (min … max):  67.356 ms … 108.634 ms  ┊ GC (min … max):  0.00% … 36.22%
 Time  (median):     78.171 ms               ┊ GC (median):    12.69%
 Time  (mean ± σ):   79.053 ms ±   8.890 ms  ┊ GC (mean ± σ):  13.00% ±  8.80%

  ▂▄▂            ██    ▂
  ████▁▁▁▁▁▁▄▁▁▁▄████▄██▆▁▄█▁▁▆▁▄▁▄▁▄▄▆▁▁▁▁▁▁▁▁▁▁▄▄▁▁▁▁▁▁▁▁▁▁▄ ▁
  67.4 ms         Histogram: frequency by time          105 ms <

 Memory estimate: 61.42 MiB, allocs estimate: 125114.
```

</details>

<details>
<summary>
Only fix (similar to 1.10)
</summary>

```julia
julia> @benchmark unwrap(A; dims=1:2) setup=A=rand(500,500)
BenchmarkTools.Trial: 40 samples with 1 evaluation.
 Range (min … max):  114.546 ms … 157.513 ms  ┊ GC (min … max): 0.00% … 26.19%
 Time  (median):     126.192 ms               ┊ GC (median):    8.14%
 Time  (mean ± σ):   126.530 ms ±  10.672 ms  ┊ GC (mean ± σ):  8.23% ±  7.21%

  █ ▃             ▁  ▁        ▁
  █▇█▁▄▁▄▁▄▁▁▁▁▄▄▄█▁▇█▄▄▄▁▁▁▁▇█▇▁▁▁▁▄▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄ ▁
  115 ms           Histogram: frequency by time          158 ms <

 Memory estimate: 53.35 MiB, allocs estimate: 250104.

julia> @benchmark unwrap(A; dims=1:3) setup=A=rand(50,50,50)
BenchmarkTools.Trial: 57 samples with 1 evaluation.
 Range (min … max):  78.370 ms … 119.592 ms  ┊ GC (min … max): 0.00% … 32.56%
 Time  (median):     88.701 ms               ┊ GC (median):    9.91%
 Time  (mean ± σ):   87.541 ms ±   8.102 ms  ┊ GC (mean ± σ):  8.33% ±  7.10%

  █▂▂                ▂ ▂▂
  ███▄█▁▆▁▁▁▁▄▁▁▁▁▄█▆█▄██▆▆▆█▆▁▄▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▄ ▁
  78.4 ms         Histogram: frequency by time          111 ms <

 Memory estimate: 43.19 MiB, allocs estimate: 125105.
```

</details>

<details>
<summary> Without PR </summary>

```julia
julia> @benchmark unwrap(A; dims=1:2) setup=A=rand(500,500)
BenchmarkTools.Trial: 32 samples with 1 evaluation.
 Range (min … max):  145.698 ms … 224.118 ms  ┊ GC (min … max): 0.00% … 32.65%
 Time  (median):     157.550 ms               ┊ GC (median):    5.90%
 Time  (mean ± σ):   158.949 ms ±  13.967 ms  ┊ GC (mean ± σ):  6.32% ±  6.64%

    █     ▂ ▂  ▅
  ▅████▁▁▅█▅██▅█▅▁█▁▁▁▁▁▁▁▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅ ▁
  146 ms           Histogram: frequency by time          224 ms <

 Memory estimate: 53.35 MiB, allocs estimate: 250104.

julia> @benchmark unwrap(A; dims=1:3) setup=A=rand(50,50,50)
BenchmarkTools.Trial: 55 samples with 1 evaluation.
 Range (min … max):  80.909 ms … 120.537 ms  ┊ GC (min … max):  0.00% … 31.32%
 Time  (median):     91.762 ms               ┊ GC (median):    10.11%
 Time  (mean ± σ):   91.261 ms ±   9.141 ms  ┊ GC (mean ± σ):   8.99% ±  8.14%

    █▄                   ▄
  ▆▇██▄▄▄▁▁▁▁▁▆▁▁▁▇▆▄▇▆▆▆█▆▆▄▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▄▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▄ ▁
  80.9 ms         Histogram: frequency by time          119 ms <

 Memory estimate: 43.19 MiB, allocs estimate: 125105.```

</details>

