### PR TITLE
[WIP] Replace FFTW with FFTA.jl as default FFT backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,9 @@ uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 version = "0.8.4"
 
 [deps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 Bessels = "0e736298-9ec6-45e8-9647-e4fc86a2fe38"
+FFTA = "b86e33f2-c0db-4aa1-a6e0-ab43e668529e"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -17,11 +19,14 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [extensions]
+FFTWExt = "FFTW"
 OffsetArraysExt = "OffsetArrays"
 
 [compat]
+AbstractFFTs = "1.0"
 Bessels = "0.2"
 DelimitedFiles = "1.6"
+FFTA = "0.3.1"
 FFTW = "1.8"
 IterTools = "1.4"
 LinearAlgebra = "1.6"
@@ -37,9 +42,10 @@ julia = "1.10"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DelimitedFiles", "OffsetArrays", "StableRNGs", "Test"]
+test = ["DelimitedFiles", "FFTW", "OffsetArrays", "StableRNGs", "Test"]

--- a/ext/FFTWExt.jl
+++ b/ext/FFTWExt.jl
@@ -1,0 +1,48 @@
+module FFTWExt
+
+using DSP: FFTBackend
+using FFTW
+import DSP.FFTBackend: AbstractFFTBackend, fft, ifft, ifft!, bfft, rfft, irfft, brfft,
+                        plan_fft, plan_ifft, plan_bfft, plan_rfft, plan_irfft, plan_brfft,
+                        plan_fft!, plan_bfft!
+
+"""
+    FFTWBackend <: AbstractFFTBackend
+
+FFT backend using FFTW.jl. This provides optimized FFT implementations for Float32 and Float64.
+Available when FFTW.jl is loaded.
+
+# Example
+```julia
+using DSP
+using FFTW
+DSP.set_fft_backend!(DSP.FFTBackend.FFTWBackend())
+```
+"""
+struct FFTWBackend <: AbstractFFTBackend end
+
+# Transform implementations - delegate to FFTW
+fft(::FFTWBackend, x) = FFTW.fft(x)
+ifft(::FFTWBackend, x) = FFTW.ifft(x)
+ifft!(::FFTWBackend, x) = FFTW.ifft!(x)
+bfft(::FFTWBackend, x) = FFTW.bfft(x)
+rfft(::FFTWBackend, x) = FFTW.rfft(x)
+irfft(::FFTWBackend, x, d) = FFTW.irfft(x, d)
+brfft(::FFTWBackend, x, d) = FFTW.brfft(x, d)
+
+# Planning - delegate to FFTW (returns FFTW plan objects directly)
+plan_fft(::FFTWBackend, x; flags=FFTW.ESTIMATE, kw...) = FFTW.plan_fft(x; flags=flags, kw...)
+plan_ifft(::FFTWBackend, x; flags=FFTW.ESTIMATE, kw...) = FFTW.plan_ifft(x; flags=flags, kw...)
+plan_bfft(::FFTWBackend, x; flags=FFTW.ESTIMATE, kw...) = FFTW.plan_bfft(x; flags=flags, kw...)
+plan_rfft(::FFTWBackend, x; flags=FFTW.ESTIMATE, kw...) = FFTW.plan_rfft(x; flags=flags, kw...)
+plan_irfft(::FFTWBackend, x, d; flags=FFTW.ESTIMATE, kw...) = FFTW.plan_irfft(x, d; flags=flags, kw...)
+plan_brfft(::FFTWBackend, x, d; flags=FFTW.ESTIMATE, kw...) = FFTW.plan_brfft(x, d; flags=flags, kw...)
+plan_fft!(::FFTWBackend, x; flags=FFTW.ESTIMATE, kw...) = FFTW.plan_fft!(x; flags=flags, kw...)
+plan_bfft!(::FFTWBackend, x; flags=FFTW.ESTIMATE, kw...) = FFTW.plan_bfft!(x; flags=flags, kw...)
+
+# Set FFTW as default when loaded (for better performance)
+function __init__()
+    FFTBackend.set_fft_backend!(FFTWBackend())
+end
+
+end # module

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -1,8 +1,22 @@
 module DSP
 
-using FFTW
 using LinearAlgebra: Transpose, mul!, rmul!
 using IterTools: subsets
+
+# FFT Backend system - must be included first
+include("fft/FFTBackend.jl")
+include("fft/FFTAImpl.jl")
+using .FFTBackend
+using .FFTAImpl
+
+# Re-export FFT backend API
+# Note: FFT functions (fft, rfft, etc.) are NOT exported to avoid conflicts with FFTW.jl
+# Users should either:
+# 1. Use FFTW.jl's exports: `using FFTW; fft(x)`
+# 2. Qualify with DSP: `DSP.fft(x)` (uses the current backend)
+# The backend selection (FFTABackend vs FFTWBackend) is automatic based on loaded packages.
+export FFTABackend, set_fft_backend!, get_fft_backend
+export fftfreq, rfftfreq, fftshift, ifftshift
 
 export conv, conv!, deconv, filt, filt!, xcorr
 

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -9,7 +9,7 @@ using Statistics: middle
 using SpecialFunctions: ellipk
 using ..DSP: optimalfftfiltlength, os_fft_complexity, SMALL_FILT_CUTOFF
 import ..DSP: filt, filt!
-using FFTW
+using ..FFTBackend
 
 include("coefficients.jl")
 export FilterCoefficients,

--- a/src/estimation.jl
+++ b/src/estimation.jl
@@ -1,7 +1,7 @@
 module Estimation
 
 using LinearAlgebra: eigen, svd
-using FFTW
+using ..FFTBackend
 using Statistics: mean
 
 export esprit, jacobsen, quinn

--- a/src/fft/FFTAImpl.jl
+++ b/src/fft/FFTAImpl.jl
@@ -1,0 +1,114 @@
+module FFTAImpl
+
+using FFTA
+using ..FFTBackend
+import ..FFTBackend: AbstractFFTBackend, fft, ifft, ifft!, bfft, rfft, irfft, brfft,
+                     plan_fft, plan_ifft, plan_bfft, plan_rfft, plan_irfft, plan_brfft,
+                     plan_fft!, plan_bfft!
+
+export FFTABackend
+
+"""
+    FFTABackend <: AbstractFFTBackend
+
+FFT backend using FFTA.jl. This is the default backend and works with arbitrary numeric types
+including BigFloat. For better performance with Float32/Float64, use FFTWBackend by loading FFTW.jl.
+"""
+struct FFTABackend <: AbstractFFTBackend end
+
+# Transform implementations
+fft(::FFTABackend, x) = FFTA.fft(x)
+bfft(::FFTABackend, x) = FFTA.bfft(x)
+
+function ifft(::FFTABackend, x)
+    result = FFTA.bfft(x)
+    return result ./ length(x)
+end
+
+function ifft!(::FFTABackend, x)
+    # FFTA doesn't have in-place operations, so we compute and copy back
+    result = FFTA.bfft(x) ./ length(x)
+    copyto!(x, result)
+    return x
+end
+
+function rfft(::FFTABackend, x::AbstractVector{<:Real})
+    X = FFTA.fft(complex.(x))
+    return X[1:length(x)÷2+1]
+end
+
+function rfft(::FFTABackend, x::AbstractArray{<:Real})
+    # For arrays, transform along first dimension
+    X = FFTA.fft(complex.(x))
+    return X[1:size(x, 1)÷2+1, axes(X)[2:end]...]
+end
+
+function irfft(::FFTABackend, X::AbstractVector{<:Complex}, d::Int)
+    if iseven(d)
+        Xfull = vcat(X, conj.(X[end-1:-1:2]))
+    else
+        Xfull = vcat(X, conj.(X[end:-1:2]))
+    end
+    return real.(FFTA.bfft(Xfull)) ./ d
+end
+
+function brfft(::FFTABackend, X::AbstractVector{<:Complex}, d::Int)
+    if iseven(d)
+        Xfull = vcat(X, conj.(X[end-1:-1:2]))
+    else
+        Xfull = vcat(X, conj.(X[end:-1:2]))
+    end
+    return real.(FFTA.bfft(Xfull))
+end
+
+# Plan wrapper (FFTA doesn't have true planning, so we simulate it)
+struct FFTAPlan{B,F,S}
+    backend::B
+    f::F
+    sz::S
+end
+
+(p::FFTAPlan)(x) = p.f(p.backend, x)
+Base.size(p::FFTAPlan) = p.sz
+
+# LinearAlgebra.mul! support for plans
+import LinearAlgebra: mul!
+function mul!(Y, p::FFTAPlan, X)
+    result = p(X)
+    copyto!(Y, result)
+    return Y
+end
+
+plan_fft(b::FFTABackend, x; kw...) = FFTAPlan(b, fft, size(x))
+plan_ifft(b::FFTABackend, x; kw...) = FFTAPlan(b, ifft, size(x))
+plan_bfft(b::FFTABackend, x; kw...) = FFTAPlan(b, bfft, size(x))
+plan_rfft(b::FFTABackend, x; kw...) = FFTAPlan(b, rfft, size(x))
+plan_irfft(b::FFTABackend, x, d; kw...) = FFTAPlan(b, (b, X) -> irfft(b, X, d), size(x))
+plan_brfft(b::FFTABackend, x, d; kw...) = FFTAPlan(b, (b, X) -> brfft(b, X, d), size(x))
+
+# In-place variants (not truly in-place for FFTA, but API compatible)
+plan_fft!(b::FFTABackend, x; kw...) = FFTAPlan(b, (b, x) -> copyto!(x, fft(b, x)), size(x))
+plan_bfft!(b::FFTABackend, x; kw...) = FFTAPlan(b, (b, x) -> copyto!(x, bfft(b, x)), size(x))
+
+# Plan inversion
+struct InversePlan{P}
+    p::P
+end
+
+function Base.inv(p::FFTAPlan)
+    if p.f === fft
+        return InversePlan(FFTAPlan(p.backend, ifft, p.sz))
+    elseif p.f === bfft
+        # inv of bfft plan would need to track normalization
+        return InversePlan(FFTAPlan(p.backend, (b, x) -> fft(b, x) ./ prod(p.sz), p.sz))
+    else
+        error("Inverse not defined for this plan type")
+    end
+end
+
+# Set FFTA as default on module load
+function __init__()
+    FFTBackend.set_fft_backend!(FFTABackend())
+end
+
+end # module

--- a/src/fft/FFTBackend.jl
+++ b/src/fft/FFTBackend.jl
@@ -1,0 +1,93 @@
+module FFTBackend
+
+using AbstractFFTs: fftfreq, rfftfreq, fftshift, ifftshift
+export fftfreq, rfftfreq, fftshift, ifftshift
+
+# FFT-compatible types (replaces FFTW.fftwReal etc.)
+const FFTReal = Union{Float32, Float64}
+const FFTComplex = Union{ComplexF32, ComplexF64}
+const FFTNumber = Union{FFTReal, FFTComplex}
+export FFTReal, FFTComplex, FFTNumber
+
+# FFT flags (for compatibility with FFTW flags interface)
+const ESTIMATE = UInt32(64)   # FFTW.ESTIMATE value
+const MEASURE = UInt32(0)     # FFTW.MEASURE value
+const NO_FLAG = UInt32(64)    # Default (ignored by non-FFTW backends)
+export ESTIMATE, MEASURE, NO_FLAG
+
+# Abstract backend type
+abstract type AbstractFFTBackend end
+export AbstractFFTBackend
+
+# Interface functions - backends must implement these
+function fft end
+function ifft end
+function ifft! end
+function bfft end
+function rfft end
+function irfft end
+function brfft end
+
+function plan_fft end
+function plan_ifft end
+function plan_bfft end
+function plan_rfft end
+function plan_irfft end
+function plan_brfft end
+function plan_fft! end
+function plan_bfft! end
+
+export fft, ifft, ifft!, bfft, rfft, irfft, brfft
+export plan_fft, plan_ifft, plan_bfft, plan_rfft, plan_irfft, plan_brfft, plan_fft!, plan_bfft!
+
+# Global default backend (mutable)
+const _default_backend = Ref{AbstractFFTBackend}()
+
+"""
+    set_fft_backend!(b::AbstractFFTBackend)
+
+Set the default FFT backend for DSP.jl.
+
+# Example
+```julia
+using DSP
+DSP.set_fft_backend!(DSP.FFTABackend())
+```
+"""
+function set_fft_backend!(b::AbstractFFTBackend)
+    _default_backend[] = b
+end
+export set_fft_backend!
+
+"""
+    get_fft_backend()
+
+Get the current default FFT backend.
+"""
+function get_fft_backend()
+    if !isassigned(_default_backend)
+        error("No FFT backend set. This should not happen - please report this as a bug.")
+    end
+    return _default_backend[]
+end
+export get_fft_backend
+
+# Convenience methods that use default backend
+fft(x) = fft(get_fft_backend(), x)
+ifft(x) = ifft(get_fft_backend(), x)
+ifft!(x) = ifft!(get_fft_backend(), x)
+bfft(x) = bfft(get_fft_backend(), x)
+rfft(x) = rfft(get_fft_backend(), x)
+irfft(x, d) = irfft(get_fft_backend(), x, d)
+brfft(x, d) = brfft(get_fft_backend(), x, d)
+
+plan_fft(x; kw...) = plan_fft(get_fft_backend(), x; kw...)
+plan_ifft(x; kw...) = plan_ifft(get_fft_backend(), x; kw...)
+plan_bfft(x; kw...) = plan_bfft(get_fft_backend(), x; kw...)
+plan_rfft(x; kw...) = plan_rfft(get_fft_backend(), x; kw...)
+plan_irfft(x, d; kw...) = plan_irfft(get_fft_backend(), x, d; kw...)
+plan_brfft(x, d; kw...) = plan_brfft(get_fft_backend(), x, d; kw...)
+plan_fft!(x; kw...) = plan_fft!(get_fft_backend(), x; kw...)
+plan_bfft!(x; kw...) = plan_bfft!(get_fft_backend(), x; kw...)
+
+end # module

--- a/src/multitaper.jl
+++ b/src/multitaper.jl
@@ -85,7 +85,7 @@ end
             ntapers = 2 * nw - 1,
             taper_weights = fill(1/ntapers, ntapers),
             onesided::Bool=T<:Real,
-            fft_flags = FFTW.MEASURE)
+            fft_flags = FFTBackend.ESTIMATE)
 
 Creates a config object which holds the configuration state
 and temporary variables used in multitaper computations,
@@ -112,7 +112,7 @@ as none of the input arguments change.
 function MTConfig{T}(n_samples; fs=1, nfft=nextpow(2, n_samples), window=nothing, nw=4,
                      ntapers=2 * nw - 1, taper_weights = fill(1/ntapers, ntapers),
                     onesided::Bool=T <: Real,
-                     fft_flags=FFTW.MEASURE) where {T}
+                     fft_flags=FFTBackend.ESTIMATE) where {T}
     if onesided && T <: Complex
         throw(ArgumentError("cannot compute one-sided FFT of a complex signal"))
     end
@@ -180,7 +180,7 @@ function mt_pgram(s::AbstractVector{T}; onesided::Bool=eltype(s)<:Real,
                   window::Union{AbstractMatrix,Nothing}=nothing) where T<:Number
     config = MTConfig{T}(length(s); fs,
         nfft, window, nw, ntapers, onesided,
-        fft_flags=FFTW.ESTIMATE)
+        fft_flags=FFTBackend.ESTIMATE)
     out = allocate_output(config)
     return mt_pgram!(out, s, config)
 end
@@ -191,7 +191,7 @@ function mt_pgram!(output, s::AbstractVector{T}; onesided::Bool=eltype(s)<:Real,
     window::Union{AbstractMatrix,Nothing}=nothing) where T<:Number
     config = MTConfig{T}(length(s); fs,
         nfft, window, nw, ntapers, onesided,
-        fft_flags=FFTW.ESTIMATE)
+        fft_flags=FFTBackend.ESTIMATE)
     return mt_pgram!(output, s, config)
 end
 
@@ -305,7 +305,7 @@ mt_spectrogram!
 function mt_spectrogram!(output, signal::AbstractVector{T}, n::Int=length(signal) >> 3,
         n_overlap::Int=n >> 1; kwargs...) where {T}
     config = MTSpectrogramConfig{T}(length(signal), n, n_overlap;
-        fft_flags=FFTW.ESTIMATE, kwargs...)
+        fft_flags=FFTBackend.ESTIMATE, kwargs...)
     return mt_spectrogram!(output, signal, config)
 end
 
@@ -356,7 +356,7 @@ mt_spectrogram
 
 function mt_spectrogram(signal::AbstractVector{T}, n::Int=length(signal) >> 3,
                         n_overlap::Int=n >> 1; kwargs...) where {T}
-    config = MTSpectrogramConfig{T}(length(signal), n, n_overlap; fft_flags=FFTW.ESTIMATE, kwargs...)
+    config = MTSpectrogramConfig{T}(length(signal), n, n_overlap; fft_flags=FFTBackend.ESTIMATE, kwargs...)
     return mt_spectrogram(signal, config)
 end
 
@@ -543,7 +543,7 @@ mt_cross_power_spectra!
 
 function mt_cross_power_spectra!(output, signal::AbstractMatrix{T}; fs=1, kwargs...) where {T}
     n_channels, n_samples = size(signal)
-    config = MTCrossSpectraConfig{T}(n_channels, n_samples; fs, fft_flags=FFTW.ESTIMATE,
+    config = MTCrossSpectraConfig{T}(n_channels, n_samples; fs, fft_flags=FFTBackend.ESTIMATE,
                                      kwargs...)
     return mt_cross_power_spectra!(output, signal, config)
 end
@@ -607,9 +607,9 @@ function cs_inner!(output, normalization_weights, x_mt, config)
     output .= zero(eltype(output))
     # Up to the `normalization_weights` scaling, we have
     # J_k^l(f) = x_mt[k, f, l]
-    # Ŝ^lm(f) = output[l, m, f]
+    # Ŝ^lm(f) = output[l, m, f]
     # using the notation from https://en.wikipedia.org/wiki/Multitaper#The_method
-    # so the formula `Ŝ^lm(f) = \sum_k conj(J_k^l(f)) * (J_k^m(f))`` becomes the following loop:
+    # so the formula `Ŝ^lm(f) = \sum_k conj(J_k^l(f)) * (J_k^m(f))`` becomes the following loop:
     @inbounds for (fi, f) in enumerate(freq_inds),
                   m in 1:n_channels,
                   l in 1:n_channels,
@@ -639,7 +639,7 @@ mt_cross_power_spectra
 
 function mt_cross_power_spectra(signal::AbstractMatrix{T}; fs=1, kwargs...) where {T}
     n_channels, n_samples = size(signal)
-    config = MTCrossSpectraConfig{T}(n_channels, n_samples; fs, fft_flags=FFTW.ESTIMATE,
+    config = MTCrossSpectraConfig{T}(n_channels, n_samples; fs, fft_flags=FFTBackend.ESTIMATE,
                                      kwargs...)
     return mt_cross_power_spectra(signal, config)
 end
@@ -784,7 +784,7 @@ end
 
 function mt_coherence!(output, signal::AbstractMatrix{T}; kwargs...) where {T}
     n_channels, n_samples = size(signal)
-    config = MTCoherenceConfig{T}(n_channels, n_samples; fft_flags=FFTW.ESTIMATE, kwargs...)
+    config = MTCoherenceConfig{T}(n_channels, n_samples; fft_flags=FFTBackend.ESTIMATE, kwargs...)
     return mt_coherence!(output, signal, config)
 end
 
@@ -806,7 +806,7 @@ mt_coherence
 
 function mt_coherence(signal::AbstractMatrix{T}; kwargs...) where {T}
     n_channels, n_samples = size(signal)
-    config = MTCoherenceConfig{T}(n_channels, n_samples; fft_flags=FFTW.ESTIMATE, kwargs...)
+    config = MTCoherenceConfig{T}(n_channels, n_samples; fft_flags=FFTBackend.ESTIMATE, kwargs...)
     return mt_coherence(signal, config)
 end
 

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -13,7 +13,8 @@ export arraysplit, nextfastfft, periodogram,
        MTCoherenceConfig, mt_coherence, mt_coherence!,
        coherence
 import ..DSP: allocate_output
-using FFTW
+using ..FFTBackend
+using AbstractFFTs: Frequencies
 
 ## ARRAY SPLITTER
 """
@@ -328,15 +329,17 @@ julia> freq(periodogram([1, 2, 3]; fs=210))
 """
 freq(p::TFR) = p.freq
 freq(p::Periodogram2) = (p.freq1, p.freq2)
-FFTW.fftshift(p::Periodogram{T,<:Frequencies} where T) =
+
+# fftshift methods for Periodogram types
+FFTBackend.fftshift(p::Periodogram{T,<:Frequencies} where T) =
     Periodogram(p.freq.n_nonnegative == p.freq.n ? p.power : fftshift(p.power), fftshift(p.freq))
-FFTW.fftshift(p::Periodogram{T,<:AbstractRange} where T) = p
+FFTBackend.fftshift(p::Periodogram{T,<:AbstractRange} where T) = p
 # 2-d
-FFTW.fftshift(p::Periodogram2{T,<:Frequencies,<:Frequencies} where T) =
+FFTBackend.fftshift(p::Periodogram2{T,<:Frequencies,<:Frequencies} where T) =
     Periodogram2(p.freq1.n_nonnegative == p.freq1.n ? fftshift(p.power,2) : fftshift(p.power), fftshift(p.freq1), fftshift(p.freq2))
-FFTW.fftshift(p::Periodogram2{T,<:AbstractRange,<:Frequencies} where T) =
+FFTBackend.fftshift(p::Periodogram2{T,<:AbstractRange,<:Frequencies} where T) =
     Periodogram2(fftshift(p.power,2), p.freq1, fftshift(p.freq2))
-FFTW.fftshift(p::Periodogram2{T,<:AbstractRange,<:AbstractRange} where T) = p
+FFTBackend.fftshift(p::Periodogram2{T,<:AbstractRange,<:AbstractRange} where T) = p
 
 # Compute the periodogram of a signal S, defined as 1/N*X[s(n)]^2, where X is the
 # DTFT of the signal S.
@@ -775,9 +778,9 @@ struct Spectrogram{T,F<:Union{Frequencies,AbstractRange}, M<:AbstractMatrix{T}} 
     freq::F
     time::Float64Range
 end
-FFTW.fftshift(p::Spectrogram{T,<:Frequencies} where T) =
+FFTBackend.fftshift(p::Spectrogram{T,<:Frequencies} where T) =
     Spectrogram(p.freq.n_nonnegative == p.freq.n ? p.power : fftshift(p.power, 1), fftshift(p.freq), p.time)
-FFTW.fftshift(p::Spectrogram{T,<:AbstractRange} where T) = p
+FFTBackend.fftshift(p::Spectrogram{T,<:AbstractRange} where T) = p
 
 """
     time(p)

--- a/src/util.jl
+++ b/src/util.jl
@@ -2,7 +2,8 @@ module Util
 using ..DSP: xcorr
 import Base: *
 using LinearAlgebra: mul!, BLAS
-using FFTW
+using ..FFTBackend
+using ..FFTBackend: FFTReal, FFTComplex, FFTNumber
 using Statistics: mean
 
 export  hilbert,
@@ -28,7 +29,7 @@ export  hilbert,
         alignsignals!
 
 
-function hilbert(x::StridedVector{T}) where T<:FFTW.fftwReal
+function hilbert(x::StridedVector{T}) where T<:FFTReal
 # Return the Hilbert transform of x (a real signal).
 # Code inspired by Scipy's implementation, which is under BSD license.
     N = length(x)
@@ -89,18 +90,18 @@ end
 ## FFT TYPES
 
 # Get the input element type of FFT for a given type
-fftintype(::Type{T}) where {T<:FFTW.fftwNumber} = T
+fftintype(::Type{T}) where {T<:FFTNumber} = T
 fftintype(::Type{T}) where {T<:Real} = Float64
 fftintype(::Type{T}) where {T<:Complex} = ComplexF64
 
 # Get the return element type of FFT for a given type
-fftouttype(::Type{T}) where {T<:FFTW.fftwComplex} = T
-fftouttype(::Type{T}) where {T<:FFTW.fftwReal} = Complex{T}
+fftouttype(::Type{T}) where {T<:FFTComplex} = T
+fftouttype(::Type{T}) where {T<:FFTReal} = Complex{T}
 fftouttype(::Type{T}) where {T<:Union{Real,Complex}} = ComplexF64
 
 # Get the real part of the return element type of FFT for a given type
-fftabs2type(::Type{Complex{T}}) where {T<:FFTW.fftwReal} = T
-fftabs2type(::Type{T}) where {T<:FFTW.fftwReal} = T
+fftabs2type(::Type{Complex{T}}) where {T<:FFTReal} = T
+fftabs2type(::Type{T}) where {T<:FFTReal} = T
 fftabs2type(::Type{T}) where {T<:Union{Real,Complex}} = Float64
 
 # Get next fast FFT size for a given signal length

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -2,7 +2,7 @@ module Windows
 using ..Util
 using Bessels: besseli0
 using LinearAlgebra: Diagonal, SymTridiagonal, eigen!, mul!, rmul!
-using FFTW
+using ..FFTBackend
 
 export  rect,
         hann,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,7 @@
-using DSP, FFTW, Test
+using DSP, Test
+
+# Load FFTW extension for backward compatibility and better performance in tests
+using FFTW
 
 using DSP: allocate_output
 using Random: seed!


### PR DESCRIPTION
## Summary
Replace FFTW (GPL licensed) with FFTA (MIT).  This still needs a bunch of work and probably a new release of FFTA to bring it up to speed with AbstractFFTs.jl and what we need here, so we can remove hacks in this package

## Changes
- New `src/fft/FFTBackend.jl`: Abstract FFT backend interface
- New `src/fft/FFTAImpl.jl`: FFTA backend implementation  
- New `ext/FFTWExt.jl`: FFTW package extension
- Updated source files to use `FFTBackend` instead of direct FFTW imports

## Usage
```julia
using DSP          # Uses FFTABackend by default
using FFTW         # Automatically switches to FFTWBackend for better Float64 performance
```

🤖 Generated with [Claude Code](https://claude.ai/code)