### PR TITLE
Deprecate multi-arg and tuple `nextfastfft`

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,4 +1,9 @@
-# deprecations after 0.6
+# deprecations in 0.8
+import .Util.nextfastfft
+@deprecate nextfastfft(ns::Tuple) nextfastfft.(ns) false
+@deprecate nextfastfft(ns...) nextfastfft.(ns) false
+
+# deprecations in 0.7
 @deprecate freqz(filter::FilterCoefficients{:z}) freqresp(filter, range(0, stop=π, length=250))
 @deprecate freqz(filter::FilterCoefficients{:z}, w) freqresp(filter, w)
 @deprecate freqs(filter::FilterCoefficients{:s}, w) freqresp(filter, w)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -613,7 +613,7 @@ function _conv_kern_fft!(out::AbstractArray{T, N},
                          u::AbstractArray{<:Real, N},
                          v::AbstractArray{<:Real, N}) where {T<:Real, N}
     outsize = size(output_indices)
-    nffts = nextfastfft(outsize)
+    nffts = nextfastfft.(outsize)
     padded = _zeropad!(similar(u, T, nffts), u)
     p = plan_rfft(padded)
     uf = p * padded
@@ -628,7 +628,7 @@ function _conv_kern_fft!(out::AbstractArray{T, N},
 end
 function _conv_kern_fft!(out::AbstractArray{T}, output_indices, u, v) where {T}
     outsize = size(output_indices)
-    nffts = nextfastfft(outsize)
+    nffts = nextfastfft.(outsize)
     upad = _zeropad!(similar(u, T, nffts), u)
     vpad = _zeropad!(similar(v, T, nffts), v)
     p! = plan_fft!(upad)

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -420,7 +420,7 @@ end
 # DTFT of the signal S if radialsum and radialavg are both false (default),
 # a radial sum if radialsum=true, or a radial averave if radialavg=true
 """
-    periodogram(s::AbstractMatrix; nfft::NTuple{2,Int}=nextfastfft(size(s)), fs=1, radialsum=false, radialavg=false)
+    periodogram(s::AbstractMatrix; nfft::NTuple{2,Int}=nextfastfft.(size(s)), fs=1, radialsum=false, radialavg=false)
 
 Computes periodogram of a 2-d signal using the 2-d FFT and returns a
 [`Periodogram2`](@ref) or [`Periodogram`](@ref) object.
@@ -471,7 +471,7 @@ DSP.Periodograms.Periodogram{Float64, AbstractFFTs.Frequencies{Float64}, Vector{
 ```
 """
 function periodogram(s::AbstractMatrix{T};
-                     nfft::NTuple{2,Int}=nextfastfft(size(s)),
+                     nfft::NTuple{2,Int}=nextfastfft.(size(s)),
                      fs::Real=1,
                      radialsum::Bool=false, radialavg::Bool=false) where T<:Real
     size(s,1)<=nfft[1] && size(s,2)<=nfft[2] || throw(ArgumentError("nfft must be >= size(s)"))

--- a/src/util.jl
+++ b/src/util.jl
@@ -115,9 +115,6 @@ computes Fourier transforms of input that is a product of these
 sizes faster than for input of other sizes.
 """
 nextfastfft(n) = nextprod(FAST_FFT_SIZES, n)
-nextfastfft(ns::Tuple) = nextfastfft.(ns)
-nextfastfft(ns...) = nextfastfft(ns)
-
 
 ## COMMON DSP TOOLS
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -56,8 +56,6 @@ end
     @test nextfastfft(64) == 64
     @test nextfastfft(65) == 70
     @test nextfastfft(127) == 128
-    @test nextfastfft((64,65,127)) == (64,70,128)
-    @test nextfastfft(64,65,127) == nextfastfft((64,65,127))
 end
 
 ## COMMON DSP TOOLS


### PR DESCRIPTION
Closes #291. I agree with the assessment therein and add that the remaining method is the only one documented.