### PR TITLE
(voodoo) Patch `_small_filt_fir!` performance for 1.12, 1.13

### DIFF
--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -33,7 +33,7 @@ filt(f::PolynomialRatio{:z}, x) = filt(coefb(f), coefa(f), x)
 
 # filt! algorithm (no checking, returns si)
 function _filt!(out::AbstractArray, si::AbstractArray{S,N}, f::SecondOrderSections{:z},
-                x::AbstractArray, col::Union{Int,CartesianIndex}) where {S,N}
+                x::AbstractArray, col::CartesianIndex) where {S,N}
     g = f.g
     biquads = f.biquads
     @inbounds for i in axes(x, 1)
@@ -68,7 +68,7 @@ filt(f::SecondOrderSections{:z,T,G}, x::AbstractArray{S}) where {T,G,S<:Number} 
 
 # filt! algorithm (no checking, returns si)
 function _filt!(out::AbstractArray, si1::Number, si2::Number, f::Biquad{:z},
-                x::AbstractArray, col::Union{Int,CartesianIndex})
+                x::AbstractArray, col::CartesianIndex)
     @inbounds for i in axes(x, 1)
         xi = x[i, col]
         yi = muladd(f.b0, xi, si1)

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -189,7 +189,7 @@ function _small_filt_fir_storesi!(
     LI = LinearIndices(si)
     for col in CartesianIndices(axes(x)[2:end])
         @static if VERSION > v"1.12-"
-            si_vec = unsafe_wrap(Array, pointer(si, LI[1, col]), col_len)
+            si_vec = Base.wrap(Array, memoryref(si.ref, LI[1, col]), col_len)
         else
             si_vec = view(si, :, col)
         end

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -188,7 +188,7 @@ function _small_filt_fir_storesi!(
     col_len = size(si, 1)
     LI = LinearIndices(si)
     for col in CartesianIndices(axes(x)[2:end])
-        @static if VERSION > v"1.11"
+        @static if VERSION > v"1.12-"
             si_vec = unsafe_wrap(Array, pointer(si, LI[1, col]), col_len)
         else
             si_vec = view(si, :, col)

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -32,8 +32,8 @@ filt(f::PolynomialRatio{:z}, x) = filt(coefb(f), coefa(f), x)
 ## SecondOrderSections
 
 # filt! algorithm (no checking, returns si)
-function _filt!(out::AbstractArray, si::AbstractArray{S,N}, f::SecondOrderSections{:z},
-                x::AbstractArray, col::CartesianIndex) where {S,N}
+function _filt!(out::AbstractArray, si::AbstractMatrix{S}, f::SecondOrderSections{:z},
+                x::AbstractArray, col::CartesianIndex) where {S}
     g = f.g
     biquads = f.biquads
     @inbounds for i in axes(x, 1)

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -162,22 +162,40 @@ function filt!(out::AbstractArray{<:Any,N}, f::DF2TFilter{<:PolynomialRatio,Arra
         mul!(out, x, b[1])
     else
         a = coefa(f.coef)
+        outer_dims = CartesianIndices(axes(x)[2:end])
+
         if length(a) != 1
-            for col in CartesianIndices(axes(x)[2:end])
+            for col in outer_dims
                 _filt_iir!(out, b, a, x, view(si, :, col), col)
             end
         elseif n <= SMALL_FILT_CUTOFF
-            vtup = ntuple(j -> b[j], Val(length(b)))
-            for col in CartesianIndices(axes(x)[2:end])
-                _filt_fir!(out, vtup, x, view(si, :, col), col, Val(true))
-            end
+            _small_filt_fir_storesi!(out, b, x, si, Val(length(b)))
         else
-            for col in CartesianIndices(axes(x)[2:end])
+            for col in outer_dims
                 _filt_fir!(out, b, x, view(si, :, col), col)
             end
         end
     end
     return out
+end
+function _small_filt_fir_storesi!(
+    out::AbstractArray, h::AbstractVector, x::AbstractArray,
+    si::Array, ::Val{bs}
+) where {bs}
+
+    bs < 2 && throw(ArgumentError("invalid tuple size"))
+    length(h) != bs && throw(ArgumentError("length(h) does not match bs"))
+    b = ntuple(j -> h[j], Val(bs))
+    col_len = size(si, 1)
+    LI = LinearIndices(si)
+    for col in CartesianIndices(axes(x)[2:end])
+        @static if VERSION >= v"1.12"
+            si_vec = unsafe_wrap(Array, pointer(si, LI[1, col]), col_len)
+        else
+            si_vec = view(si, :, col)
+        end
+        _filt_fir!(out, b, x, si_vec, col, Val(true))
+    end
 end
 
 ## SecondOrderSections

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -190,7 +190,7 @@ function _small_filt_fir_storesi!(
     LI = LinearIndices(si)
     for col in CartesianIndices(axes(x)[2:end])
         @static if VERSION >= v"1.12"
-            si_vec = unsafe_wrap(Array, pointer(si, LI[1, col]), col_len)
+            si_vec = Base.wrap(Array, memoryref(si.ref, LI[1, col]), col_len)
         else
             si_vec = view(si, :, col)
         end

--- a/src/Filters/filt.jl
+++ b/src/Filters/filt.jl
@@ -32,8 +32,8 @@ filt(f::PolynomialRatio{:z}, x) = filt(coefb(f), coefa(f), x)
 ## SecondOrderSections
 
 # filt! algorithm (no checking, returns si)
-function _filt!(out::AbstractArray, si::AbstractArray{S,N}, f::SecondOrderSections{:z},
-                x::AbstractArray, col::Union{Int,CartesianIndex}) where {S,N}
+function _filt!(out::AbstractArray, si::AbstractMatrix{S}, f::SecondOrderSections{:z},
+                x::AbstractArray, col::CartesianIndex) where {S}
     g = f.g
     biquads = f.biquads
     @inbounds for i in axes(x, 1)
@@ -68,7 +68,7 @@ filt(f::SecondOrderSections{:z,T,G}, x::AbstractArray{S}) where {T,G,S<:Number} 
 
 # filt! algorithm (no checking, returns si)
 function _filt!(out::AbstractArray, si1::Number, si2::Number, f::Biquad{:z},
-                x::AbstractArray, col::Union{Int,CartesianIndex})
+                x::AbstractArray, col::CartesianIndex)
     @inbounds for i in axes(x, 1)
         xi = x[i, col]
         yi = muladd(f.b0, xi, si1)

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -115,7 +115,7 @@ end
 const SMALL_FILT_VECT_CUTOFF = 19
 
 # Transposed direct form II
-@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, col, ::Val{StoreSI}=Val(false)) where {N,T,StoreSI}
+@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, col, ::Val{StoreSI}) where {N,T,StoreSI}
     silen = N - 1
     si_end = Symbol(:si_, silen)
 
@@ -151,7 +151,7 @@ function _small_filt_fir!(
     length(h) != bs && throw(ArgumentError("length(h) does not match bs"))
     b = ntuple(j -> h[j], Val(bs))
     for col in CartesianIndices(axes(x)[2:end])
-        _filt_fir!(out, b, x, si, col)
+        _filt_fir!(out, b, x, si, col, Val(false))
     end
 end
 

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -122,14 +122,16 @@ const SMALL_FILT_VECT_CUTOFF = 19
     quote
         N <= SMALL_FILT_VECT_CUTOFF && checkbounds(siarr, $silen)
         Base.@nextract $silen si siarr
+        VECTORIZE_LARGER = N > SMALL_FILT_VECT_CUTOFF
         for i in axes(x, 1)
             xi = x[i, col]
             val = muladd(xi, b[1], si_1)
+            if VECTORIZE_LARGER
+                @inbounds out[i, col] = val
+            end
             Base.@nexprs $(silen - 1) j -> (si_j = muladd(xi, b[j+1], si_{j + 1}))
             $si_end = xi * b[N]
-            if N > SMALL_FILT_VECT_CUTOFF
-                @inbounds out[i, col] = val
-            else
+            if !VECTORIZE_LARGER
                 out[i, col] = val
             end
         end

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -115,7 +115,8 @@ end
 const SMALL_FILT_VECT_CUTOFF = 19
 
 # Transposed direct form II
-@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, col, ::Val{StoreSI}) where {N,T,StoreSI}
+function _filt_fir!(out, b::NTuple{N,T}, x, siarr, col, ::Val{StoreSI}) where {N,T,StoreSI}
+if @generated
     silen = N - 1
     si_end = Symbol(:si_, silen)
     @static if VERSION.major == 1 && VERSION.minor == 12
@@ -150,6 +151,14 @@ const SMALL_FILT_VECT_CUTOFF = 19
         end
         return nothing
     end
+else
+    if StoreSI
+        _filt_fir!(out, b, x, siarr, col)
+    else
+        si = copy(siarr)
+        _filt_fir!(out, b, x, si, col)
+    end
+end # end if @generated
 end
 
 # Convert array filter tap input to tuple for small-filtering

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -115,21 +115,33 @@ end
 const SMALL_FILT_VECT_CUTOFF = 19
 
 # Transposed direct form II
-@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, col, ::Val{StoreSI}=Val(false)) where {N,T,StoreSI}
+@generated function _filt_fir!(out, b::NTuple{N,T}, x, siarr, col, ::Val{StoreSI}) where {N,T,StoreSI}
     silen = N - 1
     si_end = Symbol(:si_, silen)
+    @static if VERSION.major == 1 && VERSION.minor == 12
+        STORE_VAL = :(@inbounds out[i, col] = val)
+    else
+        STORE_VAL = :(out[i, col] = val)
+    end
 
     quote
-        N <= SMALL_FILT_VECT_CUTOFF && checkbounds(siarr, $silen)
+        VECTORIZE_LARGER = N > SMALL_FILT_VECT_CUTOFF
+        VECTORIZE_LARGER || checkbounds(siarr, $silen)
         Base.@nextract $silen si siarr
-        for i in axes(x, 1)
+        ax = axes(x, 1)
+        if VERSION >= v"1.12"
+            checkbounds(x, ax, col)
+            checkbounds(out, ax, col)
+        end
+        for i in ax
             xi = x[i, col]
             val = muladd(xi, b[1], si_1)
+            if VECTORIZE_LARGER
+                $STORE_VAL
+            end
             Base.@nexprs $(silen - 1) j -> (si_j = muladd(xi, b[j+1], si_{j + 1}))
             $si_end = xi * b[N]
-            if N > SMALL_FILT_VECT_CUTOFF
-                @inbounds out[i, col] = val
-            else
+            if !VECTORIZE_LARGER
                 out[i, col] = val
             end
         end
@@ -143,13 +155,19 @@ end
 # Convert array filter tap input to tuple for small-filtering
 function _small_filt_fir!(
     out::AbstractArray, h::AbstractVector, x::AbstractArray,
-        si::AbstractVector, ::Val{bs}) where {bs}
+    si::AbstractVector, ::Val{bs}
+) where {bs}
 
     bs < 2 && throw(ArgumentError("invalid tuple size"))
     length(h) != bs && throw(ArgumentError("length(h) does not match bs"))
     b = ntuple(j -> h[j], Val(bs))
     for col in CartesianIndices(axes(x)[2:end])
-        _filt_fir!(out, b, x, si, col)
+        @static if VERSION > v"1.13-"
+            fill!(si, zero(eltype(si)))
+            _filt_fir!(out, b, x, si, col, Val(true))
+        else
+            _filt_fir!(out, b, x, si, col, Val(false))
+        end
     end
 end
 

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -482,7 +482,7 @@ function periodogram(s::AbstractMatrix{T};
         ptype = 0
     elseif radialsum
         ptype = 1
-    elseif radialavg
+    else    # if radialavg
         ptype = 2
     end
     norm2 = length(s)


### PR DESCRIPTION
Benchmarks show that the previous hack for larger values of `19 <= N <= 66`, effective in Julia 1.9 and 1.10 onwards, fails again in 1.12, but it appears that this can be salvaged again by moving the stores around. This mostly restores the previous level of performance for stateless `filt`s of vectors, but the stateful and array versions may still be left slightly worse in 1.12.

~Also adjusts the `SMALL_FILT_VECT_CUTOFF`, reduced from 19 to 18.~
Benchmarks included below:
<details>

```julia-repl
julia> using DSP, BenchmarkTools

julia> out = zeros(10_000);

julia> @benchmark filt!($out, b, a, x) setup=(x = rand(10_000); b = rand(15); a = 1)
### PR ###

BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  12.600 μs … 105.800 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     12.800 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.801 μs ±   3.269 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▄ ▂▆▂  ▁       ▁▁▁▁                                         ▁
  ██▆████▆█▇▆▇▆▆▆▇█████▇█▇▇▆▆▆▄▄▅▄▅▃▃▆▇█▆▆▆▇▆▇▆▅▆▅▆▅▁▄▄▁▃▄▁▆▁▆ █
  12.6 μs       Histogram: log(frequency) by time      28.9 μs <

 Memory estimate: 176 bytes, allocs estimate: 2.

### master ###

 Range (min … max):  12.500 μs … 103.800 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     13.000 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.971 μs ±   3.395 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▇▃  █▄▁  ▂          ▂▁▁   ▁▁                                ▂
  ███▆▄███▇▇██▅▆▆▅▆▅▆▇▇███▇▇▇███▇▇▆▆▆▅▅▄▅▃▁▄▅▇▅▅▆▆█▇▅▅▄▆█▇██▇▆ █
  12.5 μs       Histogram: log(frequency) by time      25.6 μs <

 Memory estimate: 176 bytes, allocs estimate: 2.

julia> @benchmark filt!($out, b, a, x) setup=(x = rand(10_000); b = rand(30); a = 1)
### PR ###

BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  17.200 μs … 130.300 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     17.400 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   18.544 μs ±   3.109 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ██▂     ▆▅ ▁  ▃▅        ▃             ▁  ▁                   ▂
  ███▆▆▆▁▅█████▇██▇▇▆▅▄▅▆▅██▅▇█▇▇██▇██▇███▇██▇█▇▆▆▆▆▇▇▇▅▄▄▆▄▆▇ █
  17.2 μs       Histogram: log(frequency) by time      27.4 μs <

 Memory estimate: 288 bytes, allocs estimate: 2.

### master ###

 Range (min … max):  40.100 μs … 140.900 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     40.400 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   42.599 μs ±   5.875 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █  ▁ ▆▅▃▁▁  ▃▁                                               ▁
  ██▅███████▇████▇▆▆▅▆▆▅▅▅▅▄▄▁▅▅▄▄▁▁▃▁▁▃▁▁▁▅▃▁▅▄▃▃▃▁▄▁▁▄▄▃▁▄██ █
  40.1 μs       Histogram: log(frequency) by time      75.2 μs <

 Memory estimate: 288 bytes, allocs estimate: 2.

julia> @benchmark filt!($out, b, a, x) setup=(x = rand(10_000); b = rand(50); a = 1)
### PR ###

BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  26.200 μs … 147.000 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     26.300 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   27.524 μs ±   4.005 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▁      ▄▅     ▂▂▃▁                                          ▁
  ████▄▅▆▆███▇█▇██████▇▇▅▇▆▇██▇▇▅▅▆▄▅▅▄▄▄▄▃▃▃▄▄▄▄▁▃▃▄▁█▃▁▃▄▄▇▆ █
  26.2 μs       Histogram: log(frequency) by time      40.2 μs <

 Memory estimate: 480 bytes, allocs estimate: 2.

### master ###

 Range (min … max):  94.300 μs … 324.500 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     95.200 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   98.593 μs ±  10.699 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▃▁▁▇▃▁▁▁▄▁  ▃▁                                              ▁
  ████████████▇███▇▆▇▆▆▅▅▇▆▅▃▃▅▅▄▄▃▃▄▂▄▃▃▃▄▄▇▅▄▄▃▃▆▄▄▄▆▄▃▄▂▄▅▅ █
  94.3 μs       Histogram: log(frequency) by time       145 μs <

 Memory estimate: 480 bytes, allocs estimate: 2.

julia> @benchmark filt!($out, b, a, x) setup=(x = rand(10_000); b = rand(66); a = 1)
### PR ###

BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  26.300 μs … 198.400 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     26.800 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   28.160 μs ±   4.524 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▇█▆▂▃▂▂▃▁▅▆▃▁▁ ▂▂▃▃▂▁       ▁                                ▂
  █████████████████████▇██▇▆████▆▇▅▇▅▆▅▂▄▅▃▅▄▄▅▄▄▅▄▄▄▆▅▅▃▂▂▄▄▃ █
  26.3 μs       Histogram: log(frequency) by time      40.6 μs <

 Memory estimate: 576 bytes, allocs estimate: 2.

### master ###

 Range (min … max):  157.500 μs …  2.324 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     164.300 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   168.404 μs ± 27.859 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▂▄█▆█▅▄▂▂▂▄▂▄▂▁▁                                             ▂
  ██████████████████▆▆▆▆▆▇▆▅▆▆▄▆▃▄▆▅▄▄▄▄▄▄▄▁▁▄▄▅▆▆▆██▆▆▆▅▇▆▆█▆ █
  158 μs        Histogram: log(frequency) by time       254 μs <

 Memory estimate: 576 bytes, allocs estimate: 2.

```
</details>

```julia
julia> versioninfo()
Julia Version 1.12.0-rc2
Commit 72cbf019d0 (2025-09-06 12:00 UTC)
Build Info:
  Official https://julialang.org release
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: 8 × 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
  WORD_SIZE: 64
  LLVM: libLLVM-18.1.7 (ORCJIT, tigerlake)
  GC: Built with stock GC
Threads: 8 default, 1 interactive, 8 GC (on 8 virtual cores)
Environment:
  JULIA_CONDAPKG_BACKEND = Null
  JULIA_DEPOT_PATH = Q:\.julia;
  JULIA_NUM_THREADS = auto
```

I suppose we should bump the version for this patch?