### PR TITLE
Remove deprecations added in v0.7

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -3,18 +3,3 @@ import .Util.nextfastfft
 @deprecate nextfastfft(ns...) nextfastfft.(ns) false
 
 @deprecate (conv(u::AbstractVector{T}, v::AbstractVector{T}, A::AbstractMatrix{T}) where T) conv(u, transpose(v), A)
-
-# deprecations in 0.7
-@deprecate freqz(filter::FilterCoefficients{:z}) freqresp(filter, range(0, stop=π, length=250))
-@deprecate freqz(filter::FilterCoefficients{:z}, w) freqresp(filter, w)
-@deprecate freqs(filter::FilterCoefficients{:s}, w) freqresp(filter, w)
-@deprecate freqz(filter::FilterCoefficients{:z}, hz, fs) freqresp(filter,  hz * ((2 * pi) / fs))
-@deprecate freqs(filter::FilterCoefficients{:s}, hz, fs) freqresp(filter,  hz * ((2 * pi) / fs))
-@deprecate phasez(filter::FilterCoefficients{:z}) phaseresp(filter, range(0, stop=π, length=250))
-@deprecate phasez(filter::FilterCoefficients{:z}, w) phaseresp(filter, w)
-@deprecate grpdelayz(filter::FilterCoefficients{:z}) grpdelay(filter, range(0, stop=π, length=250))
-@deprecate grpdelayz(filter::FilterCoefficients{:z}, w) grpdelay(filter, w)
-@deprecate impz(filter::FilterCoefficients{:z}) impresp(filter)
-@deprecate impz(filter::FilterCoefficients{:z}, n) impresp(filter, n)
-@deprecate stepz(filter::FilterCoefficients{:z}) stepresp(filter)
-@deprecate stepz(filter::FilterCoefficients{:z}, n) stepresp(filter, n)


### PR DESCRIPTION
For some reason I thought I had already done this. Apparently not.