### PR TITLE
Add inline and inbounds annotations to unsafe_dot

### DIFF
--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -497,7 +497,7 @@ function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRRational{Th}}, x::
         bufIdx += 1
 
         if inputIdx < kernel.tapsPerϕ
-            accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, history, x, inputIdx)
+            @inline accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, history, x, inputIdx)
         else
             @inline accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, x, inputIdx)
         end

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -499,7 +499,7 @@ function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRRational{Th}}, x::
         if inputIdx < kernel.tapsPerϕ
             accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, history, x, inputIdx)
         else
-            accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, x, inputIdx)
+            @inline accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, x, inputIdx)
         end
 
         buffer[bufIdx]  = accumulator

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -497,9 +497,9 @@ function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRRational{Th}}, x::
         bufIdx += 1
 
         if inputIdx < kernel.tapsPerϕ
-            @inline accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, history, x, inputIdx)
+            accumulator = @inline unsafe_dot(kernel.pfb, kernel.ϕIdx, history, x, inputIdx)
         else
-            @inline accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, x, inputIdx)
+            accumulator = @inline unsafe_dot(kernel.pfb, kernel.ϕIdx, x, inputIdx)
         end
 
         buffer[bufIdx]  = accumulator

--- a/src/util.jl
+++ b/src/util.jl
@@ -222,7 +222,7 @@ end
 # Computes the dot product of a single column of a, specified by aColumnIdx, with the vector b.
 # The number of elements used in the dot product determined by the size(A)[1].
 # Note: bIdx is the last element of b used in the dot product.
-@inline function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector, bLastIdx::Integer)
+function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector, bLastIdx::Integer)
     aLen     = size(a, 1)
     bBaseIdx = bLastIdx - aLen
     @inbounds dotprod  = a[1, aColIdx] * b[ bBaseIdx + 1]
@@ -237,13 +237,13 @@ end
     BLAS.dot(size(a, 1), pointer(a, size(a, 1)*(aColIdx-1) + 1), 1, pointer(b, bLastIdx - size(a, 1) + 1), 1)
 end
 
-@inline function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
+function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
     aLen = size(a, 1)
     bLen = length(b)
     bLen == aLen-1  || throw(ArgumentError("length(b) must equal size(a, 1) - 1"))
     cLastIdx < aLen || throw(DomainError(cLastIdx, "cLastIdx must be < length(a)"))
 
-    @inbounds dotprod = a[1, aColIdx] * b[cLastIdx]
+    dotprod = a[1, aColIdx] * b[cLastIdx]
     @simd for i in 2:aLen-cLastIdx
         @inbounds dotprod += a[i, aColIdx] * b[i+cLastIdx-1]
     end
@@ -254,7 +254,7 @@ end
     return dotprod
 end
 
-@inline function unsafe_dot(a::T, b::AbstractArray, bLastIdx::Integer) where T
+function unsafe_dot(a::T, b::AbstractArray, bLastIdx::Integer) where T
     aLen     = length(a)
     bBaseIdx = bLastIdx - aLen
     @inbounds dotprod  = a[1] * b[bBaseIdx + 1]
@@ -269,7 +269,7 @@ end
     BLAS.dot(length(a), pointer(a), 1, pointer(b, bLastIdx - length(a) + 1), 1)
 end
 
-@inline function unsafe_dot(a::AbstractVector, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
+function unsafe_dot(a::AbstractVector, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
     aLen    = length(a)
     dotprod = zero(a[1]*b[1])
     @simd for i in 1:aLen-cLastIdx

--- a/src/util.jl
+++ b/src/util.jl
@@ -222,10 +222,10 @@ end
 # Computes the dot product of a single column of a, specified by aColumnIdx, with the vector b.
 # The number of elements used in the dot product determined by the size(A)[1].
 # Note: bIdx is the last element of b used in the dot product.
-function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector, bLastIdx::Integer)
+@inline function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector, bLastIdx::Integer)
     aLen     = size(a, 1)
     bBaseIdx = bLastIdx - aLen
-    dotprod  = a[1, aColIdx] * b[ bBaseIdx + 1]
+    @inbounds dotprod  = a[1, aColIdx] * b[ bBaseIdx + 1]
     @simd for i in 2:aLen
         @inbounds dotprod += a[i, aColIdx] * b[bBaseIdx + i]
     end
@@ -237,13 +237,13 @@ end
     BLAS.dot(size(a, 1), pointer(a, size(a, 1)*(aColIdx-1) + 1), 1, pointer(b, bLastIdx - size(a, 1) + 1), 1)
 end
 
-function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
+@inline function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
     aLen = size(a, 1)
     bLen = length(b)
     bLen == aLen-1  || throw(ArgumentError("length(b) must equal size(a, 1) - 1"))
     cLastIdx < aLen || throw(DomainError(cLastIdx, "cLastIdx must be < length(a)"))
 
-    dotprod = a[1, aColIdx] * b[cLastIdx]
+    @inbounds dotprod = a[1, aColIdx] * b[cLastIdx]
     @simd for i in 2:aLen-cLastIdx
         @inbounds dotprod += a[i, aColIdx] * b[i+cLastIdx-1]
     end
@@ -254,7 +254,7 @@ function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector{T}, c
     return dotprod
 end
 
-function unsafe_dot(a::T, b::AbstractArray, bLastIdx::Integer) where T
+@inline function unsafe_dot(a::T, b::AbstractArray, bLastIdx::Integer) where T
     aLen     = length(a)
     bBaseIdx = bLastIdx - aLen
     @inbounds dotprod  = a[1] * b[bBaseIdx + 1]
@@ -269,7 +269,7 @@ end
     BLAS.dot(length(a), pointer(a), 1, pointer(b, bLastIdx - length(a) + 1), 1)
 end
 
-function unsafe_dot(a::AbstractVector, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
+@inline function unsafe_dot(a::AbstractVector, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
     aLen    = length(a)
     dotprod = zero(a[1]*b[1])
     @simd for i in 1:aLen-cLastIdx


### PR DESCRIPTION
Hello,

I was using a FIRInterpolation filter and found that it was a bottleneck in my code. When profiling I realized that the compiler wasn't inlining the unsafe_dot function, and subsequently that there was a missing inbounds for the first multiplication. In the benchmark below the execution time after adding `@inline` and `@inbounds` is about half. I also tried longer filters, and decimation kernels, and didn't find any difference in the execution time, but I added the annotation to the other functions which did not already have them in case there is a scenario where it matters.

Let me know if you think this is worth merging.

```julia
kernel = rand(10);

interp_fil = FIRFilter(kernel, 8);
data = rand(ComplexF64, 10^6);

output = similar(data, 8 * 10^6);

@benchmark filt!(output, interp_fil, data)
```

Before PR(julia 1.11)
```julia-repl
julia> @benchmark filt!(output, interp_fil, data)
BenchmarkTools.Trial: 124 samples with 1 evaluation per sample.
 Range (min … max):  35.798 ms … 45.617 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     40.198 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   40.403 ms ±  1.944 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

                     ▂ ▂▆▂  ▆▅▂█    ▂
  ▄▁▁▄▄▅▁▁▄▄▁▁▄▅▄▄▅▄██▇███▅██████▇▅███▄▅▁▅▁▁▅▄▁▄▁▁▅▁▄▄▄▄▄▁▅▅▄ ▄
  35.8 ms         Histogram: frequency by time        45.3 ms <

 Memory estimate: 16 bytes, allocs estimate: 1.
```

After PR
```julia-repl
julia> @benchmark filt!(output, interp_fil, data)
BenchmarkTools.Trial: 228 samples with 1 evaluation per sample.
 Range (min … max):  19.426 ms … 27.220 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     21.760 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   21.913 ms ±  1.515 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃  ▂  ▃ ▂▄  ▄█▃▅ ▇▃▄▃▅▃▃▃▃   ▃ ▃
  █▅▃█▇▆██████████▇██████████▇▇█▆█▆▆▆▁▅▇▃▃▃▃▁▁▁▃▅▁▃▃▃▃▁▁▁▁▃▁▅ ▅
  19.4 ms         Histogram: frequency by time        26.7 ms <

 Memory estimate: 16 bytes, allocs estimate: 1.
```