### PR TITLE
Fix `setphase!` for pathological cases

### DIFF
--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -229,7 +229,7 @@ function setphase!(kernel::FIRArbitrary, ϕ::Real)
     (ϕ, xThrowaway) = modf(ϕ)
     kernel.inputDeficit += round(Int, xThrowaway)
     kernel.ϕAccumulator = ϕ*(kernel.Nϕ) + 1.0
-    kernel.ϕIdx         = round(kernel.ϕAccumulator)
+    kernel.ϕIdx         = floor(kernel.ϕAccumulator)
     kernel.α            = modf(kernel.ϕAccumulator)[1]
     nothing
 end

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -218,9 +218,9 @@ end
 
 function setphase!(kernel::Union{FIRInterpolator, FIRRational}, ϕ::Real)
     ϕ >= zero(ϕ) || throw(ArgumentError("ϕ must be >= 0"))
-    (ϕ, xThrowaway) = modf(ϕ)
-    kernel.inputDeficit += round(Int, xThrowaway)
-    kernel.ϕIdx = round(ϕ*(kernel.Nϕ) + 1.0)
+    xThrowaway, ϕIdx = divrem(round(Int, ϕ * kernel.Nϕ), kernel.Nϕ)
+    kernel.inputDeficit += xThrowaway
+    kernel.ϕIdx = ϕIdx + 1
     nothing
 end
 

--- a/test/filt_stream.jl
+++ b/test/filt_stream.jl
@@ -361,3 +361,7 @@ end
         test_rational(h, x, interpolation)
     end
 end
+
+# check that these don't throw; the output should actually probably be longer
+@test resample(1:2, 3, [zeros(2); 1; zeros(3)]) == [1, 0, 0, 2] # [1, 0, 0, 2, 0, 0]
+@test resample(1:2, 3//2, [zeros(2); 1; zeros(3)]) == [1, 0] # [1, 0, 0]

--- a/test/filt_stream.jl
+++ b/test/filt_stream.jl
@@ -365,3 +365,11 @@ end
 # check that these don't throw; the output should actually probably be longer
 @test resample(1:2, 3, [zeros(2); 1; zeros(3)]) == [1, 0, 0, 2] # [1, 0, 0, 2, 0, 0]
 @test resample(1:2, 3//2, [zeros(2); 1; zeros(3)]) == [1, 0] # [1, 0, 0]
+let H = FIRFilter(2.22)
+    setphase!(H, 0.99)
+    @test length(filt(H, 1:2)) == 3
+end
+let H = FIRFilter(122.2)
+    setphase!(H, 0.99)
+    @test length(filt(H, 1:2)) == 124
+end


### PR DESCRIPTION
Hit this while trying to get a handle on #186.

For odd number of phases `Nϕ` and even length of the filter kernel, the old code would yield `qidx` above `Nϕ`, namely equal to `Nϕ+1`, which would result in a `BoundsError` during `resample`. Rewrite the code to reduce `qidx` to `1` in this case and increase `inputDeficit` by one instead. All other constellations should be unaffected.

For reviewing: I think what the code does is determining `xThrowaway` and `kernel.ϕIdx` such that they are both integer and `xThrowaway + (kernel.ϕIdx-1) * kernel.Nϕ ≈ ϕ` as closely as possible. This should have been the case before and after. But also, we require `1 ≤ kernel.ϕIdx ≤  kernel.Nϕ` which the old code failed to ensure in pathological cases.