### PR TITLE
Reduce allocations for IIR filtering

### DIFF
--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -162,14 +162,7 @@ function filt!(out::AbstractArray{<:Any,N}, f::DF2TFilter{<:PolynomialRatio,Arra
         mul!(out, x, b[1])
     else
         a = coefa(f.coef)
-        as = length(a)
-        bs = length(b)
-        if as != 1
-            if as < n
-                append!(a, zero(eltype(a)) for _ in 1:(n-as))
-            elseif bs < n
-                append!(b, zero(eltype(b)) for _ in 1:(n-bs))
-            end
+        if length(a) != 1
             for col in CartesianIndices(axes(x)[2:end])
                 _filt_iir!(out, b, a, x, view(si, :, col), col)
             end


### PR DESCRIPTION
Avoid the necessity to re-allocate one of the coefficient vectors if they have different lengths by letting `_filt_iir!` handle different lengths.
~(The second commit is some performance-neutral clean-up. I'm not 100% sure we should do it.)~

For equal-length coefficient vectors performance is practically the same:
```
julia> @btime filt!($(zeros(100)), $(rand(2)), $([1; rand(1)]), $(rand(100))); # a and b both length 2
  344.546 ns (1 allocation: 64 bytes) # PR
  348.047 ns (1 allocation: 64 bytes) # master

julia> @btime filt!($(zeros(100)), $(rand(3)), $([1; rand(2)]), $(rand(100))); # a and b both length 3
  319.090 ns (1 allocation: 80 bytes) # PR
  317.876 ns (1 allocation: 80 bytes) # master

julia> @btime filt!($(zeros(100)), $(rand(2)), $([1; rand(2)]), $(rand(100)));
  294.293 ns (1 allocation: 80 bytes) # PR
  330.063 ns (2 allocations: 160 bytes) # master

julia> @btime filt!($(zeros(100)), $(rand(3)), $([1; rand(1)]), $(rand(100)));
  285.819 ns (1 allocation: 80 bytes) # PR
  332.861 ns (2 allocations: 160 bytes) # master

julia> @btime filt!($(zeros(100)), $(rand(100)), $([1; rand(1)]), $(rand(100)));
  1.247 μs (1 allocation: 896 bytes) # PR
  1.495 μs (2 allocations: 1.75 KiB) # master
```