### PR TITLE
Improve resample "irrational ratio" test

### DIFF
--- a/test/resample.jl
+++ b/test/resample.jl
@@ -79,22 +79,22 @@ end
     x        = sinpi.(2*tx)
     y        = resample(x, ratio)
     yLen     = length(y)
-    ty       = range(0, stop=cycles, length=yLen)
+    ty       = range(0, length=yLen, step=step(tx)/ratio)
     yy       = sinpi.(2*ty)
     idxLower = round(Int, yLen/3)
     idxUpper = idxLower*2
     yDelta   = abs.(y[idxLower:idxUpper].-yy[idxLower:idxUpper])
-    @test all(map(delta -> abs(delta) < 0.005, yDelta))
+    @test all(map(delta -> abs(delta) < 0.00025, yDelta))
 
     # Test Float32 ratio (#302)
     f32_ratio = convert(Float32, ratio)
     f32_y     = resample(x, f32_ratio)
-    ty        = range(0, stop =cycles, length =yLen)
+    ty        = range(0, length=yLen, step=step(tx)/ratio)
     yy        = sinpi.(2*ty)
     idxLower  = round(Int, yLen/3)
     idxUpper  = idxLower*2
     yDelta    = abs.(f32_y[idxLower:idxUpper].-yy[idxLower:idxUpper])
-    @test all(map(delta -> abs(delta) < 0.005, yDelta))
+    @test all(map(delta -> abs(delta) < 0.00025, yDelta))
 end
 
 @testset "arbitrary ratio" begin

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -84,17 +84,17 @@ end
     idxLower = round(Int, yLen/3)
     idxUpper = idxLower*2
     yDelta   = abs.(y[idxLower:idxUpper].-yy[idxLower:idxUpper])
-    @test all(map(delta -> abs(delta) < 0.00025, yDelta))
+    @test maximum(yDelta) < 0.00025
 
     # Test Float32 ratio (#302)
     f32_ratio = convert(Float32, ratio)
     f32_y     = resample(x, f32_ratio)
-    ty        = range(0, length=yLen, step=step(tx)/ratio)
+    ty        = range(0, length=yLen, step=step(tx)/f32_ratio)
     yy        = sinpi.(2*ty)
     idxLower  = round(Int, yLen/3)
     idxUpper  = idxLower*2
     yDelta    = abs.(f32_y[idxLower:idxUpper].-yy[idxLower:idxUpper])
-    @test all(map(delta -> abs(delta) < 0.00025, yDelta))
+    @test maximum(yDelta) < 0.00025
 end
 
 @testset "arbitrary ratio" begin


### PR DESCRIPTION
Ref. https://github.com/JuliaDSP/DSP.jl/pull/596#discussion_r1862008820: computing the reference signal with the proper ratio seems more logical - that's what an ideal resampling should produce - and allows a much tighter bound. While at it, avoid doing `abs` twice to simplify the test criterion.