### PR TITLE
Add FFT convolution kernels

### DIFF
--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -765,13 +765,14 @@ end
 
 abstract type FFTConvKernel{T,N} end
 struct RFFTConvKernel{
-    T<:Real,
-    N,
-    M<:AbstractArray{T,N},
-    C<:AbstractArray{Complex{T},N},
-    FP<:AbstractFFTs.Plan{T},
-    IP<:AbstractFFTs.ScaledPlan{Complex{T}},
-    X<:Tuple{Vararg{<:AbstractRange,N}}} <: FFTConvKernel{T,N}
+        T<:Real,
+        N,
+        M<:AbstractArray{T,N},
+        C<:AbstractArray{Complex{T},N},
+        FP<:AbstractFFTs.Plan{T},
+        IP<:AbstractFFTs.ScaledPlan{Complex{T}},
+        X<:Tuple{Vararg{<:AbstractRange,N}}
+    } <: FFTConvKernel{T,N}
 
     p_rfft::FP
     p_irfft::IP
@@ -782,12 +783,13 @@ struct RFFTConvKernel{
     ax::X
 end
 struct CFFTConvKernel{
-    T<:Complex,
-    N,
-    M<:AbstractArray{T,N},
-    FP<:AbstractFFTs.Plan{T},
-    IP<:AbstractFFTs.ScaledPlan{T},
-    X<:Tuple{Vararg{<:AbstractRange,N}}} <: FFTConvKernel{T,N}
+        T<:Complex,
+        N,
+        M<:AbstractArray{T,N},
+        FP<:AbstractFFTs.Plan{T},
+        IP<:AbstractFFTs.ScaledPlan{T},
+        X<:Tuple{Vararg{<:AbstractRange,N}}
+    } <: FFTConvKernel{T,N}
 
     p_fft::FP
     p_ifft::IP


### PR DESCRIPTION
This is a draft for adding FFT convolution kernels (that are also plans), which are useful for repeated convolutions.
A lot has been adapted from the code [here](https://github.com/JuliaDSP/DSP.jl/issues/358#issuecomment-3013551397), courtesy of @JanJereczek
Here's what I have done so far:
- created an abstract type for FFT convolution kernels tentatively named `FFTConvKernel`, subtypes `R/CFFTConvKernel`
- working code for real and complex FFT convolution kernels and `Array`, FFTW flag defaults to FFTW.MEASURE
- in the process, found that we don't check if the output indices are valid (i.e. `out[output_indices]` doesn't throw) before doing work except for `:direct`, so I added that. Don't remember if we have discussed this before, so left it in just in case
- IIUC the kernel/plans can be reused for smaller `x`, maybe larger depending on `nffts`
- not very tested, will add tests later if the feature is wanted

A typical workflow goes like this:
1. Calculate `outsize`, the size of the intended output `size(out) .+ size(ker) .- 1`
2. Create kernel with `RFFTConvKernel` or `CFFTConvKernel(kernel, outsize)`
3. Run something like `conv!(out[i], arrs[i], kernel)` in a loop

Feedback would be much appreciated