### PR TITLE
Reland #639 and minor housekeeping

### DIFF
--- a/src/Filters/design.jl
+++ b/src/Filters/design.jl
@@ -707,7 +707,7 @@ function _resample_filter(f_nyq, Nϕ, rel_bw, attenuation)
 
     # Round the number of taps up to a multiple of Nϕ.
     # Otherwise the missing taps will be filled with 0.
-    hLen = Nϕ * ceil(Int, hLen / Nϕ)
+    hLen = Nϕ * cld(hLen, Nϕ)
 
     # Ensure that the filter is an odd length
     if iseven(hLen)

--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -114,12 +114,10 @@ end
 
 Returns `grid`, `des`, and `wt` arrays
 """
-function build_grid(nfilt, band_defs, Hz, grid_density, neg)
+function build_grid(nfilt, band_defs, Hz, grid_density, neg::Bool)
     nodd = isodd(nfilt)
     nfcns = nfilt ÷ 2
-    if nodd && !neg
-        nfcns = nfcns + 1
-    end
+    nfcns += nodd & !neg
 
     #
     # SET UP THE DENSE GRID. THE NUMBER OF POINTS IN THE GRID
@@ -134,31 +132,26 @@ function build_grid(nfilt, band_defs, Hz, grid_density, neg)
         fl = convert(Float64, clamp(b.first[1] / Hz, flimlow, flimhigh))
         fu = convert(Float64, clamp(b.first[2] / Hz, flimlow, flimhigh))
         # make sure desired and weight are functions
-        if !isa(b.second, Tuple{Any, Any})
-            desired = b.second
-            weight = 1.0
-        else
+        if isa(b.second, Tuple{Any, Any})
             desired = b.second[1]
             weight = b.second[2]
+        else
+            desired = b.second
+            weight = 1.0
         end
         if isa(desired, Real)
-            let d = desired
-                desired = _ -> d
-            end
+            desired = Returns(desired)
         end
         if isa(weight, Real)
-            let w = weight
-                weight = _ -> w
-            end
+            weight = Returns(weight)
         end
         return Pair{Tuple{Float64,Float64},Tuple{Any,Any}}((fl, fu), (desired, weight))
     end
     normalized_band_defs = normalize_banddef_entry.(band_defs)
 
-    local ngrid
     # work around JuliaLang/julia#15276
-    let delf=delf
-        ngrid = sum(max(length(band_def.first[1]:delf:band_def.first[2]), 1) for band_def in normalized_band_defs)#::Int
+    ngrid = let delf=delf
+        sum(max(length(band_def.first[1]:delf:band_def.first[2]), 1) for band_def in normalized_band_defs)#::Int
     end
 
     grid = zeros(Float64, ngrid)  # the array of frequencies, between 0 and 0.5
@@ -177,8 +170,7 @@ function build_grid(nfilt, band_defs, Hz, grid_density, neg)
     # TO THE ORIGINAL PROBLEM
     #
     for band_def in normalized_band_defs
-        flow = band_def.first[1]
-        fup = band_def.first[2]
+        flow, fup = band_def.first
         # outline inner loop to have it type-stable (band_def.second is Tuple{Any,Any})
         j = _buildgrid!(grid, des, wt, j, [(flow:delf:fup)[1:end-1]; fup], neg, nodd, Hz,
                         band_def.second)
@@ -189,11 +181,12 @@ function build_grid(nfilt, band_defs, Hz, grid_density, neg)
 end
 
 function _buildgrid!(grid, des, wt, j, fs, neg, nodd, Hz, des_wt)
+    desired, weight = des_wt
     for f in fs
-        change = neg ? (nodd ? sinpi(2f) : sinpi(f)) : (nodd ? 1.0 : cospi(f))
+        change = neg ? sinpi(nodd ? 2f : f) : (nodd ? 1.0 : cospi(f))
         grid[j] = cospi(2f)
-        des[j] = des_wt[1](f * Hz) / change
-        wt[j] = des_wt[2](f * Hz) * change
+        des[j] = desired(f * Hz) / change
+        wt[j] = weight(f * Hz) * change
         j += 1
     end
     return j

--- a/src/Filters/response.jl
+++ b/src/Filters/response.jl
@@ -24,7 +24,7 @@ end
 Frequency response of digital `filter` at normalized frequency or
 frequencies `w` in radians/sample.
 """
-freqresp(filter::FilterCoefficients{:z}, w) = _freq(filter).(exp.(im .* w))
+freqresp(filter::FilterCoefficients{:z}, w) = _freq(filter).(cis.(w))
 
 """
     freqresp(filter::FilterCoefficients{:s}, w)
@@ -104,7 +104,7 @@ function grpdelay(filter::FilterCoefficients{:z}, w)
 
     c = xcorr(b, a; padmode = :none)
     cr = range(0, stop=length(c)-1) .* c
-    ejw = exp.(-im .* w)
+    ejw = cis.(.- w)
     num = Polynomial(cr).(ejw)
     den = Polynomial(c).(ejw)
     return real.(num ./ den) .- (length(a) - 1)
@@ -163,7 +163,7 @@ function _freqrange(filter::FilterCoefficients{:s})
     first_nonzero = findfirst(!iszero, w_interesting)
     if isnothing(first_nonzero) # no non-zero poles or zeros
         if !include_zero || !isfinite(1 / filter.k)
-            return setindex!(10.0 .^ (-1:6), 0.0, 1) # fallback
+            return [0.0, 1.0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6] # fallback
         end
         # include the point where |H|=1 (if any) and go further by factor 10
         return collect(range(0.0, stop=10 * Float64(max(filter.k, 1 / filter.k)), length=200))

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -413,9 +413,12 @@ timedelay(self::FIRFilter) = timedelay(self.kernel)
 # Single rate filtering
 #
 
-function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRStandard{Th}}, x::AbstractVector{Tx}) where {Tb,Th,Tx}
+function filt!(
+    buffer::AbstractVector{Tb},
+    self::FIRFilter{FIRStandard{Th}},
+    x::AbstractVector{Tx}, history::Vector{Tx}
+) where {Tb,Th,Tx}
     kernel              = self.kernel
-    history::Vector{Tx} = self.history
     bufLen              = length(buffer)
     xLen                = length(x)
 
@@ -439,10 +442,12 @@ end
 # Interpolation
 #
 
-function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRInterpolator{Th}}, x::AbstractVector{Tx}) where {Tb,Th,Tx}
+function filt!(
+    buffer::AbstractVector{Tb},
+    self::FIRFilter{FIRInterpolator{Th}},
+    x::AbstractVector{Tx}, history::Vector{Tx}
+) where {Tb,Th,Tx}
     kernel              = self.kernel
-    history::Vector{Tx} = self.history
-    interpolation       = kernel.interpolation
     xLen                = length(x)
     bufLen              = length(buffer)
     bufIdx              = 0
@@ -480,9 +485,12 @@ end
 # Rational resampling
 #
 
-function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRRational{Th}}, x::AbstractVector{Tx}) where {Tb,Th,Tx}
+function filt!(
+    buffer::AbstractVector{Tb},
+    self::FIRFilter{FIRRational{Th}},
+    x::AbstractVector{Tx}, history::Vector{Tx}
+) where {Tb,Th,Tx}
     kernel              = self.kernel
-    history::Vector{Tx} = self.history
     xLen                = length(x)
     bufLen              = length(buffer)
     bufIdx              = 0
@@ -527,11 +535,14 @@ end
 # Decimation
 #
 
-function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRDecimator{Th}}, x::AbstractVector{Tx}) where {Tb,Th,Tx}
+function filt!(
+    buffer::AbstractVector{Tb},
+    self::FIRFilter{FIRDecimator{Th}},
+    x::AbstractVector{Tx}, history::Vector{Tx}
+) where {Tb,Th,Tx}
     kernel              = self.kernel
     bufLen              = length(buffer)
     xLen                = length(x)
-    history::Vector{Tx} = self.history
     bufIdx              = 0
 
     if xLen < kernel.inputDeficit
@@ -593,14 +604,13 @@ end
 function filt!(
     buffer::AbstractVector{Tb},
     self::FIRFilter{FIRArbitrary{Th}},
-    x::AbstractVector{Tx}
+    x::AbstractVector{Tx}, history::Vector{Tx}
 ) where {Tb,Th,Tx}
     kernel              = self.kernel
     pfb                 = kernel.pfb
     dpfb                = kernel.dpfb
     xLen                = length(x)
     bufIdx              = 0
-    history::Vector{Tx} = self.history
 
     # Do we have enough input samples to produce one or more output samples?
     # if xLen < kernel.inputDeficit     # redundant; while cond covers case.
@@ -639,6 +649,29 @@ function filt!(
     return bufIdx
 end
 
+"""
+    filt!(buffer::AbstractVector, self::FIRFilter, x::AbstractVector{Tx})
+    filt!(buffer::AbstractVector, self::FIRFilter, x::AbstractVector{Tx}, history::Vector{Tx})
+
+Filters `x` with `self::FIRFilter` and writes the output to `buffer`.
+A history `Vector` with the same eltype as `x` can be provided that
+will then be set as `self.history`.
+
+The default argument is `convert(Vector{Tx}, self.history)`.
+"""
+filt!(buffer::AbstractVector, self::FIRFilter, x::AbstractVector{Tx}) where Tx =
+    filt!(buffer, self, x, convert(Vector{Tx}, self.history))
+
+
+
+"""
+    filt(self::FIRFilter{Tk}, x::AbstractVector{Th})
+
+Filters `x` with `self::FIRFilter`. The output array will have
+eltype `promote_type(Tk, Th)`.
+
+To choose otherwise, provide an output array as the first argument to `filt!`.
+"""
 function filt(self::FIRFilter{Tk}, x::AbstractVector) where Tk<:FIRKernel
     buffer = allocate_output(self, x)
     bufLen = length(buffer)

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -116,6 +116,9 @@ function FIRArbitrary(h::Vector, rate::Float64, Nϕ::Int)
     α            = 0.0
     xIdx         = 1
     inputDeficit = 1
+    if Nϕ + Δ > maxintfloat(Float64)    # invariant; ensure safe trunc
+        throw(ArgumentError("Nϕ + Δ must be <= than maxintfloat(Float64)"))
+    end
     FIRArbitrary(
         rate,
         pfb,
@@ -569,16 +572,22 @@ end
 # Updates FIRArbitrary state. See Section 7.5.1 in [1].
 #   [1] uses a phase accumulator that increments by Δ (Nϕ/rate)
 
-function update!(kernel::FIRArbitrary)
-    kernel.ϕAccumulator += kernel.Δ
+@fastmath function update!(kernel::FIRArbitrary)
+    ϕAcc = kernel.ϕAccumulator + kernel.Δ
+    xIdx = kernel.xIdx
+    α, ϕosF64 = modf(ϕAcc)
+    ϕ_os = unsafe_trunc(Int, ϕosF64)
 
-    if kernel.ϕAccumulator >= kernel.Nϕ
-        Δx, kernel.ϕAccumulator = divrem(kernel.ϕAccumulator, kernel.Nϕ)
-        kernel.xIdx += trunc(Int, Δx)
+    if ϕ_os >= kernel.Nϕ
+        Δx, ϕ_os = divrem(ϕ_os, kernel.Nϕ)
+        ϕAcc = ϕ_os + α
+        kernel.xIdx = (xIdx += Δx)
     end
-
-    kernel.α, foffset = modf(kernel.ϕAccumulator)
-    kernel.ϕIdx = 1 + trunc(Int, foffset)
+    # "atomic" update
+    kernel.α = α
+    kernel.ϕIdx = 1 + ϕ_os
+    kernel.ϕAccumulator = ϕAcc
+    xIdx
 end
 
 function filt!(
@@ -594,36 +603,37 @@ function filt!(
     history::Vector{Tx} = self.history
 
     # Do we have enough input samples to produce one or more output samples?
-    if xLen < kernel.inputDeficit
-        self.history = shiftin!(history, x)
-        kernel.inputDeficit -= xLen
-        return bufIdx
-    end
+    # if xLen < kernel.inputDeficit     # redundant; while cond covers case.
+    #     self.history = shiftin!(history, x)
+    #     kernel.inputDeficit -= xLen
+    #     return bufIdx
+    # end
 
     # Skip over input samples that are not needed to produce output results.
     # We do this by seting inputIdx to inputDeficit which was calculated in the previous run.
     # InputDeficit is set to 1 when instantiation the FIRArbitrary kernel, that way the first
     #   input always produces an output.
-    kernel.xIdx = kernel.inputDeficit
+    kernel.xIdx = xIdx = kernel.inputDeficit
 
-    while kernel.xIdx <= xLen
+    while xIdx <= xLen
         bufIdx += 1
+        ϕIdx = kernel.ϕIdx
 
-        if kernel.xIdx < kernel.tapsPerϕ
-            yLower = unsafe_dot(pfb,  kernel.ϕIdx, history, x, kernel.xIdx)
-            yUpper = unsafe_dot(dpfb, kernel.ϕIdx, history, x, kernel.xIdx)
+        if xIdx < kernel.tapsPerϕ
+            yLower = unsafe_dot(pfb,  ϕIdx, history, x, xIdx)
+            yUpper = unsafe_dot(dpfb, ϕIdx, history, x, xIdx)
         else
-            yLower = unsafe_dot(pfb,  kernel.ϕIdx, x, kernel.xIdx)
-            yUpper = unsafe_dot(dpfb, kernel.ϕIdx, x, kernel.xIdx)
+            yLower = unsafe_dot(pfb,  ϕIdx, x, xIdx)
+            yUpper = unsafe_dot(dpfb, ϕIdx, x, xIdx)
         end
 
         # Used to have @inbounds. Restore @inbounds if buffer length
         # can be verified prior to access.
         buffer[bufIdx] = muladd(yUpper, kernel.α, yLower)
-        update!(kernel)
+        xIdx = update!(kernel)
     end
 
-    kernel.inputDeficit = kernel.xIdx - xLen
+    kernel.inputDeficit = xIdx - xLen
     self.history        = shiftin!(history, x)
 
     return bufIdx

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -497,9 +497,9 @@ function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRRational{Th}}, x::
         bufIdx += 1
 
         if inputIdx < kernel.tapsPerϕ
-            accumulator = @inline unsafe_dot(kernel.pfb, kernel.ϕIdx, history, x, inputIdx)
+            accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, history, x, inputIdx)
         else
-            accumulator = @inline unsafe_dot(kernel.pfb, kernel.ϕIdx, x, inputIdx)
+            accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, x, inputIdx)
         end
 
         buffer[bufIdx]  = accumulator

--- a/src/Filters/stream_filt.jl
+++ b/src/Filters/stream_filt.jl
@@ -24,8 +24,8 @@ mutable struct FIRInterpolator{T} <: FIRKernel{T}
     const Nϕ::Int
     const tapsPerϕ::Int
     const hLen::Int
-    inputDeficit::Int
     ϕIdx::Int
+    inputDeficit::Int
 end
 
 function FIRInterpolator(h::Vector, interpolation::Int)
@@ -35,7 +35,7 @@ function FIRInterpolator(h::Vector, interpolation::Int)
     ϕIdx         = 1
     hLen         = length(h)
 
-    FIRInterpolator(pfb, interpolation, Nϕ, tapsPerϕ, hLen, inputDeficit, ϕIdx)
+    FIRInterpolator(pfb, interpolation, Nϕ, tapsPerϕ, hLen, ϕIdx, inputDeficit)
 end
 FIRInterpolator(h::Vector, interpolation::Integer) = FIRInterpolator(h, Int(interpolation))
 
@@ -71,9 +71,9 @@ function FIRRational(h::Vector, ratio::Rational{Int})
     pfb          = taps2pfb(h, numerator(ratio))
     tapsPerϕ, Nϕ = size(pfb)
     ϕIdxStepSize = mod(denominator(ratio), numerator(ratio))
+    hLen         = length(h)
     ϕIdx         = 1
     inputDeficit = 1
-    hLen         = length(h)
     FIRRational(pfb, ratio, Nϕ, ϕIdxStepSize, tapsPerϕ, hLen, ϕIdx, inputDeficit)
 end
 FIRRational(h::Vector, ratio::Union{Integer,Rational}) = FIRRational(h, convert(Rational{Int}, ratio))
@@ -95,13 +95,13 @@ mutable struct FIRArbitrary{T} <: FIRKernel{T}
     const dpfb::PFB{T}
     const Nϕ::Int
     const tapsPerϕ::Int
+    const hLen::Int
+    const Δ::Float64
     ϕAccumulator::Float64
     ϕIdx::Int
     α::Float64
-    const Δ::Float64
-    inputDeficit::Int
     xIdx::Int
-    const hLen::Int
+    inputDeficit::Int
 end
 
 function FIRArbitrary(h::Vector, rate::Float64, Nϕ::Int)
@@ -109,26 +109,26 @@ function FIRArbitrary(h::Vector, rate::Float64, Nϕ::Int)
     pfb          = taps2pfb(h,  Nϕ)
     dpfb         = taps2pfb(dh, Nϕ)
     tapsPerϕ     = size(pfb, 1)
+    hLen         = length(h)
+    Δ            = Nϕ / rate
     ϕAccumulator = 0.0
     ϕIdx         = 1
     α            = 0.0
-    Δ            = Nϕ/rate
-    inputDeficit = 1
     xIdx         = 1
-    hLen         = length(h)
+    inputDeficit = 1
     FIRArbitrary(
         rate,
         pfb,
         dpfb,
         Nϕ,
         tapsPerϕ,
+        hLen,
+        Δ,
         ϕAccumulator,
         ϕIdx,
         α,
-        Δ,
-        inputDeficit,
         xIdx,
-        hLen
+        inputDeficit
     )
 end
 FIRArbitrary(h::Vector, rate::Real, Nϕ::Integer) = FIRArbitrary(h, convert(Float64, rate), convert(Int, Nϕ))
@@ -154,6 +154,8 @@ converting recorded audio from 48 KHz to 44.1 KHz).
 Constructs `h` with `resample_filter(ratio, args...)` if it is not provided.
 """
 function FIRFilter(h::Vector, resampleRatio::Union{Integer,Rational} = 1)
+    Base.@constprop :aggressive
+    resampleRatio > 0 || throw(DomainError(resampleRatio, "ratio must be positive"))
     interpolation = numerator(resampleRatio)
     decimation    = denominator(resampleRatio)
     historyLen    = 0
@@ -192,6 +194,7 @@ Constructs `h` with `resample_filter(rate, Nϕ, args...)` if it is not provided.
 """
 function FIRFilter(h::Vector, rate::AbstractFloat, Nϕ::Integer=32)
     rate > 0.0 || throw(DomainError(rate, "rate must be greater than 0"))
+    Nϕ > 0 || throw(DomainError(Nϕ, "Nϕ must be greater than 0"))
     kernel     = FIRArbitrary(h, rate, Nϕ)
     historyLen = kernel.tapsPerϕ - 1
     history    = zeros(historyLen)
@@ -229,11 +232,12 @@ function setphase!(kernel::Union{FIRInterpolator, FIRRational}, ϕ::Real)
 end
 
 function setphase!(kernel::FIRArbitrary, ϕ::Real)
-    ϕ >= zero(ϕ) || throw(DomainError(ϕ, "ϕ must be >= 0"))
-    (ϕ, xThrowaway) = modf(ϕ)
-    kernel.inputDeficit += round(Int, xThrowaway)
+    zero(ϕ) <= ϕ < maxintfloat(typeof(ϕ), Int) ||
+        throw(DomainError(ϕ, "ϕ must be >= 0 and < maxintfloat(ϕ)"))
+    ϕ, xThrowaway = modf(ϕ)
+    kernel.inputDeficit += unsafe_trunc(Int, xThrowaway)    # safe, but llvm unable to optimize
     kernel.ϕAccumulator = ϕ * kernel.Nϕ
-    kernel.ϕIdx         = 1 + floor(Int, kernel.ϕAccumulator)
+    kernel.ϕIdx         = 1 + trunc(Int, kernel.ϕAccumulator)
     kernel.α            = modf(kernel.ϕAccumulator)[1]
     nothing
 end
@@ -263,8 +267,8 @@ function reset!(kernel::FIRArbitrary)
     kernel.ϕAccumulator = 0.0
     kernel.ϕIdx         = 1
     kernel.α            = 0.0
-    kernel.inputDeficit = 1
     kernel.xIdx         = 1
+    kernel.inputDeficit = 1
     kernel
 end
 
@@ -293,7 +297,7 @@ end
 
 function taps2pfb(h::Vector{T}, Nϕ::Integer) where T
     hLen     = length(h)
-    tapsPerϕ = ceil(Int, hLen / Nϕ)
+    tapsPerϕ = cld(hLen, Nϕ)
     pfb      = Matrix{T}(undef, tapsPerϕ, Nϕ)
     hIdx     = 1
 
@@ -317,8 +321,8 @@ end
 function outputlength(inputlength::Integer, ratio::Union{Integer,Rational}, initialϕ::Integer)
     interpolation = numerator(ratio)
     decimation    = denominator(ratio)
-    outLen        = ((inputlength * interpolation) - initialϕ + 1) / decimation
-    ceil(Int, outLen)
+    outLen        = cld((inputlength * interpolation) - initialϕ + 1, decimation)
+    outLen
 end
 
 function outputlength(::FIRStandard, inputlength::Integer)
@@ -348,49 +352,49 @@ end
 
 #
 # Calculates the input length of a multirate filtering operation,
-# given the output length
-# With RoundDown, inputlength returns the largest input length such that the
-# actual output length will be at most the given one.
-# With RoundUp, inputlength returns the shortest input length such that the
-# actual output length will be at least the given one.
+# given the output length. The dividend is assumed positive.
+# With RoundToZero and RoundDown, inputlength returns the largest input length
+# such that the actual output length will be _at most_ the given one.
+# With RoundUp and RoundFromZero, inputlength returns the shortest input length
+# such that the actual output length will be _at least_ the given one.
 #
 
-function inputlength(outputlength::Int, ratio::Union{Integer,Rational}, initialϕ::Integer, r::RoundingMode=RoundDown)
+function inputlength(outputlength::Int, ratio::Union{Integer,Rational}, initialϕ::Integer, r::RoundingMode=RoundToZero)
     interpolation = numerator(ratio)
     decimation    = denominator(ratio)
     d             = r == RoundUp || r == RoundFromZero ? decimation : 1
-    inLen         = (outputlength * decimation + initialϕ - d) / interpolation
-    round(Int, inLen, r)
+    inLen         = div((outputlength * decimation + initialϕ - d), interpolation, r)
+    inLen
 end
 
-function inputlength(::FIRStandard, outputlength::Integer, ::RoundingMode=RoundDown)
+function inputlength(::FIRStandard, outputlength::Int, ::RoundingMode)
     outputlength
 end
 
-function inputlength(kernel::FIRInterpolator, outputlength::Integer, r::RoundingMode=RoundDown)
+function inputlength(kernel::FIRInterpolator, outputlength::Int, r::RoundingMode)
     inLen = inputlength(outputlength, kernel.interpolation, kernel.ϕIdx, r)
     inLen += kernel.inputDeficit - 1
 end
 
-function inputlength(kernel::FIRDecimator, outputlength::Integer, r::RoundingMode=RoundDown)
+function inputlength(kernel::FIRDecimator, outputlength::Int, r::RoundingMode)
     inLen  = inputlength(outputlength, 1//kernel.decimation, 1, r)
     inLen += kernel.inputDeficit - 1
 end
 
-function inputlength(kernel::FIRRational, outputlength::Integer, r::RoundingMode=RoundDown)
+function inputlength(kernel::FIRRational, outputlength::Int, r::RoundingMode)
     inLen  = inputlength(outputlength, kernel.ratio, kernel.ϕIdx, r)
     inLen += kernel.inputDeficit - 1
 end
 
-function inputlength(kernel::FIRArbitrary, outputlength::Integer, r::RoundingMode=RoundDown)
+function inputlength(kernel::FIRArbitrary, outputlength::Int, r::RoundingMode)
     d      = r == RoundUp || r == RoundFromZero ? 1 : 0
-    inLen  = floor(Int, (outputlength - d + kernel.ϕAccumulator / kernel.Δ)/kernel.rate) + d
+    inLen  = trunc(Int, (outputlength - d + kernel.ϕAccumulator / kernel.Δ)/kernel.rate) + d
     inLen += kernel.inputDeficit - 1
 end
 
-function inputlength(self::FIRFilter, outputlength::Integer, r::RoundingMode=RoundDown)
-    inputlength(self.kernel, outputlength, r)
-end
+inputlength(kernel::FIRKernel, outputlength::Integer) = inputlength(kernel, Int(outputlength), RoundToZero)
+inputlength(self::FIRFilter, outputlength::Integer, r::RoundingMode=RoundToZero) =
+    inputlength(self.kernel, Int(outputlength), r)
 
 
 #
@@ -486,26 +490,27 @@ function filt!(buffer::AbstractVector{Tb}, self::FIRFilter{FIRRational{Th}}, x::
         return bufIdx
     end
 
-    outLen = outputlength(xLen-kernel.inputDeficit+1, kernel.ratio, kernel.ϕIdx)
+    outLen = outputlength(kernel, xLen)
     bufLen >= outLen || throw(ArgumentError("buffer is too small"))
 
     interpolation       = numerator(kernel.ratio)
     decimation          = denominator(kernel.ratio)
     inputIdx            = kernel.inputDeficit
+    ϕIdx                = kernel.ϕIdx
 
     while inputIdx <= xLen
         bufIdx += 1
 
         if inputIdx < kernel.tapsPerϕ
-            accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, history, x, inputIdx)
+            accumulator = unsafe_dot(kernel.pfb, ϕIdx, history, x, inputIdx)
         else
-            accumulator = unsafe_dot(kernel.pfb, kernel.ϕIdx, x, inputIdx)
+            accumulator = unsafe_dot(kernel.pfb, ϕIdx, x, inputIdx)
         end
 
         buffer[bufIdx]  = accumulator
-        inputIdx       += div(kernel.ϕIdx + decimation - 1, interpolation)
-        ϕIdx            = kernel.ϕIdx + kernel.ϕIdxStepSize
-        kernel.ϕIdx     = ϕIdx > interpolation ? ϕIdx - interpolation : ϕIdx
+        inputIdx       += div(ϕIdx + decimation - 1, interpolation)
+        ϕIdx           += kernel.ϕIdxStepSize
+        kernel.ϕIdx     = ϕIdx = ifelse(ϕIdx > interpolation, ϕIdx - interpolation, ϕIdx)
     end
 
     kernel.inputDeficit = inputIdx - xLen
@@ -569,11 +574,11 @@ function update!(kernel::FIRArbitrary)
 
     if kernel.ϕAccumulator >= kernel.Nϕ
         Δx, kernel.ϕAccumulator = divrem(kernel.ϕAccumulator, kernel.Nϕ)
-        kernel.xIdx += Int(Δx)
+        kernel.xIdx += trunc(Int, Δx)
     end
 
     kernel.α, foffset = modf(kernel.ϕAccumulator)
-    kernel.ϕIdx = 1 + Int(foffset)
+    kernel.ϕIdx = 1 + trunc(Int, foffset)
 end
 
 function filt!(
@@ -746,17 +751,17 @@ as an optional argument, which defaults to 32.
 """
 function resample(x::AbstractArray, rate::Union{Integer,Rational}, h::Vector; dims)
     sf = FIRFilter(h, rate)
-    return _resample!(x, rate, sf; dims)
+    _resample!(x, rate, sf, dims)
 end
 function resample(x::AbstractArray, rate::AbstractFloat, h::Vector, Nϕ=32; dims)
     sf = FIRFilter(h, rate, Nϕ)
-    _resample!(x, rate, sf; dims)
+    _resample!(x, rate, sf, dims)
 end
 
 resample(x::AbstractArray, rate::Real, args::Real...; dims) =
-    _resample!(x, rate, FIRFilter(rate, args...); dims)
+    _resample!(x, rate, FIRFilter(rate, args...), dims)
 
-function _resample!(x::AbstractArray{T}, rate::Real, sf::FIRFilter; dims::Int) where T
+function _resample!(x::AbstractArray{T}, rate::Real, sf::FIRFilter, dims::Int) where T
     undelay!(sf)
     size_v  = size(x, dims)
     outLen  = ceil(Int, size_v * rate)
@@ -779,7 +784,15 @@ end
 #
 
 # [1] F.J. Harris, *Multirate Signal Processing for Communication Systems*. Prentice Hall, 2004
-# [2] Dick, C.; Harris, F., "Options for arbitrary resamplers in FPGA-based modulators," Signals, Systems and Computers, 2004. Conference Record of the Thirty-Eighth Asilomar Conference on , vol.1, no., pp.777,781 Vol.1, 7-10 Nov. 2004
-# [3] Kim, S.C.; Plishker, W.L.; Bhattacharyya, S.S., "An efficient GPU implementation of an arbitrary resampling polyphase channelizer," Design and Architectures for Signal and Image Processing (DASIP), 2013 Conference on, vol., no., pp.231,238, 8-10 Oct. 2013
-# [4] Horridge, J.P.; Frazer, Gordon J., "Accurate arbitrary resampling with exact delay for radar applications," Radar, 2008 International Conference on , vol., no., pp.123,127, 2-5 Sept. 2008
-# [5] Blok, M., "Fractional delay filter design for sample rate conversion," Computer Science and Information Systems (FedCSIS), 2012 Federated Conference on , vol., no., pp.701,706, 9-12 Sept. 2012
+# [2] Dick, C.; Harris, F., "Options for arbitrary resamplers in FPGA-based modulators",
+#       Signals, Systems and Computers, 2004.
+#       Conference Record of the Thirty-Eighth Asilomar Conference on vol.1, no., pp.777,781 Vol.1, 7-10 Nov. 2004
+# [3] Kim, S.C.; Plishker, W.L.; Bhattacharyya, S.S.,
+#       "An efficient GPU implementation of an arbitrary resampling polyphase channelizer",
+#       Design and Architectures for Signal and Image Processing (DASIP),
+#       2013 Conference on, vol., no., pp.231,238, 8-10 Oct. 2013
+# [4] Horridge, J.P.; Frazer, Gordon J., "Accurate arbitrary resampling with exact delay for radar applications",
+#       Radar, 2008 International Conference on , vol., no., pp.123,127, 2-5 Sept. 2008
+# [5] Blok, M., "Fractional delay filter design for sample rate conversion",
+#       Computer Science and Information Systems (FedCSIS),
+#       2012 Federated Conference on , vol., no., pp.701,706, 9-12 Sept. 2012

--- a/src/dspbase.jl
+++ b/src/dspbase.jl
@@ -49,7 +49,7 @@ function filt!(out::AbstractArray, b::Union{AbstractVector, Number}, a::Union{Ab
     si = Vector{promote_type(eltype(b), eltype(a), T)}(undef, sz - 1)
 
     if as == 1 && bs <= SMALL_FILT_CUTOFF
-        fill!(si, zero(eltype(si)))
+        @static VERSION < v"1.13-" && fill!(si, zero(eltype(si)))
         _small_filt_fir!(out, b, x, si, Val(bs))
     else
         for col in CartesianIndices(axes(x)[2:end])
@@ -119,26 +119,25 @@ function _filt_fir!(out, b::NTuple{N,T}, x, siarr, col, ::Val{StoreSI}) where {N
 if @generated
     silen = N - 1
     si_end = Symbol(:si_, silen)
-    @static if VERSION.major == 1 && VERSION.minor == 12
-        STORE_VAL = :(@inbounds out[i, col] = val)
-    else
-        STORE_VAL = :(out[i, col] = val)
-    end
 
     quote
         VECTORIZE_LARGER = N > SMALL_FILT_VECT_CUTOFF
         VECTORIZE_LARGER || checkbounds(siarr, $silen)
         Base.@nextract $silen si siarr
         ax = axes(x, 1)
-        if VERSION >= v"1.12"
-            checkbounds(x, ax, col)
-            checkbounds(out, ax, col)
-        end
+        $(@static if VERSION >= v"1.12"
+          :(checkbounds(x, ax, col);
+            checkbounds(out, ax, col))
+        end)
         for i in ax
             xi = x[i, col]
             val = muladd(xi, b[1], si_1)
             if VECTORIZE_LARGER
-                $STORE_VAL
+      $(@static if VERSION.major == 1 && VERSION.minor == 12
+                    :(@inbounds out[i, col] = val)
+                else
+                    :(out[i, col] = val)
+                end)
             end
             Base.@nexprs $(silen - 1) j -> (si_j = muladd(xi, b[j+1], si_{j + 1}))
             $si_end = xi * b[N]

--- a/src/lpc.jl
+++ b/src/lpc.jl
@@ -75,20 +75,21 @@ function arburg(x::AbstractVector{T}, p::Integer) where T<:Number
         reflection_coeffs[m] = k
 
         rev_buf[1:m] .= a[m:-1:1]
-        @. a[2:m+1] = muladd(k, conj(rev_buf[1:m]), a[2:m+1])
+        kc = conj(k)
+        @. a[2:m+1] = muladd(kc, conj(rev_buf[1:m]), a[2:m+1])
 
         # update prediction errors
         for i in eachindex(ef, eb)
             ef_i, eb_i = ef[i], eb[i]
             ef[i] = muladd(k, eb_i, ef[i])
-            eb[i] = muladd(conj(k), ef_i, eb[i])
+            eb[i] = muladd(kc, ef_i, eb[i])
         end
 
         ratio = one(R) - abs2(k)
         prediction_err *= ratio
     end
 
-    return conj!(a), prediction_err, reflection_coeffs
+    return a, prediction_err, reflection_coeffs
 end
 
 function lpc(x::AbstractVector{<:Number}, p::Integer, ::LPCLevinson)

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -138,7 +138,7 @@ Base.collect(x::ArraySplit) = collect(copy(a) for a in x)
 ## UTILITY FUNCTIONS
 
 # Convert the output of an FFT to a PSD and add it to out
-function fft2pow!(out::AbstractArray{T}, s_fft::AbstractVector{Complex{T}}, nfft::Int, r::Real, onesided::Bool, offset::Int=0) where T
+function fft2pow!(out::AbstractVecOrMat{T}, s_fft::AbstractVector{Complex{T}}, nfft::Int, r::Real, onesided::Bool, offset::Int=0) where T
     m1 = convert(T, 1/r)
     n = length(s_fft)
     if onesided
@@ -179,7 +179,7 @@ function fft2pow2!(out::Matrix{T}, s_fft::Matrix{Complex{T}}, r::Real) where T
     out
 end
 # Convert the output of a 2-d FFT to a radial PSD and add it to out
-function fft2pow2radial!(out::Array{T}, s_fft::Matrix{Complex{T}}, n1::Int, n2::Int, r::Real, ptype::Int) where T
+function fft2pow2radial!(out::Vector{T}, s_fft::Matrix{Complex{T}}, n1::Int, n2::Int, r::Real, ptype::Int) where T
     nmin = min(n1, n2)
     n1max = n1 >> 1 + 1  # since rfft is used
     n1max != size(s_fft, 1) && throw(ArgumentError("fft size incorrect"))
@@ -231,7 +231,7 @@ function fft2pow2radial!(out::Array{T}, s_fft::Matrix{Complex{T}}, n1::Int, n2::
     out
 end
 
-function fft2oneortwosided!(out::Array{Complex{T}}, s_fft::Vector{Complex{T}}, nfft::Int, onesided::Bool, offset::Int=0) where T
+function fft2oneortwosided!(out::Matrix{V}, s_fft::Vector{V}, nfft::Int, onesided::Bool, offset::Int=0) where V <: Complex
     n = length(s_fft)
     copyto!(out, offset+1, s_fft, 1, n)
     if !onesided && n != nfft
@@ -557,9 +557,11 @@ julia> wconfig1 = WelchConfig(x; n=length(x), noverlap=0, window=hanning, nfft=1
 julia> wconfig2 = WelchConfig(8, Float64; n=length(x), noverlap=0, window=hanning, nfft=16);
 ```
 """
-function WelchConfig(nsamples, ::Type{T}; n::Int=nsamples >> 3, noverlap::Int=n >> 1,
+function WelchConfig(nsamples::Integer, ::Type{T};
+    n::Int=Int(nsamples >> 3), noverlap::Int=Int(n >> 1),
     onesided::Bool=T <: Real, nfft::Int=nextfastfft(n),
-    fs::Real=1, window::Union{Function,AbstractVector,Nothing}=welch_config_default_window()) where T
+    fs::Real=1, window::Union{Function,AbstractVector,Nothing}=welch_config_default_window()
+) where T
 
     onesided && T <: Complex && throw(ArgumentError("cannot compute one-sided FFT of a complex signal"))
     nfft >= n || throw(DomainError((; nfft, n), "nfft must be >= n"))
@@ -743,7 +745,7 @@ function welch_pgram!(out::AbstractVector, s::AbstractVector{T}, config::WelchCo
     welch_pgram_helper!(out, s, config)
 end
 
-function welch_pgram_helper!(out, s, config)
+function welch_pgram_helper!(out::AbstractVector, s::AbstractVector, config::WelchConfig)
     fill!(out, 0)
     sig_split = arraysplit(s, config.nsamples, config.noverlap, config.nfft, config.window;
                            buffer=config.inbuf)
@@ -878,7 +880,7 @@ function stft(s::AbstractVector{T}, n::Int=length(s)>>3, noverlap::Int=n>>1,
     win, norm2 = compute_window(window, n)
     sig_split = arraysplit(s, n, noverlap, nfft, win)
     nout = onesided ? (nfft >> 1)+1 : nfft
-    out = zeros(stfttype(T, psdonly), nout, length(sig_split))
+    out = zeros(stfttype(T, psdonly), (nout, length(sig_split)))
     tmp = Vector{fftouttype(T)}(undef, T<:Real ? (nfft >> 1)+1 : nfft)
     r = fs*norm2
 

--- a/src/periodograms.jl
+++ b/src/periodograms.jl
@@ -49,7 +49,6 @@ struct ArraySplit{T<:AbstractVector,S,W} <: AbstractVector{Vector{S}}
         new{Ti,Si,Wi}(s, buffer, n, noverlap, window, length(s) >= n ? div((length(s) - n),
             n - noverlap) + 1 : 0)
     end
-
 end
 ArraySplit(s::T, n, noverlap, nfft, window::W; kwargs...) where {S,T<:AbstractVector{S},W} =
     ArraySplit{T,fftintype(S),W}(s, n, noverlap, nfft, window; kwargs...)
@@ -186,16 +185,17 @@ function fft2pow2radial!(out::Array{T}, s_fft::Matrix{Complex{T}}, n1::Int, n2::
     n1max != size(s_fft, 1) && throw(ArgumentError("fft size incorrect"))
     m1 = convert(T, 1/r)
     m2 = convert(T, 2/r)
-    wavenum = 0          # wavenumber index
-    kmax = length(out)   # the highest wavenumber
-    wc = zeros(Int, kmax) # wave count for radial average
-    if n1 == nmin        # scale the wavevector for non-square s_fft
+    wavenum = 0             # wavenumber index
+    kmax = length(out)      # the highest wavenumber
+    wc = zeros(Int, kmax)   # wave count for radial average
+    if n1 == nmin           # scale the wavevector for non-square s_fft
         c2 = n1/n2
         c1 = one(c2)
     else
         c1 = n2/n1
         c2 = one(c1)
     end
+    d1, d2 = iseven(n1) ? (m1, 1) : (m2, 2)
 
     sqrt_muladd(a, k) = sqrt(muladd(a, a, k))
 
@@ -218,8 +218,8 @@ function fft2pow2radial!(out::Array{T}, s_fft::Matrix{Complex{T}}, n1::Int, n2::
             end
             wavenum = round(Int, sqrt_muladd(c1 * (n1max - 1), kj2)) + 1
             if wavenum<=kmax
-                out[wavenum] = muladd(abs2(s_fft[n1max, j]), ifelse(iseven(n1), m1, m2), out[wavenum])
-                wc[wavenum] += ifelse(iseven(n1), 1, 2)
+                out[wavenum] = muladd(abs2(s_fft[n1max, j]), d1, out[wavenum])
+                wc[wavenum] += d2
             end
         end
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -181,7 +181,7 @@ amp2db(a::Real) = 20*log10(a)
     rms(s; dims)
 
 Return the root mean square (rms) of signal `s`. Optional keyword parameter
-`dims` can be used to specify the dimensions along which to compue the rms.
+`dims` can be used to specify the dimensions along which to compute the rms.
 """
 function rms(s::AbstractArray{T}; dims=:) where {T<:Number}
     if dims === (:)
@@ -222,11 +222,12 @@ end
 # Computes the dot product of a single column of a, specified by aColumnIdx, with the vector b.
 # The number of elements used in the dot product determined by the size(A)[1].
 # Note: bIdx is the last element of b used in the dot product.
-function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector, bLastIdx::Integer)
+function unsafe_dot(a::AbstractMatrix{T}, aColIdx::Integer, b::AbstractVector{V}, bLastIdx::Integer) where {T,V}
+    @inline     # generally good for performance
     aLen     = size(a, 1)
     bBaseIdx = bLastIdx - aLen
-    @inbounds dotprod  = a[1, aColIdx] * b[ bBaseIdx + 1]
-    @simd for i in 2:aLen
+    dotprod  = zero(promote_type(T, V))
+    @simd for i in 1:aLen
         @inbounds dotprod += a[i, aColIdx] * b[bBaseIdx + i]
     end
 
@@ -234,17 +235,26 @@ function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector, bLas
 end
 
 @inline function unsafe_dot(a::Matrix{T}, aColIdx::Integer, b::Vector{T}, bLastIdx::Integer) where T<:BLAS.BlasReal
-    BLAS.dot(size(a, 1), pointer(a, size(a, 1)*(aColIdx-1) + 1), 1, pointer(b, bLastIdx - size(a, 1) + 1), 1)
+    GC.@preserve a b begin
+        pa = pointer(a, size(a, 1)*(aColIdx-1) + 1)
+        pb = pointer(b, bLastIdx - size(a, 1)  + 1)
+        BLAS.dot(size(a, 1), pa, 1, pb, 1)
+    end
 end
 
-function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
+# cold path for FIR(Standard/Decimator) - b is usually history
+function unsafe_dot(
+    a::AbstractMatrix{T}, aColIdx::Integer,
+    b::AbstractVector{V},
+    c::AbstractVector{V}, cLastIdx::Integer
+) where {T,V}
     aLen = size(a, 1)
     bLen = length(b)
     bLen == aLen-1  || throw(ArgumentError("length(b) must equal size(a, 1) - 1"))
     cLastIdx < aLen || throw(DomainError(cLastIdx, "cLastIdx must be < length(a)"))
 
-    dotprod = a[1, aColIdx] * b[cLastIdx]
-    @simd for i in 2:aLen-cLastIdx
+    dotprod = zero(promote_type(T, V))
+    @simd for i in 1:aLen-cLastIdx
         @inbounds dotprod += a[i, aColIdx] * b[i+cLastIdx-1]
     end
     @simd for i in 1:cLastIdx
@@ -254,11 +264,12 @@ function unsafe_dot(a::AbstractMatrix, aColIdx::Integer, b::AbstractVector{T}, c
     return dotprod
 end
 
-function unsafe_dot(a::T, b::AbstractArray, bLastIdx::Integer) where T
+function unsafe_dot(a::AbstractVector{T}, b::AbstractArray{V}, bLastIdx::Integer) where {T,V}
+    @inline     # normally inlines anyway, but just in case
     aLen     = length(a)
     bBaseIdx = bLastIdx - aLen
-    @inbounds dotprod  = a[1] * b[bBaseIdx + 1]
-    @simd for i in 2:aLen
+    dotprod  = zero(promote_type(T, V))
+    @simd for i in 1:aLen
         @inbounds dotprod += a[i] * b[bBaseIdx + i]
     end
 
@@ -266,12 +277,13 @@ function unsafe_dot(a::T, b::AbstractArray, bLastIdx::Integer) where T
 end
 
 @inline function unsafe_dot(a::Vector{T}, b::Array{T}, bLastIdx::Integer) where T<:BLAS.BlasReal
-    BLAS.dot(length(a), pointer(a), 1, pointer(b, bLastIdx - length(a) + 1), 1)
+    GC.@preserve a b BLAS.dot(length(a), pointer(a), 1, pointer(b, bLastIdx - length(a) + 1), 1)
 end
 
-function unsafe_dot(a::AbstractVector, b::AbstractVector{T}, c::AbstractVector{T}, cLastIdx::Integer) where T
+# cold path for FIR(Interpolator/Rational/Arbitrary) - b is usually history
+function unsafe_dot(a::AbstractVector{T}, b::AbstractVector{V}, c::AbstractVector{V}, cLastIdx::Integer) where {T,V}
     aLen    = length(a)
-    dotprod = zero(a[1]*b[1])
+    dotprod = zero(promote_type(T, V))
     @simd for i in 1:aLen-cLastIdx
         @inbounds dotprod += a[i] * b[i+cLastIdx-1]
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -309,6 +309,7 @@ julia> shiftin!([1,2,3,4], [5, 6])
 ```
 """
 function shiftin!(a::AbstractVector{T}, b::AbstractVector{T}) where T
+    @noinline
     aLen = length(a)
     bLen = length(b)
     fi_a = firstindex(a)

--- a/test/filt_stream.jl
+++ b/test/filt_stream.jl
@@ -363,13 +363,24 @@ end
     end
 end
 
-@test resample(1:2, 3, [zeros(2); 1; zeros(3)]) == [1, 0, 0, 2, 0, 0]
-@test resample(1:2, 3//2, [zeros(2); 1; zeros(3)]) == [1, 0, 0]
-let H = FIRFilter(2.22)
-    setphase!(H, 0.99)
-    @test length(filt(H, 1:2)) == 3
+@testset "pathological cases: setphase! and outputlength" begin
+    # PR #596
+    @test resample(1:2, 3, [zeros(2); 1; zeros(3)]) == [1, 0, 0, 2, 0, 0]
+    @test resample(1:2, 3//2, [zeros(2); 1; zeros(3)]) == [1, 0, 0]
+    # PR #593
+    let H = FIRFilter(2.22)
+        setphase!(H, 0.99)
+        @test length(filt(H, 1:2)) == 3
+    end
+    let H = FIRFilter(122.2)
+        setphase!(H, 0.99)
+        @test length(filt(H, 1:2)) == 124
+    end
 end
-let H = FIRFilter(122.2)
-    setphase!(H, 0.99)
-    @test length(filt(H, 1:2)) == 124
+
+@testset "FIRArbitrary exceptions" begin
+    @test_throws ArgumentError FIRFilter(rand(10), 1e-13, 1000)
+    @test_throws DomainError FIRFilter(rand(10), 1.1, -1)
+    @test_throws DomainError setphase!(FIRFilter(rand(10), 1.1, 1), -1.0)
+    @test_throws DomainError setphase!(FIRFilter(rand(10), 1.1, 1), nextfloat(maxintfloat()))
 end

--- a/test/lpc.jl
+++ b/test/lpc.jl
@@ -1,4 +1,5 @@
 # Filter some noise, try to learn the coefficients
+using DSP, Test
 using Statistics: std
 @testset "$method" for method in (LPCBurg(), LPCLevinson())
     @testset "$T" for T in (Float64, ComplexF64)

--- a/test/periodograms.jl
+++ b/test/periodograms.jl
@@ -359,7 +359,7 @@ end
             xrcfft = fft(x)
         end
         xfft = fft(x)
-        out = zeros(fftouttype(atype),nout,3)
+        out = zeros(fftouttype(atype), (nout, 3))
         if !(onesided == true && atype <: Complex)
             outft = DSP.Periodograms.fft2oneortwosided!(out, xrcfft, nfft, onesided, nout)
         end

--- a/test/windows.jl
+++ b/test/windows.jl
@@ -178,17 +178,18 @@ end
     n = 12
     ft = typeof(1.0)
     for W in(:rect, :hanning, :hamming, :cosine, :lanczos, :triang, :bartlett, :bartlett_hann, :blackman)
-        @eval @test Array{$ft,1} == typeof($W($n)) && length($W($n)) == $n
+        @eval @test Vector{$ft} == typeof($W($n)) && length($W($n)) == $n
     end
 
-    @test Array{ft,1} == typeof(tukey(n, 0.4)) && length(tukey(n, 0.4)) == n
-    @test Array{ft,1} == typeof(gaussian(n, 0.4)) && length(gaussian(n, 0.4)) == n
-    @test Array{ft,1} == typeof(kaiser(n, 0.4)) && length(kaiser(n, 0.4)) == n
-    @test Array{ft,2} == typeof(dpss(n, 1.5)) && size(dpss(n, 1.5),1) == n  # size(,2) depends on the parameters
-    @test Array{ft,1} == typeof(blackmanharris(n, 4)) && length(blackmanharris(n, 4)) == n
-    @test Array{ft,1} == typeof(blackmanharris(n, 3)) && length(blackmanharris(n, 3)) == n
-    @test Array{ft,1} == typeof(nuttall(n, 4)) && length(nuttall(n, 4)) == n
-    @test Array{ft,1} == typeof(nuttall(n, 3)) && length(nuttall(n, 3)) == n
+    @test Vector{ft} == typeof(tukey(n, 0.4)) && length(tukey(n, 0.4)) == n
+    @test Vector{ft} == typeof(gaussian(n, 0.4)) && length(gaussian(n, 0.4)) == n
+    @test Vector{ft} == typeof(kaiser(n, 0.4)) && length(kaiser(n, 0.4)) == n
+    @test Vector{ft} == typeof(blackmanharris(n, 4)) && length(blackmanharris(n, 4)) == n
+    @test Vector{ft} == typeof(blackmanharris(n, 3)) && length(blackmanharris(n, 3)) == n
+    @test Vector{ft} == typeof(nuttall(n, 4)) && length(nuttall(n, 4)) == n
+    @test Vector{ft} == typeof(nuttall(n, 3)) && length(nuttall(n, 3)) == n
+
+    @test Matrix{ft} == typeof(dpss(n, 1.5)) && size(dpss(n, 1.5),1) == n   # size(,2) depends on the parameters
 end
 
 @testset "tensor product windows" begin
@@ -206,46 +207,29 @@ end
         end
     end
 
-    for winf in [zeroarg_wins; onearg_wins],
-         arg in (nothing, 0.4, (0.4, 0.5))
-        # skip invalid combinations
-        winf in zeroarg_wins && arg !== nothing && continue
-        winf in onearg_wins && arg === nothing && continue
-        for padding in (nothing, 4, (4,5)),
-          zerophase in (nothing, true, (true,false))
-            w1_expr = :($winf(15))
-            w2_expr = :($winf(20))
-            w3_expr = :($winf((15,20)))
-            w_all = (w1_expr, w2_expr, w3_expr)
+    function test_matrix_window(winfs, args)
+        for winf in winfs,
+             arg in args
+            for padding in (nothing, 4, (4,5)),
+              zerophase in (nothing, true, (true,false))
+                w1_expr = :($winf(15))
+                w2_expr = :($winf(20))
+                w3_expr = :($winf((15,20)))
+                w_all = (w1_expr, w2_expr, w3_expr)
 
-            push_args!(w_all, arg, Real, identity)
-            push_args!(w_all, padding, Integer, s -> Expr(:kw, :padding, s))
-            push_args!(w_all, zerophase, Bool, s -> Expr(:kw, :zerophase, s))
+                push_args!(w_all, arg, Real, identity)
+                push_args!(w_all, padding, Integer, s -> Expr(:kw, :padding, s))
+                push_args!(w_all, zerophase, Bool, s -> Expr(:kw, :zerophase, s))
 
-            w1 = eval(w1_expr)
-            w2 = eval(w2_expr)
-            w3 = eval(w3_expr)
-            @test w3 ≈ w1 * w2'
+                w1 = eval(w1_expr)
+                w2 = eval(w2_expr)
+                w3 = eval(w3_expr)
+                @test w3 ≈ w1 * w2'
+            end
         end
     end
 
-    for winf in termarg_wins,
-        arg in (3, 4)
-        for padding in (nothing, 4, (4,5)),
-          zerophase in (nothing, true, (true,false))
-            w1_expr = :($winf(15))
-            w2_expr = :($winf(20))
-            w3_expr = :($winf((15,20)))
-            w_all = (w1_expr, w2_expr, w3_expr)
-
-            push_args!(w_all, arg, Integer, identity)
-            push_args!(w_all, padding, Integer, s -> Expr(:kw, :padding, s))
-            push_args!(w_all, zerophase, Bool, s -> Expr(:kw, :zerophase, s))
-
-            w1 = eval(w1_expr)
-            w2 = eval(w2_expr)
-            w3 = eval(w3_expr)
-            @test w3 ≈ w1 * w2'
-        end
-    end
+    test_matrix_window(zeroarg_wins, (nothing,))
+    test_matrix_window(onearg_wins, (0.4, (0.4, 0.5)))
+    test_matrix_window(termarg_wins, (3, 4))
 end


### PR DESCRIPTION
Turns out the `@inline` annotation there was for `FIRRational` and not `FIRInterpolator`, so I benchmarked the wrong thing.
Now the inlining is done for all functions that use that `unsafe_dot` method. The performance boost from this is bigger on 1.13.

Also fixes #318 for constant `ratio` by annotating with `@constprop :aggressive`, which is probably the upper limit of what can be accomplished with the current API.

Plus a few other minor modifications (`cld`) and housekeeping.