### PR TITLE
Fix multi-column `filt` for `ndims(x)>2`

### DIFF
--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -40,7 +40,7 @@ _zerosi(f::SecondOrderSections{:z,T,G}, ::AbstractArray{S}) where {T,G,S} =
 
 # filt! algorithm (no checking, returns si)
 function _filt!(out::AbstractArray, si::AbstractArray{S,N}, f::SecondOrderSections{:z},
-                x::AbstractArray, col::Int) where {S,N}
+                x::AbstractArray, col::Union{Int,CartesianIndex}) where {S,N}
     g = f.g
     biquads = f.biquads
     n = length(biquads)
@@ -69,7 +69,7 @@ function filt!(out::AbstractArray, f::SecondOrderSections{:z}, x::AbstractArray,
 
     initial_si = si
     si = similar(si, axes(si)[1:2])
-    for col = 1:ncols
+    for col in CartesianIndices(axes(x)[2:end])
         copyto!(si, view(initial_si, :, :, N > 2 ? col : 1))
         _filt!(out, si, f, x, col)
     end
@@ -85,7 +85,7 @@ _zerosi(::Biquad{:z,T}, ::AbstractArray{S}) where {T,S} =
 
 # filt! algorithm (no checking, returns si)
 function _filt!(out::AbstractArray, si1::Number, si2::Number, f::Biquad{:z},
-                x::AbstractArray, col::Int)
+                x::AbstractArray, col::Union{Int,CartesianIndex})
     @inbounds for i in axes(x, 1)
         xi = x[i, col]
         yi = muladd(f.b0, xi, si1)
@@ -105,7 +105,7 @@ function filt!(out::AbstractArray, f::Biquad{:z}, x::AbstractArray,
     (size(si, 1) != 2 || (N > 1 && Base.trailingsize(si, 2) != ncols)) &&
         throw(ArgumentError("si must have two rows and 1 or nsignals columns"))
 
-    for col = 1:ncols
+    for col in CartesianIndices(axes(x)[2:end])
         _filt!(out, si[1, N > 1 ? col : 1], si[2, N > 1 ? col : 1], f, x, col)
     end
     out

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -68,7 +68,7 @@ function filt!(out::AbstractArray, b::Union{AbstractVector, Number}, a::Union{Ab
     else
         initial_si = si
         si = similar(si, axes(si, 1))
-        for col in axes(x, 2)
+        for col in CartesianIndices(axes(x)[2:end])
             # Reset the filter state
             copyto!(si, view(initial_si, :, N > 1 ? col : 1))
             if as > 1

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -63,6 +63,18 @@ using DSP, Test, Random, FilterTestHelpers
     @test_nowarn filt(f, s)
 end
 
+@testset "multi-column filt $D-D" for D in 1:4
+     b = [0.1, 0.1]
+     a = [1.0, -0.8]
+     sz = (10, ntuple(n -> n+1, Val(D))...)
+     y_ref = filt(b, a, ones(sz[1]))
+     x = ones(sz)
+     @test all(col -> col ≈ y_ref, eachslice(filt(b, a, x); dims=ntuple(n -> n+1, Val(D))))
+     @test all(col -> col ≈ y_ref, eachslice(filt(PolynomialRatio(b, a), x); dims=ntuple(n -> n+1, Val(D))))
+     @test all(col -> col ≈ y_ref, eachslice(filt(Biquad(PolynomialRatio(b, a)), x); dims=ntuple(n -> n+1, Val(D))))
+     @test all(col -> col ≈ y_ref, eachslice(filt(SecondOrderSections(PolynomialRatio(b, a)), x); dims=ntuple(n -> n+1, Val(D))))
+end
+
 #
 # filtfilt
 #


### PR DESCRIPTION
Our `filt` (and `filt!`) support multi-column input, working column-wise. That is extremely useful for e.g. stereo audio signals. The functions accept arbitrary-dimensional input, but only work properly for at most two dimensions.

Master:
```julia
julia> H = PolynomialRatio([0.1, 0.1], [1, -0.8]);

julia> filt(H, ones(5,3,2))
5×3×2 Array{Float64, 3}:
[:, :, 1] =
 0.1      0.1      0.1
 0.28     0.28     0.28
 0.424    0.424    0.424
 0.5392   0.5392   0.5392
 0.63136  0.63136  0.63136

[:, :, 2] =
 6.90139e-310  6.90139e-310  6.90139e-310
 6.90139e-310  6.90139e-310  6.90139e-310
 6.90139e-310  6.90139e-310  6.90139e-310
 6.90139e-310  6.90139e-310  6.90139e-310
 6.90139e-310  6.90139e-310  6.90139e-310

julia> filt(SecondOrderSections(H), ones(5,3,2))
5×3×2 Array{Float64, 3}:
[:, :, 1] =
 0.1      0.1      0.1
 0.28     0.28     0.28
 0.424    0.424    0.424
 0.5392   0.5392   0.5392
 0.63136  0.63136  0.63136

[:, :, 2] =
 0.1      0.1      0.1
 0.28     0.28     0.28
 0.424    0.424    0.424
 0.5392   0.5392   0.5392
 0.63136  0.63136  0.63136
```
While `SecondOrderSections` looks ok, running with `-check-bounds=yes` reveals that it's not quite sound either:
```julia
julia> filt(H, ones(5,3,2))
ERROR: BoundsError: attempt to access 5×3×2 Array{Float64, 3} at index [1, 1]
# [...]

julia> filt(SecondOrderSections(H), ones(5,3,2))
ERROR: BoundsError: attempt to access 5×3×2 Array{Float64, 3} at index [1, 1]
# [...]
```
I think once upon the time, Julia supported partial linear indexing, treating the last index in a `getindex` as a linear index for all remaining dimensions. Nowadays, using a `CartesianIndex` seems best for addressing the "column", so do that.