### PR TITLE
Disallow mixing offset and non-offset axes in `conv` input

### DIFF
--- a/ext/OffsetArraysExt.jl
+++ b/ext/OffsetArraysExt.jl
@@ -2,6 +2,6 @@ module OffsetArraysExt
 import DSP
 import OffsetArrays
 
-DSP.conv_with_offset(::OffsetArrays.IdOffsetRange) = true
+DSP.conv_axis_with_offset(::OffsetArrays.IdOffsetRange) = true
 
 end

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -72,12 +72,18 @@ end
 
         offset_arr = OffsetVector{Int}(undef, -1:2)
         offset_arr[:] = a
-        @test conv(offset_arr, 1:3) == OffsetVector(expectation, 0:5)
+        @test_throws ArgumentError conv(offset_arr, 1:3)
+        @test conv(offset_arr, OffsetArray(1:3)) == OffsetVector(expectation, 0:5)
         offset_arr_f = OffsetVector{Float64}(undef, -1:2)
         offset_arr_f[:] = fa
-        @test conv(offset_arr_f, 1:3) ≈ OffsetVector(fexp, 0:5)
+        @test_throws ArgumentError conv(offset_arr_f, 1:3)
+        @test conv(offset_arr_f, OffsetArray(1:3)) ≈ OffsetVector(fexp, 0:5)
         @test_throws ArgumentError conv!(zeros(6), offset_arr, 1:3) # output needs to be OA, too
         @test_throws ArgumentError conv!(OffsetVector{Int}(undef, 1:6), 1:4, 1:3) # output mustn't be OA
+
+        @test conv(fa, fill(true)) == conv(fill(true), fa) == fa
+        @test_broken conv(offset_arr_f, fill(true)) == conv(fill(true), offset_arr_f) == offset_arr_f
+        @test conv(fill(true), fill(true)) == fill(true)
 
         for M in [10, 200], N in [10, 200], T in [Float64, ComplexF64]
             u = rand(T, M)
@@ -156,7 +162,8 @@ end
 
         offset_arr = OffsetMatrix{Int}(undef, -1:1, -1:1)
         offset_arr[:] = a
-        @test conv(offset_arr, b) == OffsetArray(expectation, 0:3, 0:3)
+        @test_throws ArgumentError conv(offset_arr, b)
+        @test conv(offset_arr, OffsetArray(b)) == OffsetArray(expectation, 0:3, 0:3)
 
         for (M1, M2) in [(10, 20), (190, 200)], (N1, N2) in [(20, 10), (210, 200)], T in [Float64, ComplexF64]
             u = rand(T, M1, M2)


### PR DESCRIPTION
In reference to #583, but doesn't fix it. Rather, it explicitly throws an error for any input where we're not quite sure what it should do. That would leave us the opportunity to make a more informed choice later when (and if) concrete use cases for mixed offset/non-offset inputs are reported.