### PR TITLE
Fix output length of `resample`

### DIFF
--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -702,11 +702,14 @@ function resample(x::AbstractVector, rate::Real, h::Vector)
 
     # Calculate the number of 0's required
     outLen      = ceil(Int, length(x)*rate)
-    reqInlen    = inputlength(self, outLen)
+    reqInlen    = inputlength(self, outLen, RoundUp)
     reqZerosLen = reqInlen - length(x)
     xPadded     = [x; zeros(eltype(x), reqZerosLen)]
 
-    filt(self, xPadded)
+    y = filt(self, xPadded)
+    @assert length(y) >= outLen
+    length(y) > outLen && resize!(y, outLen)
+    return y
 end
 
 function resample(x::AbstractVector, rate::Real)

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -336,7 +336,7 @@ function outputlength(kernel::FIRRational, inputlength::Integer)
 end
 
 function outputlength(kernel::FIRArbitrary, inputlength::Integer)
-    ceil(Int, (inputlength-kernel.inputDeficit+1) * kernel.rate)
+    ceil(Int, (inputlength-kernel.inputDeficit+1) * kernel.rate - (kernel.ϕAccumulator - 1) / kernel.Δ)
 end
 
 function outputlength(self::FIRFilter, inputlength::Integer)
@@ -378,7 +378,7 @@ end
 
 # TODO: figure out why this fails. Might be fine, but the filter operation might not being stepping through the phases correcty.
 function inputlength(kernel::FIRArbitrary, outputlength::Integer)
-    inLen  = floor(Int, outputlength/kernel.rate)
+    inLen  = floor(Int, (outputlength + (1 - kernel.ϕAccumulator) / kernel.Δ)/kernel.rate)
     inLen += kernel.inputDeficit - 1
 end
 

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -332,7 +332,7 @@ function outputlength(kernel::FIRDecimator, inputlength::Integer)
 end
 
 function outputlength(kernel::FIRRational, inputlength::Integer)
-    outputlength(inputlength-kernel.inputDeficit+1, kernel.ratio, 1)
+    outputlength(inputlength-kernel.inputDeficit+1, kernel.ratio, kernel.ϕIdx)
 end
 
 function outputlength(kernel::FIRArbitrary, inputlength::Integer)
@@ -645,7 +645,11 @@ function filt(self::FIRFilter{Tk}, x::AbstractVector{Tx}) where {Th,Tx,Tk<:FIRKe
     buffer         = Vector{promote_type(Th,Tx)}(undef, bufLen)
     samplesWritten = filt!(buffer, self, x)
 
-    samplesWritten == bufLen || resize!(buffer, samplesWritten)
+    if Tk <: FIRArbitrary
+        samplesWritten == bufLen || resize!(buffer, samplesWritten)
+    else
+        @assert samplesWritten == bufLen
+    end
 
     return buffer
 end

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -210,14 +210,14 @@ end
 # setphase! set's filter kernel phase index
 #
 function setphase!(kernel::FIRDecimator, ϕ::Real)
-    ϕ >= zero(ϕ) || throw(ArgumentError("ϕ must be >= 0"))
+    ϕ >= zero(ϕ) || throw(DomainError(ϕ, "ϕ must be >= 0"))
     xThrowaway = round(Int, ϕ)
     kernel.inputDeficit += xThrowaway
     nothing
 end
 
 function setphase!(kernel::Union{FIRInterpolator, FIRRational}, ϕ::Real)
-    ϕ >= zero(ϕ) || throw(ArgumentError("ϕ must be >= 0"))
+    ϕ >= zero(ϕ) || throw(DomainError(ϕ, "ϕ must be >= 0"))
     xThrowaway, ϕIdx = divrem(round(Int, ϕ * kernel.Nϕ), kernel.Nϕ)
     kernel.inputDeficit += xThrowaway
     kernel.ϕIdx = ϕIdx + 1
@@ -225,7 +225,7 @@ function setphase!(kernel::Union{FIRInterpolator, FIRRational}, ϕ::Real)
 end
 
 function setphase!(kernel::FIRArbitrary, ϕ::Real)
-    ϕ >= zero(ϕ) || throw(ArgumentError("ϕ must be >= 0"))
+    ϕ >= zero(ϕ) || throw(DomainError(ϕ, "ϕ must be >= 0"))
     (ϕ, xThrowaway) = modf(ϕ)
     kernel.inputDeficit += round(Int, xThrowaway)
     kernel.ϕAccumulator = ϕ * kernel.Nϕ
@@ -395,19 +395,10 @@ end
 # Calculates the delay caused by the FIR filter in # samples, at the input sample rate, caused by the filter process
 #
 
-function timedelay(kernel::Union{FIRRational, FIRInterpolator, FIRArbitrary})
-    (kernel.hLen - 1)/(2.0*kernel.Nϕ)
-end
-
-function timedelay(kernel::Union{FIRStandard, FIRDecimator})
-    (kernel.hLen - 1)/2
-end
-
-
-function timedelay(self::FIRFilter)
-    timedelay(self.kernel)
-end
-
+timedelay(kernel::Union{FIRRational,FIRInterpolator,FIRArbitrary}) =
+    (kernel.hLen - 1) / (2 * kernel.Nϕ)
+timedelay(kernel::Union{FIRStandard,FIRDecimator}) = (kernel.hLen - 1) / 2
+timedelay(self::FIRFilter) = timedelay(self.kernel)
 
 #
 # Single rate filtering

--- a/test/filt_stream.jl
+++ b/test/filt_stream.jl
@@ -362,9 +362,8 @@ end
     end
 end
 
-# check that these don't throw; the output should actually probably be longer
-@test resample(1:2, 3, [zeros(2); 1; zeros(3)]) == [1, 0, 0, 2] # [1, 0, 0, 2, 0, 0]
-@test resample(1:2, 3//2, [zeros(2); 1; zeros(3)]) == [1, 0] # [1, 0, 0]
+@test resample(1:2, 3, [zeros(2); 1; zeros(3)]) == [1, 0, 0, 2, 0, 0]
+@test resample(1:2, 3//2, [zeros(2); 1; zeros(3)]) == [1, 0, 0]
 let H = FIRFilter(2.22)
     setphase!(H, 0.99)
     @test length(filt(H, 1:2)) == 3

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -100,10 +100,10 @@ end
 @testset "arbitrary ratio" begin
     # https://github.com/JuliaDSP/DSP.jl/issues/317
     @testset "Buffer length calculation" begin
-        @test length(resample(sin.(1:1:35546),  1/55.55)) == 641
-        @test length(resample(randn(1822), 0.9802414928649835)) == 1787
-        @test length(resample(1:16_367_000*2, 10_000_000/16_367_000)) == 20_000_001
-        @test resample(zeros(1000), 0.012) == zeros(13)
+        @test length(resample(sin.(1:1:35546),  1/55.55)) == 640
+        @test length(resample(randn(1822), 0.9802414928649835)) == 1786
+        @test length(resample(1:16_367_000*2, 10_000_000/16_367_000)) == 20_000_000
+        @test resample(zeros(1000), 0.012) == zeros(12)
     end
 end
 

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -151,3 +151,35 @@ end
         @test isapprox(rc, Nϕ/2, rtol=0.001)
     end
 end
+
+@testset "inputlength" begin
+    # FIRDecimator, FIRInterpolator, FIRRational
+    for _ in 1:1000
+        M=rand(1:10)//rand(1:10)
+        H=FIRFilter(zeros(rand(1:100)), M)
+        if M != 1
+            setphase!(H, 10*rand())
+        end
+        yL = rand(1:100)
+        @test outputlength(H, inputlength(H, yL)) <= yL < outputlength(H, inputlength(H, yL)+1)
+        @test outputlength(H, inputlength(H, yL, RoundUp)-1) < yL <= outputlength(H, inputlength(H, yL, RoundUp))
+    end
+
+    # FIRArbitrary
+    for _ in 1:1000
+        M = 10*rand()
+        H = FIRFilter(zeros(rand(1:100)), M)
+        setphase!(H, 10*rand())
+        yL = rand(1:100)
+        @test outputlength(H, inputlength(H, yL)) <= yL < outputlength(H, inputlength(H, yL)+1)
+        @test outputlength(H, inputlength(H, yL, RoundUp)-1) < yL <= outputlength(H, inputlength(H, yL, RoundUp))
+    end
+    let
+        M = 2.0
+        H = FIRFilter(resample_filter(M), M)
+        setphase!(H, timedelay(H))
+        yL = 200
+        @test outputlength(H, inputlength(H, yL)) <= yL < outputlength(H, inputlength(H, yL)+1)
+        @test outputlength(H, inputlength(H, yL, RoundUp)-1) < yL <= outputlength(H, inputlength(H, yL, RoundUp))
+    end
+end


### PR DESCRIPTION
This comprises a few changes that can be considered in on their own, but later ones depend on earlier ones for proper results. In commit order:
* `outputlength(::FIRRational, inputlength)` is fixed to correctly predict the number of valid samples produced by `filt!`. (For context: `filt!` expects a sufficiently large output buffer and returns the number of samples actually written.)
* `outputlength(::FIRArbitrary, inputlength)` is improved to do this correctly more often. Unfortunately, it can still be off-by-one sometimes, which seems almost inevitable. The reason is -- somewhat simplified -- that `filt!` increases the time incrementally, which may be numerically different from considering the whole time-span at once. More complicated in reality, but conceptually: Starting at sample 1 and going in steps of 0.1, how many steps do you need to reach sample 2? Ten, because `10 * 0.1 == 1`? No, one more, because `0.1 + 0.1 + 0.1 + 0.1 + 0.1 + 0.1 + 0.1 + 0.1 + 0.1 + 0.1 < 1`. Now, to be sure to have `outputlength` give the correct result, I think one would have to replicate the same iterative index/phase computations, which seems excessive.
* Add rounding mode support to `inputlength`, specifically for `RoundUp` and `RoundDown` (where the latter is the old behavior and still the default). With `RoundDown`, `inputlength` returns the largest input length such that the actual output length will be at most the given one, i.e. `outputlength(H, inputlength(H, yL)) <= yL < outputlength(H, inputlength(H, yL)+1)`. OTOH, with `RoundUp`,  `inputlength` returns the shortest input length such that the actual output length will be at least the given one, i.e. `outputlength(H, inputlength(H, yL, RoundUp)-1) < yL <= outputlength(H, inputlength(H, yL, RoundUp))`.
* In `resample`, use `inputlength` in `RoundUp` mode to pad the input to the minimum length to get at least `ceil(Int, length(x)*rate)` output samples, then trim the output to the required size as necessary.

Some points I'd especially appreciate feedback on:
* Are the current tests sufficient or should I add more? If so, which?
* Are we confident with the `@assert`s or should that be more defensive?
* Is the `RoundingMode` API for `inputlength` appropriate? Only `RoundUp` and `RoundDown` really make sense there, I guess, so maybe not? (Or should we just drop the `RoundDown` behavior which might not be needed at all?)

Fixes #186.