### PR TITLE
Support multi-column filtering for `DF2TFilter`

### DIFF
--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -144,12 +144,12 @@ struct DF2TFilter{T<:FilterCoefficients{:z},S<:Array}
         new{Ti,Si}(coef, state)
     end
     function DF2TFilter{Ti,Si}(coef::SecondOrderSections{:z}, state::Array) where {Ti,Si}
-        (size(state, 1) == 2 && size(state, 2) == length(coef.biquads)) ||
+        size(state, 1) == 2 && size(state, 2) == length(coef.biquads) ||
             throw(ArgumentError("state must be 2 x nbiquads"))
         new{Ti,Si}(coef, state)
     end
     function DF2TFilter{Ti,Si}(coef::Biquad{:z}, state::Array) where {Ti,Si}
-        size(state,1) == 2 || throw(ArgumentError("length of state must be 2"))
+        size(state, 1) == 2 || throw(ArgumentError("length of state must be 2"))
         new{Ti,Si}(coef, state)
     end
 end
@@ -165,7 +165,7 @@ DF2TFilter(coef::PolynomialRatio{:z,T}, coldims::Tuple{Vararg{Integer}}) where {
 DF2TFilter(coef::PolynomialRatio{:z,T}, ::Type{V}=T, coldims::Tuple{Vararg{Integer}}=()) where {T,V} =
     DF2TFilter(coef, zeros(promote_type(T, V), max(length(coefa(coef)), length(coefb(coef))) - 1, coldims...))
 
-function filt!(out::AbstractArray{<:Any, N}, f::DF2TFilter{<:PolynomialRatio,Array{T,N}} where T, x::AbstractArray{<:Any, N}) where N
+function filt!(out::AbstractArray{<:Any,N}, f::DF2TFilter{<:PolynomialRatio,Array{T,N}} where T, x::AbstractArray{<:Any,N}) where N
     size(x) != size(out) && throw(ArgumentError("out size must match x"))
 
     si = f.state
@@ -207,7 +207,7 @@ DF2TFilter(coef::SecondOrderSections{:z,T}, coldims::Tuple{Vararg{Integer}}) whe
 DF2TFilter(coef::SecondOrderSections{:z,T,G}, ::Type{V}=T, coldims::Tuple{Vararg{Integer}}=()) where {T,G,V} =
     DF2TFilter(coef, zeros(promote_type(T, G, V), 2, length(coef.biquads), coldims...))
 
-function filt!(out::AbstractArray{<:Any, N}, f::DF2TFilter{<:SecondOrderSections,<:Array}, x::AbstractArray{<:Any, N}) where N
+function filt!(out::AbstractArray{<:Any,N}, f::DF2TFilter{<:SecondOrderSections,<:Array}, x::AbstractArray{<:Any,N}) where N
     size(x) != size(out) && throw(ArgumentError("out size must match x"))
     size(x)[2:end] != size(f.state)[3:end] && throw(ArgumentError("state size must match x"))
     for col in CartesianIndices(axes(x)[2:end])
@@ -221,7 +221,7 @@ DF2TFilter(coef::Biquad{:z,T}, coldims::Tuple{Vararg{Integer}}) where {T} = DF2T
 DF2TFilter(coef::Biquad{:z,T}, ::Type{V}=T, coldims::Tuple{Vararg{Integer}}=()) where {T,V} =
     DF2TFilter(coef, zeros(promote_type(T, V), 2, coldims...))
 
-function filt!(out::AbstractArray{<:Any, N}, f::DF2TFilter{<:Biquad,Array{T, N}} where T, x::AbstractArray{<:Any, N}) where N
+function filt!(out::AbstractArray{<:Any,N}, f::DF2TFilter{<:Biquad,Array{T,N}} where T, x::AbstractArray{<:Any,N}) where N
     size(x) != size(out) && throw(ArgumentError("out size must match x"))
     si = f.state
     size(x)[2:end] != size(si)[2:end] && throw(ArgumentError("state size must match x"))

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -246,7 +246,10 @@ filt(f::DF2TFilter{<:FilterCoefficients{:z},<:Array{T}}, x::AbstractArray{V}) wh
     filt!(similar(x, promote_type(T, V)), f, x)
 
 # Fall back to SecondOrderSections
-DF2TFilter(coef::FilterCoefficients{:z}, args...) = DF2TFilter(convert(SecondOrderSections, coef), args...)
+DF2TFilter(coef::FilterCoefficients{:z}, coldims::Tuple{Vararg{Integer}}=()) =
+    DF2TFilter(convert(SecondOrderSections, coef), coldims)
+DF2TFilter(coef::FilterCoefficients{:z}, ::Type{V}, coldims::Tuple{Vararg{Integer}}=()) where {V} =
+    DF2TFilter(convert(SecondOrderSections, coef), V, coldims)
 
 #
 # filtfilt

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -191,7 +191,7 @@ function filt!(out::AbstractArray{<:Any, N}, f::DF2TFilter{<:PolynomialRatio,Arr
         elseif n <= SMALL_FILT_CUTOFF
             vtup = ntuple(j -> b[j], Val(length(b)))
             for col in CartesianIndices(axes(x)[2:end])
-                si .= getfield.(_filt_fir!(out, vtup, x, view(si, :, col), col, Val(true)), :value)
+                _filt_fir!(out, vtup, x, view(si, :, col), col, Val(true))
             end
         else
             for col in CartesianIndices(axes(x)[2:end])

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -116,19 +116,24 @@ filt(f::FilterCoefficients{:z}, x) = filt(convert(SecondOrderSections, f), x)
 filt!(out, f::FilterCoefficients{:z}, x) = filt!(out, convert(SecondOrderSections, f), x)
 
 """
-    DF2TFilter(coef::FilterCoefficients{:z}[, si])
-    DF2TFilter(coef::FilterCoefficients{:z}[, sitype::Type][, coldims::Tuple])
+    DF2TFilter(coef::FilterCoefficients{:z})
+    DF2TFilter(coef::FilterCoefficients{:z}, coldims::Tuple)
+    DF2TFilter(coef::FilterCoefficients{:z}, sitype::Type, coldims::Tuple = ())
+    DF2TFilter(coef::FilterCoefficients{:z}, si)
 
 Construct a stateful direct form II transposed filter with
 coefficients `coef`.
 
-One can optionally specify as the second argument either
-- `si`, an array representing the initial filter state, or
-- `sitype`, the eltype of a zeroed `si` and/or `coldims`, the size of extra dimensions
-  of the input. E.g. to column-wise filter an input with dims `(L, N1, N2)`, set
-  `coldims` to `(N1, N2)`.
+The initial filter state defaults to zeros (of a type derived from `coef`)
+suitable for vector input. Another element type of the state can be specified
+with `sitype`.
 
-The initial filter state defaults to zeros if called with one argument.
+To allow column-wise filtering of higher-dimensional input, the size of the
+extra dimensions have to be given in `coldims`. To e.g. column-wise filter an
+input with size `(L, N1, N2)`, set `coldims` to `(N1, N2)`.
+
+Alternatively, an array representing the initial filter state can be passed
+as `si`.
 
 If `coef` is a `PolynomialRatio`, `Biquad`, or `SecondOrderSections`,
 filtering is implemented directly. If `coef` is a `ZeroPoleGain`

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -118,7 +118,7 @@ end
 const SMALL_FILT_VECT_CUTOFF = 19
 
 # Transposed direct form II
-@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, colv) where {N,T}
+@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, colv, _::Val{AsVecElem}=Val(false)) where {N,T,AsVecElem}
     silen = N - 1
     si_end = Symbol(:si_, silen)
 
@@ -137,7 +137,7 @@ const SMALL_FILT_VECT_CUTOFF = 19
                 out[i, col] = val
             end
         end
-        if colv isa Val{:DF2}
+        if AsVecElem
             return Base.@ntuple $silen j -> VecElement(si_j)
         end
     end

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -118,12 +118,11 @@ end
 const SMALL_FILT_VECT_CUTOFF = 19
 
 # Transposed direct form II
-@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, colv, _::Val{AsVecElem}=Val(false)) where {N,T,AsVecElem}
+@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, col, ::Val{StoreSI}=Val(false)) where {N,T,StoreSI}
     silen = N - 1
     si_end = Symbol(:si_, silen)
 
     quote
-        col = colv isa Val{:DF2} ? CartesianIndex() : colv
         N <= SMALL_FILT_VECT_CUTOFF && checkbounds(siarr, $silen)
         Base.@nextract $silen si siarr
         for i in axes(x, 1)
@@ -137,9 +136,10 @@ const SMALL_FILT_VECT_CUTOFF = 19
                 out[i, col] = val
             end
         end
-        if AsVecElem
-            return Base.@ntuple $silen j -> VecElement(si_j)
+        if StoreSI
+            Base.@nexprs $silen j -> siarr[j] = si_j
         end
+        return nothing
     end
 end
 

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -89,6 +89,26 @@ end
      @test all(col -> col ≈ y_ref, eachslice(filt(PolynomialRatio(b, a), x); dims=slicedims))
 end
 
+@testset "multi-column DF2TFilter $D-D" for D in 1:4
+    b = [0.1, 0.1]
+    a = [1.0, -0.8]
+    sz = (10, ntuple(n -> n+1, Val(D))...)
+    y_ref = filt(b, a, ones(2*sz[1]))
+    x = ones(sz)
+
+    H = DF2TFilter(PolynomialRatio(b, a), zeros(1, sz[2:end]...))
+    @test all(col -> col ≈ y_ref[1:sz[1]], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
+    @test all(col -> col ≈ y_ref[sz[1]+1:end], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
+
+    H = DF2TFilter(SecondOrderSections(PolynomialRatio(b, a)), zeros(2, 1, sz[2:end]...))
+    @test all(col -> col ≈ y_ref[1:sz[1]], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
+    @test all(col -> col ≈ y_ref[sz[1]+1:end], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
+
+    H = DF2TFilter(Biquad(PolynomialRatio(b, a)), zeros(2, sz[2:end]...))
+    @test all(col -> col ≈ y_ref[1:sz[1]], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
+    @test all(col -> col ≈ y_ref[sz[1]+1:end], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
+end
+
 #
 # filtfilt
 #

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -63,6 +63,9 @@ using DSP, Test, Random, FilterTestHelpers
     df = digitalfilter(Lowpass(0.25), Butterworth(4))
     f = @test_nowarn DF2TFilter(df, ComplexF64)
     @test_nowarn filt(f, s)
+
+    # DF2TFilter{ZPG/SOS} stackoverflow error
+    @test_throws MethodError DF2TFilter(ZeroPoleGain([1], [2], 3), :D, 'x', Ref(1))
 end
 
 @testset "multi-column filt $D-D" for D in 1:4

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -96,15 +96,15 @@ end
     y_ref = filt(b, a, ones(2*sz[1]))
     x = ones(sz)
 
-    H = DF2TFilter(PolynomialRatio(b, a), zeros(1, sz[2:end]...))
+    H = DF2TFilter(PolynomialRatio(b, a),sz[2:end])
     @test all(col -> col ≈ y_ref[1:sz[1]], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
     @test all(col -> col ≈ y_ref[sz[1]+1:end], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
 
-    H = DF2TFilter(SecondOrderSections(PolynomialRatio(b, a)), zeros(2, 1, sz[2:end]...))
+    H = DF2TFilter(SecondOrderSections(PolynomialRatio(b, a)), sz[2:end])
     @test all(col -> col ≈ y_ref[1:sz[1]], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
     @test all(col -> col ≈ y_ref[sz[1]+1:end], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
 
-    H = DF2TFilter(Biquad(PolynomialRatio(b, a)), zeros(2, sz[2:end]...))
+    H = DF2TFilter(Biquad(PolynomialRatio(b, a)), sz[2:end])
     @test all(col -> col ≈ y_ref[1:sz[1]], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
     @test all(col -> col ≈ y_ref[sz[1]+1:end], eachslice(filt(H, x); dims=ntuple(n -> n+1, Val(D))))
 end


### PR DESCRIPTION
Fixes #372. I mostly wanted to see whether #372 could be tackled in a non-breaking way. The answer is yes, so this could wait until after release of v0.8. OTOH, it seems simple enough that it's unlikely to stall v0.8 even more, so here it is.

Note that while this is API-wise orthogonal to #599, there will be some clean-up possible after both of them have been merged. (Or rather, after the first one merges, the second one can be extended to include the clean-up.)