### PR TITLE
Remove recursion from `Base.:^`

### DIFF
--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -48,11 +48,8 @@ Base.inv(f::ZeroPoleGain{D}) where {D} = ZeroPoleGain{D}(f.p, f.z, inv(f.k))
 
 function Base.:^(f::ZeroPoleGain{D}, e::Integer) where {D}
     ae = uabs(e)
-    z, p, k = repeat(f.z, ae), repeat(f.p, ae), f.k
-    if e < 0
-        z, p, k = p, z, inv(k)
-    end
-    return ZeroPoleGain{D}(z, p, k^ae)
+    z, p = repeat(f.z, ae), repeat(f.p, ae)
+    return e < 0 ? ZeroPoleGain{D}(p, z, inv(f.k)^ae) : ZeroPoleGain{D}(z, p, f.k^ae)
 end
 
 #
@@ -331,8 +328,12 @@ Base.inv(f::SecondOrderSections{D}) where {D} = SecondOrderSections{D}(inv.(f.bi
 
 function Base.:^(f::SecondOrderSections{D}, e::Integer) where {D}
     ae = uabs(e)
-    pf = e < 0 ? inv(f) : f
-    return SecondOrderSections{D}(repeat(pf.biquads, ae), pf.g^ae)
+    if e < 0
+        inv_f = inv(f)
+        return SecondOrderSections{D}(repeat(inv_f.biquads, ae), inv_f.g^ae)
+    else
+        return SecondOrderSections{D}(repeat(f.biquads, ae), f.g^ae)
+    end
 end
 
 function Base.:^(f::Biquad{D}, e::Integer) where {D}

--- a/src/Filters/coefficients.jl
+++ b/src/Filters/coefficients.jl
@@ -48,8 +48,11 @@ Base.inv(f::ZeroPoleGain{D}) where {D} = ZeroPoleGain{D}(f.p, f.z, inv(f.k))
 
 function Base.:^(f::ZeroPoleGain{D}, e::Integer) where {D}
     ae = uabs(e)
-    res = ZeroPoleGain{D}(repeat(f.z, ae), repeat(f.p, ae), f.k^ae)
-    return e < 0 ? inv(res) : res
+    z, p, k = repeat(f.z, ae), repeat(f.p, ae), f.k
+    if e < 0
+        z, p, k = p, z, inv(k)
+    end
+    return ZeroPoleGain{D}(z, p, k^ae)
 end
 
 #

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -236,11 +236,11 @@ end
             @test filt(H^0, x) ≈ x
         end
     end
-    # test that checked_abs in Base.^ throws DomainError instead of StackOverFlowError
-    @test_throws "abs(e)" PolynomialRatio([1.0], [2.0])^typemin(Int)
-    @test_throws DomainError ZeroPoleGain([1], [2], 3)^typemin(Int)
-    @test_throws DomainError Biquad(1:5...)^typemin(Int)
-    @test_throws DomainError SecondOrderSections(Biquad(1:5...))^typemin(Int)
+    # test that ^ doesn't cause stack overflow
+    @test_nowarn PolynomialRatio([1.0], [2.0])^typemin(Int8)
+    @test_nowarn ZeroPoleGain([1], [2], 3)^typemin(Int8)
+    @test_nowarn Biquad(1:5...)^typemin(Int8)
+    @test_nowarn SecondOrderSections(Biquad(1:5...))^typemin(Int8)
 end
 
 @testset "types" begin

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -237,10 +237,22 @@ end
         end
     end
     # test that ^ doesn't cause stack overflow
-    @test_nowarn PolynomialRatio([1.0], [2.0])^typemin(Int8)
-    @test_nowarn ZeroPoleGain([1], [2], 3)^typemin(Int8)
-    @test_nowarn Biquad(1:5...)^typemin(Int8)
-    @test_nowarn SecondOrderSections(Biquad(1:5...))^typemin(Int8)
+    let H = PolynomialRatio([1.0], [2.0])^typemin(Int8)
+        @test coefb(H) == [2.0^128]
+        @test coefa(H) == [1.0]
+    end
+    let zpg = ZeroPoleGain([1], [2], 3)^typemin(Int8)
+        @test length(zpg.z) == length(zpg.p) == 128
+        @test all(==(2), zpg.z)
+        @test all(==(1), zpg.p)
+    end
+    let bq = Biquad(1:5...)
+        sos1 = bq^typemin(Int8)
+        sos2 = SecondOrderSections(bq)^typemin(Int8)
+        @test all(==(inv(bq)), sos1.biquads)
+        @test all(==(inv(bq)), sos2.biquads)
+        @test sos1.g == sos2.g == 1
+    end
 end
 
 @testset "types" begin

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -219,7 +219,7 @@ end
         p = rand(ComplexF64, Npc) .- (0.5 + 0.5im);
         p = [p; conj(p); rand(Npr) .- 0.5; zeros(max(2Nzc+Nzr-2Npc-Npr, 0))]
         H′ = ZeroPoleGain(z, p,
-            (rand() + 0.5) * rand([-1, 1]), # non-zero gain with random sign
+            (rand() + 0.5) * rand((-1, 1)), # non-zero gain with random sign
         )
         maybe_biquad = length(z) ≤ 2 && length(p) ≤ 2 ? (Biquad,) : ()
         for T ∈ (PolynomialRatio, ZeroPoleGain, SecondOrderSections, maybe_biquad...)
@@ -236,6 +236,11 @@ end
             @test filt(H^0, x) ≈ x
         end
     end
+    # test that checked_abs in Base.^ throws DomainError instead of StackOverFlowError
+    @test_throws "abs(e)" PolynomialRatio([1.0], [2.0])^typemin(Int)
+    @test_throws DomainError ZeroPoleGain([1], [2], 3)^typemin(Int)
+    @test_throws DomainError Biquad(1:5...)^typemin(Int)
+    @test_throws DomainError SecondOrderSections(Biquad(1:5...))^typemin(Int)
 end
 
 @testset "types" begin

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -245,6 +245,7 @@ end
         @test length(zpg.z) == length(zpg.p) == 128
         @test all(==(2), zpg.z)
         @test all(==(1), zpg.p)
+        @test zpg.k ≈ inv(3)^128
     end
     let bq = Biquad(1:5...)
         sos1 = bq^typemin(Int8)

--- a/test/filter_conversion.jl
+++ b/test/filter_conversion.jl
@@ -249,6 +249,7 @@ end
     let bq = Biquad(1:5...)
         sos1 = bq^typemin(Int8)
         sos2 = SecondOrderSections(bq)^typemin(Int8)
+        @test length(sos1.biquads) == length(sos2.biquads) == 128
         @test all(==(inv(bq)), sos1.biquads)
         @test all(==(inv(bq)), sos2.biquads)
         @test sos1.g == sos2.g == 1


### PR DESCRIPTION
Prevents stack overflow, in the admittedly unlikely case that `-e == e`, for `e == typemin(Int8)` etc.
Also moves some definitions around for readability.