### PR TITLE
Let `filt`/`filt!` return state if provided as input

### DIFF
--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -20,16 +20,16 @@ using DSP: filt, filt!, deconv, conv, xcorr,
     @test filt(b, 1., [x 1.0:8.0]) == [filt(b, 1., x) filt(b, 1., 1.0:8.0)]
     @test filt(b, [1., -0.5], [x 1.0:8.0]) == [filt(b, [1., -0.5], x) filt(b, [1., -0.5], 1.0:8.0)]
     si = zeros(3)
-    @test filt(b, 1., [x 1.0:8.0], si) == [filt(b, 1., x, si) filt(b, 1., 1.0:8.0, si)]
+    @test first(filt(b, 1., [x 1.0:8.0], si)) == [first(filt(b, 1., x, si)) first(filt(b, 1., 1.0:8.0, si))]
     @test si == zeros(3) # Will likely fail if/when arrayviews are implemented
     si = [zeros(3) ones(3)]
-    @test filt(b, 1., [x 1.0:8.0], si) == [filt(b, 1., x, zeros(3)) filt(b, 1., 1.0:8.0, ones(3))]
+    @test first(filt(b, 1., [x 1.0:8.0], si)) == [first(filt(b, 1., x, zeros(3))) first(filt(b, 1., 1.0:8.0, ones(3)))]
     # With initial conditions: a lowpass 5-pole butterworth filter with W_n = 0.25,
     # and a stable initial filter condition matched to the initial value
     b = [0.003279216306360201,0.016396081531801006,0.03279216306360201,0.03279216306360201,0.016396081531801006,0.003279216306360201]
     a = [1.0,-2.4744161749781606,2.8110063119115782,-1.703772240915465,0.5444326948885326,-0.07231566910295834]
     si = [0.9967207836936347,-1.4940914728163142,1.2841226760316475,-0.4524417279474106,0.07559488540931815]
-    @test filt(b, a, ones(10), si) ≈ ones(10) # Shouldn't affect DC offset
+    @test first(filt(b, a, ones(10), si)) ≈ ones(10) # Shouldn't affect DC offset
 
     @test_throws ArgumentError filt!([1, 2], [1], [1], [1])
 end


### PR DESCRIPTION
As argued in https://github.com/JuliaDSP/DSP.jl/issues/372#issuecomment-2506259561, I don't think the possibility to pass in state to `filt` and `filt!` in the current form is very helpful, as there is no supported way of obtaining such state. There is the internal `_zerosi`, but explicitly passing the zero-state is equivalent to passing no state, so why bother. Otherwise, the filter state should probably be considered an implementation detail and it is undocumented, so hand-crafting it is not recommended. (With the exception of the use in DSPs own `filtfilt`, maybe.) The most likely use of passing in state is to resume a filtering operation, e.g. for blockwise processing. (Yes, that's what using a `DF2TFilter` allows, too.) But to enable that, one would need the final state to be provided by `filt`/`filt!`.

And that's what this PR does, but only if an input state is provided. I.e. one can do
```julia
(outblock1, state) = filt(H, inblock1, state)
(outblock2, state) = filt(H, inblock2, state)
```

The implementation is somewhat rough-and-dirty for now, as I first wanted to get a feel for this and see if we want to do this. There are some questions on the API worth thinking about:
* How should the initial state be obtained? Make `_zerosi` public (with a better name)? Or support some placeholder value for the `state` parameter that indicates a zero-state should be set up?
* Should `filt!` modify the `state` instead of returning it? Seems reasonable, but up to now, care was taken not to modify the state.
* For multi-column input, we support passing in a single state which will then be replicated for each column. Do we need to keep supporting that?

Putting on the milestone as this would be breaking.