### PR TITLE
Simplify (and slightly speed up) `coefb`/`coefa`

### DIFF
--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -191,8 +191,8 @@ function Base.:^(f::PolynomialRatio{D,T}, e::Integer) where {D,T}
     end
 end
 
-coef_s(p::LaurentPolynomial{T}) where T = (n = firstindex(p);  append!(reverse!(coeffs(p)), zero(T) for _ in 1:n))
-coef_z(p::LaurentPolynomial{T}) where T = (n = -lastindex(p); prepend!(reverse!(coeffs(p)), zero(T) for _ in 1:n))
+coef_s(p::LaurentPolynomial) = p[end:-1:0]
+coef_z(p::LaurentPolynomial) = p[0:-1:begin]
 
 """
     coefb(f::PolynomialRatio)


### PR DESCRIPTION
Noticed this the other day. Main benefit is readability. Only in cases where trailing/leading zeros had to be re-appended/prepended, one allocation is eliminated. Otherwise, performance is almost unchanged.